### PR TITLE
[codex] Support optional plugin migrations in core

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,5 +1,6 @@
 import asyncio
 from logging.config import fileConfig
+from pathlib import Path
 
 from sqlalchemy import pool
 from sqlalchemy.ext.asyncio import async_engine_from_config
@@ -9,9 +10,22 @@ from alembic import context
 from opensoar.config import settings
 from opensoar.db import Base
 import opensoar.models  # noqa: F401 — ensure all models are imported
+from opensoar.plugins import (
+    configure_alembic_version_locations,
+    get_plugin_migration_config,
+    import_optional_plugin_models,
+)
 
 config = context.config
 config.set_main_option("sqlalchemy.url", settings.database_url)
+
+import_optional_plugin_models()
+plugin_migration_config = get_plugin_migration_config()
+configure_alembic_version_locations(
+    config,
+    core_versions_path=str((Path(__file__).resolve().parent / "versions").resolve()),
+    plugin_version_locations=plugin_migration_config.version_locations,
+)
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)

--- a/src/opensoar/plugins.py
+++ b/src/opensoar/plugins.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import importlib
 import logging
+import os
 from collections.abc import Iterable
+from dataclasses import dataclass
 from importlib.metadata import entry_points
+from pathlib import Path
+from types import ModuleType
 from typing import Any
 
 from fastapi import FastAPI
@@ -10,6 +15,8 @@ from fastapi import FastAPI
 logger = logging.getLogger(__name__)
 
 PLUGIN_GROUP = "opensoar.plugins"
+PLUGIN_MODEL_MODULES_ATTR = "PLUGIN_MODEL_MODULES"
+PLUGIN_VERSION_LOCATIONS_ATTR = "PLUGIN_VERSION_LOCATIONS"
 
 
 def initialize_plugin_state(app: FastAPI) -> None:
@@ -27,6 +34,75 @@ def iter_plugin_entry_points(group: str = PLUGIN_GROUP) -> Iterable[Any]:
     if hasattr(discovered, "select"):
         return discovered.select(group=group)
     return discovered.get(group, [])
+
+
+@dataclass(frozen=True)
+class PluginMigrationConfig:
+    model_modules: tuple[str, ...] = ()
+    version_locations: tuple[str, ...] = ()
+
+
+def _load_plugin_module(plugin_ep: Any) -> ModuleType:
+    plugin = plugin_ep.load()
+    module_name = getattr(plugin_ep, "module", None) or getattr(plugin, "__module__", None)
+    if not module_name:
+        raise ValueError(f"Unable to determine plugin module for entry point {plugin_ep.name}")
+    return importlib.import_module(module_name)
+
+
+def _normalize_version_location(module: ModuleType, location: str) -> str:
+    path = Path(location)
+    if path.is_absolute():
+        return str(path)
+
+    module_file = getattr(module, "__file__", None)
+    if not module_file:
+        raise ValueError(
+            f"Plugin module {module.__name__} must define __file__ for relative version paths"
+        )
+    return str((Path(module_file).resolve().parent / path).resolve())
+
+
+def get_plugin_migration_config(group: str = PLUGIN_GROUP) -> PluginMigrationConfig:
+    model_modules: list[str] = []
+    version_locations: list[str] = []
+
+    for plugin_ep in iter_plugin_entry_points(group):
+        module = _load_plugin_module(plugin_ep)
+
+        for model_module in getattr(module, PLUGIN_MODEL_MODULES_ATTR, ()):
+            if model_module not in model_modules:
+                model_modules.append(model_module)
+
+        for location in getattr(module, PLUGIN_VERSION_LOCATIONS_ATTR, ()):
+            normalized = _normalize_version_location(module, location)
+            if normalized not in version_locations:
+                version_locations.append(normalized)
+
+    return PluginMigrationConfig(
+        model_modules=tuple(model_modules),
+        version_locations=tuple(version_locations),
+    )
+
+
+def import_optional_plugin_models(group: str = PLUGIN_GROUP) -> tuple[str, ...]:
+    config = get_plugin_migration_config(group)
+    imported: list[str] = []
+    for model_module in config.model_modules:
+        importlib.import_module(model_module)
+        imported.append(model_module)
+    return tuple(imported)
+
+
+def configure_alembic_version_locations(
+    alembic_config: Any,
+    *,
+    core_versions_path: str,
+    plugin_version_locations: Iterable[str],
+) -> tuple[str, ...]:
+    version_locations = [core_versions_path, *plugin_version_locations]
+    alembic_config.set_main_option("version_locations", os.pathsep.join(version_locations))
+    return tuple(version_locations)
 
 
 def load_optional_plugins(app: FastAPI, group: str = PLUGIN_GROUP) -> list[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,10 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from opensoar.db import Base
+import opensoar.models  # noqa: F401 - populate core metadata for drop_all/create paths
+from opensoar.plugins import import_optional_plugin_models
+
+import_optional_plugin_models()
 
 # Use DATABASE_URL env var if set (CI), otherwise default test DB
 TEST_DATABASE_URL = os.environ.get(

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,14 +1,23 @@
 from __future__ import annotations
 
+from types import ModuleType
+
 from fastapi import FastAPI
 
-from opensoar.plugins import get_auth_capabilities, load_optional_plugins
+from opensoar.plugins import (
+    configure_alembic_version_locations,
+    get_auth_capabilities,
+    get_plugin_migration_config,
+    import_optional_plugin_models,
+    load_optional_plugins,
+)
 
 
 class FakeEntryPoint:
-    def __init__(self, name: str, plugin):
+    def __init__(self, name: str, plugin, module: str | None = None):
         self.name = name
         self._plugin = plugin
+        self.module = module
 
     def load(self):
         return self._plugin
@@ -63,3 +72,73 @@ def test_load_optional_plugins_registers_auth_provider(monkeypatch):
             }
         ],
     }
