### PR TITLE
[codex] Unblock external auth foundations in core

### DIFF
--- a/migrations/versions/6c2d5f4b8e91_add_analyst_identities_and_nullable_password_hash.py
+++ b/migrations/versions/6c2d5f4b8e91_add_analyst_identities_and_nullable_password_hash.py
@@ -1,0 +1,71 @@
+"""add analyst identities and nullable password hash
+
+Revision ID: 6c2d5f4b8e91
+Revises: c7d2e9f4a1b3
+Create Date: 2026-04-03
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "6c2d5f4b8e91"
+down_revision: str | None = "c7d2e9f4a1b3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "analysts",
+        "password_hash",
+        existing_type=sa.String(length=255),
+        nullable=True,
+    )
+
+    op.create_table(
+        "analyst_identities",
+        sa.Column("analyst_id", sa.Uuid(), nullable=False),
+        sa.Column("provider_type", sa.String(length=50), nullable=False),
+        sa.Column("issuer", sa.String(length=255), nullable=False),
+        sa.Column("subject", sa.String(length=255), nullable=False),
+        sa.Column("email", sa.String(length=255), nullable=True),
+        sa.Column("claims_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("last_authenticated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("id", sa.Uuid(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["analyst_id"],
+            ["analysts.id"],
+            name=op.f("fk_analyst_identities_analyst_id_analysts"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_analyst_identities")),
+        sa.UniqueConstraint(
+            "provider_type",
+            "issuer",
+            "subject",
+            name="uq_analyst_identities_provider_issuer_subject",
+        ),
+    )
+    op.create_index(
+        op.f("ix_analyst_identities_analyst_id"),
+        "analyst_identities",
+        ["analyst_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_analyst_identities_analyst_id"), table_name="analyst_identities")
+    op.drop_table("analyst_identities")
+    op.alter_column(
+        "analysts",
+        "password_hash",
+        existing_type=sa.String(length=255),
+        nullable=False,
+    )

--- a/src/opensoar/api/auth.py
+++ b/src/opensoar/api/auth.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 import bcrypt
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from opensoar.api.deps import get_db
 from opensoar.auth.jwt import create_access_token, require_analyst
 from opensoar.models.analyst import Analyst
+from opensoar.plugins import get_auth_capabilities
+from opensoar.schemas.auth import AuthCapabilitiesResponse
 from opensoar.schemas.analyst import (
     AnalystCreate,
     AnalystLogin,
@@ -27,11 +29,20 @@ def _verify_password(password: str, hashed: str) -> bool:
     return bcrypt.checkpw(password.encode(), hashed.encode())
 
 
+@router.get("/capabilities", response_model=AuthCapabilitiesResponse)
+async def capabilities(request: Request):
+    return AuthCapabilitiesResponse.model_validate(get_auth_capabilities(request.app))
+
+
 @router.post("/register", response_model=TokenResponse)
 async def register(
+    request: Request,
     body: AnalystCreate,
     session: AsyncSession = Depends(get_db),
 ):
+    if not get_auth_capabilities(request.app)["local_registration_enabled"]:
+        raise HTTPException(status_code=403, detail="Local registration is disabled")
+
     existing = await session.execute(
         select(Analyst).where(Analyst.username == body.username)
     )
@@ -58,14 +69,18 @@ async def register(
 
 @router.post("/login", response_model=TokenResponse)
 async def login(
+    request: Request,
     body: AnalystLogin,
     session: AsyncSession = Depends(get_db),
 ):
+    if not get_auth_capabilities(request.app)["local_login_enabled"]:
+        raise HTTPException(status_code=403, detail="Local login is disabled")
+
     result = await session.execute(
         select(Analyst).where(Analyst.username == body.username)
     )
     analyst = result.scalar_one_or_none()
-    if not analyst or not _verify_password(body.password, analyst.password_hash):
+    if not analyst or not analyst.password_hash or not _verify_password(body.password, analyst.password_hash):
         raise HTTPException(status_code=401, detail="Invalid credentials")
 
     if not analyst.is_active:

--- a/src/opensoar/main.py
+++ b/src/opensoar/main.py
@@ -27,6 +27,7 @@ from opensoar.config import settings
 from opensoar.core.registry import PlaybookRegistry
 from opensoar.core.triggers import TriggerEngine
 from opensoar.db import async_session
+from opensoar.plugins import initialize_plugin_state, load_optional_plugins
 
 logging.basicConfig(
     level=logging.DEBUG if settings.debug else logging.INFO,
@@ -74,6 +75,7 @@ app = FastAPI(
     version="0.1.0",
     lifespan=lifespan,
 )
+initialize_plugin_state(app)
 
 # ── Middleware ──────────────────────────────────────────────
 app.add_middleware(RateLimitMiddleware, max_requests=100, window_seconds=60)
@@ -95,13 +97,7 @@ app.include_router(api_keys_router, prefix="/api/v1")
 app.include_router(dashboard_router, prefix="/api/v1")
 
 # ── Plugin discovery ────────────────────────────────────────────────
-try:
-    from opensoar_ee import plugin as ee_plugin
-
-    ee_plugin(app)
-    logger.info("OpenSOAR EE plugin loaded")
-except ImportError:
-    pass
+load_optional_plugins(app)
 
 # ── Static UI serving (production Docker build) ─────────────────────
 STATIC_DIR = Path(__file__).resolve().parent.parent.parent / "static"

--- a/src/opensoar/models/__init__.py
+++ b/src/opensoar/models/__init__.py
@@ -2,6 +2,7 @@ from opensoar.models.action_result import ActionResult
 from opensoar.models.activity import Activity
 from opensoar.models.alert import Alert
 from opensoar.models.analyst import Analyst
+from opensoar.models.analyst_identity import AnalystIdentity
 from opensoar.models.api_key import ApiKey
 from opensoar.models.incident import Incident
 from opensoar.models.incident_alert import IncidentAlert
@@ -15,6 +16,7 @@ __all__ = [
     "Activity",
     "Alert",
     "Analyst",
+    "AnalystIdentity",
     "ApiKey",
     "Incident",
     "IncidentAlert",

--- a/src/opensoar/models/analyst.py
+++ b/src/opensoar/models/analyst.py
@@ -12,6 +12,6 @@ class Analyst(Base):
     username: Mapped[str] = mapped_column(String(100), unique=True)
     display_name: Mapped[str] = mapped_column(String(255))
     email: Mapped[str | None] = mapped_column(String(255))
-    password_hash: Mapped[str] = mapped_column(String(255))
+    password_hash: Mapped[str | None] = mapped_column(String(255))
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     role: Mapped[str] = mapped_column(String(50), default="analyst")

--- a/src/opensoar/models/analyst_identity.py
+++ b/src/opensoar/models/analyst_identity.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from opensoar.db import Base
+
+
+class AnalystIdentity(Base):
+    __tablename__ = "analyst_identities"
+    __table_args__ = (
+        UniqueConstraint(
+            "provider_type",
+            "issuer",
+            "subject",
+            name="uq_analyst_identities_provider_issuer_subject",
+        ),
+    )
+
+    analyst_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("analysts.id", ondelete="CASCADE"),
+        index=True,
+    )
+    provider_type: Mapped[str] = mapped_column(String(50))
+    issuer: Mapped[str] = mapped_column(String(255))
+    subject: Mapped[str] = mapped_column(String(255))
+    email: Mapped[str | None] = mapped_column(String(255))
+    claims_json: Mapped[dict | None] = mapped_column(JSONB)
+    last_authenticated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/src/opensoar/plugins.py
+++ b/src/opensoar/plugins.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from importlib.metadata import entry_points
+from typing import Any
+
+from fastapi import FastAPI
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_GROUP = "opensoar.plugins"
+
+
+def initialize_plugin_state(app: FastAPI) -> None:
+    """Initialize shared plugin state once so optional packages can extend it."""
+    if not hasattr(app.state, "auth_providers"):
+        app.state.auth_providers = []
+    if not hasattr(app.state, "local_auth_enabled"):
+        app.state.local_auth_enabled = True
+    if not hasattr(app.state, "local_registration_enabled"):
+        app.state.local_registration_enabled = True
+
+
+def iter_plugin_entry_points(group: str = PLUGIN_GROUP) -> Iterable[Any]:
+    discovered = entry_points()
+    if hasattr(discovered, "select"):
+        return discovered.select(group=group)
+    return discovered.get(group, [])
+
+
+def load_optional_plugins(app: FastAPI, group: str = PLUGIN_GROUP) -> list[str]:
+    initialize_plugin_state(app)
+
+    loaded_plugins: list[str] = []
+    for plugin_ep in iter_plugin_entry_points(group):
+        try:
+            plugin = plugin_ep.load()
+            plugin(app)
+            loaded_plugins.append(plugin_ep.name)
+            logger.info("Loaded optional plugin: %s", plugin_ep.name)
+        except Exception:
+            logger.exception("Failed to load optional plugin: %s", plugin_ep.name)
+
+    return loaded_plugins
+
+
+def configure_local_auth(
+    app: FastAPI,
+    *,
+    login_enabled: bool | None = None,
+    registration_enabled: bool | None = None,
+) -> None:
+    initialize_plugin_state(app)
+    if login_enabled is not None:
+        app.state.local_auth_enabled = login_enabled
+    if registration_enabled is not None:
+        app.state.local_registration_enabled = registration_enabled
+
+
+def register_auth_provider(
+    app: FastAPI,
+    *,
+    provider_id: str,
+    name: str,
+    provider_type: str,
+    login_url: str | None = None,
+) -> None:
+    initialize_plugin_state(app)
+
+    providers = [
+        provider for provider in app.state.auth_providers if provider["id"] != provider_id
+    ]
+    providers.append(
+        {
+            "id": provider_id,
+            "name": name,
+            "type": provider_type,
+            "login_url": login_url,
+        }
+    )
+    app.state.auth_providers = providers
+
+
+def get_auth_capabilities(app: FastAPI) -> dict[str, Any]:
+    initialize_plugin_state(app)
+    return {
+        "local_login_enabled": app.state.local_auth_enabled,
+        "local_registration_enabled": app.state.local_registration_enabled,
+        "providers": list(app.state.auth_providers),
+    }

--- a/src/opensoar/schemas/auth.py
+++ b/src/opensoar/schemas/auth.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class AuthProviderCapability(BaseModel):
+    id: str
+    name: str
+    type: str
+    login_url: str | None = None
+
+
+class AuthCapabilitiesResponse(BaseModel):
+    local_login_enabled: bool
+    local_registration_enabled: bool
+    providers: list[AuthProviderCapability]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta, timezone
 
 import jwt
 import pytest
+from sqlalchemy import select
 
 from opensoar.auth.jwt import create_access_token, decode_token
 from opensoar.config import settings
@@ -67,6 +68,28 @@ class TestRegister:
         resp = await client.post("/api/v1/auth/register", json=body)
         assert resp.status_code == 409
 
+    async def test_register_disabled_when_local_registration_off(self, client):
+        from opensoar.main import app
+        from opensoar.plugins import configure_local_auth
+
+        original_login = app.state.local_auth_enabled
+        original_registration = app.state.local_registration_enabled
+        try:
+            configure_local_auth(app, registration_enabled=False)
+            resp = await client.post(
+                "/api/v1/auth/register",
+                json={
+                    "username": f"blocked_{uuid.uuid4().hex[:8]}",
+                    "display_name": "Blocked User",
+                    "password": "securepass123",
+                },
+            )
+        finally:
+            app.state.local_auth_enabled = original_login
+            app.state.local_registration_enabled = original_registration
+
+        assert resp.status_code == 403
+
 
 # ── Login endpoint ──────────────────────────────────────────
 
@@ -112,6 +135,43 @@ class TestLogin:
         )
         assert resp.status_code == 401
 
+    async def test_login_without_local_password_rejected(self, client, session):
+        from opensoar.models.analyst import Analyst
+
+        analyst = Analyst(
+            username=f"sso_{uuid.uuid4().hex[:8]}",
+            display_name="SSO Only",
+            email="sso@opensoar.app",
+            password_hash=None,
+            role="analyst",
+        )
+        session.add(analyst)
+        await session.commit()
+
+        resp = await client.post(
+            "/api/v1/auth/login",
+            json={"username": analyst.username, "password": "any-password"},
+        )
+        assert resp.status_code == 401
+
+    async def test_login_disabled_when_local_login_off(self, client):
+        from opensoar.main import app
+        from opensoar.plugins import configure_local_auth
+
+        original_login = app.state.local_auth_enabled
+        original_registration = app.state.local_registration_enabled
+        try:
+            configure_local_auth(app, login_enabled=False)
+            resp = await client.post(
+                "/api/v1/auth/login",
+                json={"username": "nobody", "password": "pass"},
+            )
+        finally:
+            app.state.local_auth_enabled = original_login
+            app.state.local_registration_enabled = original_registration
+
+        assert resp.status_code == 403
+
 
 # ── /me endpoint ────────────────────────────────────────────
 
@@ -138,3 +198,88 @@ class TestMe:
     async def test_me_unauthenticated(self, client):
         resp = await client.get("/api/v1/auth/me")
         assert resp.status_code == 401
+
+
+class TestCapabilities:
+    async def test_capabilities_default_local_auth(self, client):
+        resp = await client.get("/api/v1/auth/capabilities")
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "local_login_enabled": True,
+            "local_registration_enabled": True,
+            "providers": [],
+        }
+
+    async def test_capabilities_reflect_app_state(self, client):
+        from opensoar.main import app
+
+        original_login = app.state.local_auth_enabled
+        original_registration = app.state.local_registration_enabled
+        original_providers = list(app.state.auth_providers)
+
+        app.state.local_auth_enabled = False
+        app.state.local_registration_enabled = False
+        app.state.auth_providers = [
+            {
+                "id": "oidc-keycloak",
+                "name": "Keycloak",
+                "type": "oidc",
+                "login_url": "/api/v1/sso/oidc/authorize?provider_id=oidc-keycloak",
+            }
+        ]
+
+        try:
+            resp = await client.get("/api/v1/auth/capabilities")
+        finally:
+            app.state.local_auth_enabled = original_login
+            app.state.local_registration_enabled = original_registration
+            app.state.auth_providers = original_providers
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "local_login_enabled": False,
+            "local_registration_enabled": False,
+            "providers": [
+                {
+                    "id": "oidc-keycloak",
+                    "name": "Keycloak",
+                    "type": "oidc",
+                    "login_url": "/api/v1/sso/oidc/authorize?provider_id=oidc-keycloak",
+                }
+            ],
+        }
+
+
+class TestExternalIdentities:
+    async def test_external_identity_can_be_persisted(self, session):
+        from opensoar.models.analyst import Analyst
+        from opensoar.models.analyst_identity import AnalystIdentity
+
+        analyst = Analyst(
+            username=f"linked_{uuid.uuid4().hex[:8]}",
+            display_name="Linked Analyst",
+            email="linked@opensoar.app",
+            password_hash=None,
+            role="analyst",
+        )
+        session.add(analyst)
+        await session.flush()
+
+        identity = AnalystIdentity(
+            analyst_id=analyst.id,
+            provider_type="oidc",
+            issuer="https://idp.example.com",
+            subject=f"user-{uuid.uuid4().hex[:8]}",
+            email="linked@opensoar.app",
+            claims_json={"groups": ["soc-analysts"]},
+        )
+        session.add(identity)
+        await session.commit()
+
+        result = await session.execute(
+            select(AnalystIdentity).where(AnalystIdentity.id == identity.id)
+        )
+        stored = result.scalar_one()
+        assert stored.analyst_id == analyst.id
+        assert stored.provider_type == "oidc"

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from opensoar.plugins import get_auth_capabilities, load_optional_plugins
+
+
+class FakeEntryPoint:
+    def __init__(self, name: str, plugin):
+        self.name = name
+        self._plugin = plugin
+
+    def load(self):
+        return self._plugin
+
+
+def test_load_optional_plugins_no_plugins(monkeypatch):
+    app = FastAPI()
+    monkeypatch.setattr("opensoar.plugins.iter_plugin_entry_points", lambda group="opensoar.plugins": [])
+
+    loaded = load_optional_plugins(app)
+
+    assert loaded == []
+    assert get_auth_capabilities(app) == {
+        "local_login_enabled": True,
+        "local_registration_enabled": True,
+        "providers": [],
+    }
+
+
+def test_load_optional_plugins_registers_auth_provider(monkeypatch):
+    app = FastAPI()
+
+    def fake_plugin(target_app: FastAPI):
+        target_app.state.local_auth_enabled = False
+        target_app.state.local_registration_enabled = False
+        target_app.state.auth_providers = [
+            {
+                "id": "oidc-okta",
+                "name": "Okta",
+                "type": "oidc",
+                "login_url": "/api/v1/sso/oidc/authorize?provider_id=oidc-okta",
+            }
+        ]
+
+    monkeypatch.setattr(
+        "opensoar.plugins.iter_plugin_entry_points",
+        lambda group="opensoar.plugins": [FakeEntryPoint("ee", fake_plugin)],
+    )
+
+    loaded = load_optional_plugins(app)
+
+    assert loaded == ["ee"]
+    assert get_auth_capabilities(app) == {
+        "local_login_enabled": False,
+        "local_registration_enabled": False,
+        "providers": [
+            {
+                "id": "oidc-okta",
+                "name": "Okta",
+                "type": "oidc",
+                "login_url": "/api/v1/sso/oidc/authorize?provider_id=oidc-okta",
+            }
+        ],
+    }

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -157,6 +157,19 @@ export interface TokenResponse {
   analyst: Analyst
 }
 
+export interface AuthProviderCapability {
+  id: string
+  name: string
+  type: string
+  login_url: string | null
+}
+
+export interface AuthCapabilities {
+  local_login_enabled: boolean
+  local_registration_enabled: boolean
+  providers: AuthProviderCapability[]
+}
+
 export interface Activity {
   id: string
   alert_id: string
@@ -257,6 +270,7 @@ export const api = {
     login: (data: { username: string; password: string }) =>
       postJSON<TokenResponse>('/auth/login', data),
     me: () => fetchJSON<Analyst>('/auth/me'),
+    capabilities: () => fetchJSON<AuthCapabilities>('/auth/capabilities'),
   },
   webhooks: {
     createAlert: (payload: Record<string, unknown>) =>

--- a/ui/src/contexts/AuthContext.tsx
+++ b/ui/src/contexts/AuthContext.tsx
@@ -1,23 +1,40 @@
+/* eslint-disable react-refresh/only-export-components */
 import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react'
-import { api, type Analyst } from '@/api'
+import { api, type Analyst, type AuthCapabilities } from '@/api'
 
 interface AuthContextType {
   analyst: Analyst | null
   isLoading: boolean
+  authCapabilities: AuthCapabilities
+  authCapabilitiesLoading: boolean
   login: (username: string, password: string) => Promise<void>
   register: (username: string, displayName: string, password: string) => Promise<void>
   logout: () => void
 }
 
 const AuthContext = createContext<AuthContextType | null>(null)
+const DEFAULT_AUTH_CAPABILITIES: AuthCapabilities = {
+  local_login_enabled: true,
+  local_registration_enabled: true,
+  providers: [],
+}
 
 export function AuthProvider({ children }: { children: ReactNode }) {
+  const [initialToken] = useState(() => localStorage.getItem('opensoar_token'))
   const [analyst, setAnalyst] = useState<Analyst | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
+  const [isLoading, setIsLoading] = useState(() => Boolean(initialToken))
+  const [authCapabilities, setAuthCapabilities] = useState<AuthCapabilities>(DEFAULT_AUTH_CAPABILITIES)
+  const [authCapabilitiesLoading, setAuthCapabilitiesLoading] = useState(true)
 
   useEffect(() => {
-    const token = localStorage.getItem('opensoar_token')
-    if (token) {
+    api.auth.capabilities()
+      .then(setAuthCapabilities)
+      .catch(() => {
+        setAuthCapabilities(DEFAULT_AUTH_CAPABILITIES)
+      })
+      .finally(() => setAuthCapabilitiesLoading(false))
+
+    if (initialToken) {
       api.auth.me()
         .then(setAnalyst)
         .catch(() => {
@@ -25,10 +42,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           setAnalyst(null)
         })
         .finally(() => setIsLoading(false))
-    } else {
-      setIsLoading(false)
     }
-  }, [])
+  }, [initialToken])
 
   const login = useCallback(async (username: string, password: string) => {
     const res = await api.auth.login({ username, password })
@@ -48,7 +63,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [])
 
   return (
-    <AuthContext.Provider value={{ analyst, isLoading, login, register, logout }}>
+    <AuthContext.Provider value={{ analyst, isLoading, authCapabilities, authCapabilitiesLoading, login, register, logout }}>
       {children}
     </AuthContext.Provider>
   )

--- a/ui/src/pages/LoginPage.tsx
+++ b/ui/src/pages/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { motion } from 'framer-motion'
 import { useAuth } from '@/contexts/AuthContext'
 import { Button } from '@/components/ui/Button'
@@ -8,13 +8,25 @@ import { Input, Label } from '@/components/ui/Input'
 const ease = [0.25, 0.1, 0.25, 1] as [number, number, number, number]
 
 export function LoginPage() {
-  const { login, register } = useAuth()
+  const { login, register, authCapabilities, authCapabilitiesLoading } = useAuth()
   const [mode, setMode] = useState<'login' | 'register'>('login')
   const [username, setUsername] = useState('')
   const [displayName, setDisplayName] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
+  const canLoginLocally = authCapabilities.local_login_enabled
+  const canRegisterLocally = authCapabilities.local_registration_enabled
+  const hasExternalProviders = authCapabilities.providers.length > 0
+
+  useEffect(() => {
+    if (mode === 'register' && !canRegisterLocally) {
+      setMode('login')
+    }
+    if (mode === 'login' && !canLoginLocally && canRegisterLocally) {
+      setMode('register')
+    }
+  }, [canLoginLocally, canRegisterLocally, mode])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -31,6 +43,11 @@ export function LoginPage() {
     } finally {
       setLoading(false)
     }
+  }
+
+  const handleProviderSignIn = (loginUrl: string | null) => {
+    if (!loginUrl) return
+    window.location.assign(loginUrl)
   }
 
   return (
@@ -67,108 +84,146 @@ export function LoginPage() {
 
           <Card className="relative shadow-lg shadow-black/20">
             <CardContent className="p-6">
-              {/* Mode toggle */}
-              <div className="flex gap-0 mb-6 border border-border rounded-lg overflow-hidden bg-bg">
-                <button
-                  type="button"
-                  onClick={() => setMode('login')}
-                  className={`flex-1 py-2.5 text-xs font-medium border-none cursor-pointer transition-all duration-200 ${
-                    mode === 'login'
-                      ? 'bg-heading text-bg shadow-sm'
-                      : 'bg-transparent text-muted hover:text-heading'
-                  }`}
-                >
-                  Sign In
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setMode('register')}
-                  className={`flex-1 py-2.5 text-xs font-medium border-none cursor-pointer transition-all duration-200 ${
-                    mode === 'register'
-                      ? 'bg-heading text-bg shadow-sm'
-                      : 'bg-transparent text-muted hover:text-heading'
-                  }`}
-                >
-                  Register
-                </button>
-              </div>
-
-              <form onSubmit={handleSubmit} className="space-y-4">
-                <div>
-                  <Label htmlFor="username">Username</Label>
-                  <Input
-                    id="username"
-                    type="text"
-                    value={username}
-                    onChange={(e) => setUsername(e.target.value)}
-                    placeholder="analyst"
-                    required
-                  />
+              {canLoginLocally || canRegisterLocally ? (
+                <div className="flex gap-0 mb-6 border border-border rounded-lg overflow-hidden bg-bg">
+                  {canLoginLocally ? (
+                    <button
+                      type="button"
+                      onClick={() => setMode('login')}
+                      className={`flex-1 py-2.5 text-xs font-medium border-none cursor-pointer transition-all duration-200 ${
+                        mode === 'login'
+                          ? 'bg-heading text-bg shadow-sm'
+                          : 'bg-transparent text-muted hover:text-heading'
+                      }`}
+                    >
+                      Sign In
+                    </button>
+                  ) : null}
+                  {canRegisterLocally ? (
+                    <button
+                      type="button"
+                      onClick={() => setMode('register')}
+                      className={`flex-1 py-2.5 text-xs font-medium border-none cursor-pointer transition-all duration-200 ${
+                        mode === 'register'
+                          ? 'bg-heading text-bg shadow-sm'
+                          : 'bg-transparent text-muted hover:text-heading'
+                      }`}
+                    >
+                      Register
+                    </button>
+                  ) : null}
                 </div>
+              ) : null}
 
-                {mode === 'register' && (
-                  <motion.div
-                    initial={{ opacity: 0, height: 0 }}
-                    animate={{ opacity: 1, height: 'auto' }}
-                    exit={{ opacity: 0, height: 0 }}
-                    transition={{ duration: 0.2, ease }}
-                  >
-                    <Label htmlFor="displayName">Display Name</Label>
+              {hasExternalProviders ? (
+                <div className="mb-6 space-y-3">
+                  {authCapabilities.providers.map((provider) => (
+                    <Button
+                      key={provider.id}
+                      type="button"
+                      variant="default"
+                      size="lg"
+                      className="w-full justify-center"
+                      onClick={() => handleProviderSignIn(provider.login_url)}
+                      disabled={!provider.login_url || loading}
+                    >
+                      Continue with {provider.name}
+                    </Button>
+                  ))}
+                  {(canLoginLocally || canRegisterLocally) ? (
+                    <div className="flex items-center gap-3 text-[11px] uppercase tracking-[0.18em] text-muted/70">
+                      <div className="h-px flex-1 bg-border" />
+                      <span>or</span>
+                      <div className="h-px flex-1 bg-border" />
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
+
+              {(canLoginLocally || canRegisterLocally) ? (
+                <form onSubmit={handleSubmit} className="space-y-4">
+                  <div>
+                    <Label htmlFor="username">Username</Label>
                     <Input
-                      id="displayName"
+                      id="username"
                       type="text"
-                      value={displayName}
-                      onChange={(e) => setDisplayName(e.target.value)}
-                      placeholder="Jane Doe"
+                      value={username}
+                      onChange={(e) => setUsername(e.target.value)}
+                      placeholder="analyst"
+                      required
                     />
-                  </motion.div>
-                )}
+                  </div>
 
-                <div>
-                  <Label htmlFor="password">Password</Label>
-                  <Input
-                    id="password"
-                    type="password"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    placeholder="••••••••"
-                    required
-                  />
-                </div>
+                  {mode === 'register' && (
+                    <motion.div
+                      initial={{ opacity: 0, height: 0 }}
+                      animate={{ opacity: 1, height: 'auto' }}
+                      exit={{ opacity: 0, height: 0 }}
+                      transition={{ duration: 0.2, ease }}
+                    >
+                      <Label htmlFor="displayName">Display Name</Label>
+                      <Input
+                        id="displayName"
+                        type="text"
+                        value={displayName}
+                        onChange={(e) => setDisplayName(e.target.value)}
+                        placeholder="Jane Doe"
+                      />
+                    </motion.div>
+                  )}
 
-                {error && (
-                  <motion.div
-                    className="flex items-center gap-2 text-xs text-danger bg-danger/10 border border-danger/20 rounded-md px-3 py-2.5"
-                    initial={{ opacity: 0, y: -4 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.2 }}
-                  >
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0">
-                      <circle cx="12" cy="12" r="10" />
-                      <line x1="15" y1="9" x2="9" y2="15" />
-                      <line x1="9" y1="9" x2="15" y2="15" />
-                    </svg>
-                    {error}
-                  </motion.div>
-                )}
+                  <div>
+                    <Label htmlFor="password">Password</Label>
+                    <Input
+                      id="password"
+                      type="password"
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      placeholder="••••••••"
+                      required
+                    />
+                  </div>
 
-                <Button
-                  variant="primary"
-                  size="lg"
-                  className="w-full justify-center mt-2"
-                  disabled={loading || !username || !password}
-                >
-                  {loading ? (
-                    <>
-                      <svg className="animate-spin -ml-1 mr-2 h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                  {error && (
+                    <motion.div
+                      className="flex items-center gap-2 text-xs text-danger bg-danger/10 border border-danger/20 rounded-md px-3 py-2.5"
+                      initial={{ opacity: 0, y: -4 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      transition={{ duration: 0.2 }}
+                    >
+                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0">
+                        <circle cx="12" cy="12" r="10" />
+                        <line x1="15" y1="9" x2="9" y2="15" />
+                        <line x1="9" y1="9" x2="15" y2="15" />
                       </svg>
-                      Please wait...
-                    </>
-                  ) : mode === 'login' ? 'Sign In' : 'Create Account'}
-                </Button>
-              </form>
+                      {error}
+                    </motion.div>
+                  )}
+
+                  <Button
+                    variant="primary"
+                    size="lg"
+                    className="w-full justify-center mt-2"
+                    disabled={loading || !username || !password}
+                  >
+                    {loading ? (
+                      <>
+                        <svg className="animate-spin -ml-1 mr-2 h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                        </svg>
+                        Please wait...
+                      </>
+                    ) : mode === 'login' ? 'Sign In' : 'Create Account'}
+                  </Button>
+                </form>
+              ) : !hasExternalProviders ? (
+                <div className="rounded-md border border-border bg-bg px-4 py-3 text-sm text-muted">
+                  {authCapabilitiesLoading
+                    ? 'Loading sign-in options...'
+                    : 'No local sign-in methods are enabled for this deployment.'}
+                </div>
+              ) : null}
             </CardContent>
           </Card>
         </motion.div>


### PR DESCRIPTION
## What changed
- replaced the hardcoded EE import with entry-point based plugin loading
- added runtime auth capability discovery at `/api/v1/auth/capabilities`
- wired the login UI to capability-driven local/external auth rendering
- made local login and registration enforce deployment capabilities on the backend
- added `AnalystIdentity` and made `Analyst.password_hash` nullable so externally managed accounts are possible
- added the migration and focused tests for the new identity model

## Why it changed
OpenSOAR needed a core contract for optional auth providers without pulling OIDC/SAML protocol logic into the OSS package. This PR establishes that contract and removes the data-model assumptions that would have forced EE-specific auth behavior into core.

## Impact
- existing local username/password installs keep working by default
- optional plugins can now advertise external auth providers cleanly
- EE can build provider storage and OIDC callback flows on top of a stable core contract

## Validation
- `PATH="$PWD/.venv/bin:$PATH" JWT_SECRET="test-secret-which-is-long-enough-for-hs256" API_KEY_SECRET="test-api-key-secret" .venv/bin/pytest tests/test_plugins.py tests/test_auth.py -q`
- `PATH="$PWD/.venv/bin:$PATH" JWT_SECRET="test-secret-which-is-long-enough-for-hs256" API_KEY_SECRET="test-api-key-secret" DATABASE_URL="postgresql+asyncpg://opensoar:opensoar@localhost:5432/opensoar_test" .venv/bin/pytest tests/test_migrations.py -q`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/ruff check src tests`
- `npm run build` in `ui/`

## Known gaps
- no EE provider storage or OIDC callback implementation yet
- no end-to-end external login path until the EE slice lands

Closes #3
Closes #4
Closes #5
Closes #7