+
+
+def test_get_plugin_migration_config_no_plugins(monkeypatch):
+    monkeypatch.setattr(
+        "opensoar.plugins.iter_plugin_entry_points",
+        lambda group="opensoar.plugins": [],
+    )
+
+    config = get_plugin_migration_config()
+
+    assert config.model_modules == ()
+    assert config.version_locations == ()
+
+
+def test_get_plugin_migration_config_collects_models_and_versions(monkeypatch, tmp_path):
+    plugin_file = tmp_path / "opensoar_ee" / "__init__.py"
+    plugin_file.parent.mkdir()
+    plugin_file.write_text("# plugin module\n")
+
+    plugin_module = ModuleType("opensoar_ee")
+    plugin_module.__file__ = str(plugin_file)
+    plugin_module.PLUGIN_MODEL_MODULES = ("opensoar_ee.models",)
+    plugin_module.PLUGIN_VERSION_LOCATIONS = ("migrations/versions",)
+
+    imported_modules: dict[str, ModuleType] = {
+        "opensoar_ee": plugin_module,
+        "opensoar_ee.models": ModuleType("opensoar_ee.models"),
+    }
+
+    def fake_import_module(name: str):
+        return imported_modules[name]
+
+    def fake_plugin(_app: FastAPI):
+        return None
+
+    monkeypatch.setattr(
+        "opensoar.plugins.iter_plugin_entry_points",
+        lambda group="opensoar.plugins": [
+            FakeEntryPoint("ee", fake_plugin, module="opensoar_ee")
+        ],
+    )
+    monkeypatch.setattr("opensoar.plugins.importlib.import_module", fake_import_module)
+
+    config = get_plugin_migration_config()
+    imported = import_optional_plugin_models()
+
+    assert config.model_modules == ("opensoar_ee.models",)
+    assert config.version_locations == (
+        str((plugin_file.parent / "migrations" / "versions").resolve()),
+    )
+    assert imported == ("opensoar_ee.models",)
+
+
+def test_configure_alembic_version_locations():
+    class FakeConfig:
+        def __init__(self):
+            self.values: dict[str, str] = {}
+
+        def set_main_option(self, key: str, value: str):
+            self.values[key] = value
+
+    config = FakeConfig()
+    result = configure_alembic_version_locations(
+        config,
+        core_versions_path="/core/versions",
+        plugin_version_locations=("/ee/versions",),
+    )
+
+    assert result == ("/core/versions", "/ee/versions")
+    assert config.values["version_locations"] == "/core/versions:/ee/versions"


### PR DESCRIPTION
## What changed
- added a plugin migration contract in `src/opensoar/plugins.py`
- taught Alembic to import optional plugin model modules before comparing metadata
- taught Alembic to include plugin-provided version locations alongside core migrations
- fixed the test fixture so metadata-backed table cleanup deterministically imports core and optional plugin models
- added focused tests for plugin migration config discovery and version-location wiring

## Why it changed
`opensoar-core` can now load optional plugins at runtime, but schema management still only understood core-owned models and core-owned revision directories. That blocked persisted EE work such as SSO provider storage, tenant tables, and compliance tables.

## Impact
- core-only installs keep using the same migration path
- optional plugins now have an explicit contract for contributing model modules and Alembic version directories
- EE provider persistence can build on a real migration path instead of inventing a side-channel bootstrap

## Validation
- `PATH="$PWD/.venv/bin:$PATH" JWT_SECRET="test-secret-which-is-long-enough-for-hs256" API_KEY_SECRET="test-api-key-secret" .venv/bin/pytest tests/test_plugins.py tests/test_auth.py tests/test_migrations.py -q`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/ruff check src/opensoar/plugins.py migrations/env.py tests/test_plugins.py tests/conftest.py`

## Known gaps
- no installed EE plugin metadata is using the new contract yet
- no real multi-package migration run has been exercised until the EE slice lands

Closes #9
