### PR TITLE
[codex] Add core audit sink abstraction

### DIFF
--- a/src/opensoar/api/api_keys.py
+++ b/src/opensoar/api/api_keys.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -13,6 +13,8 @@ from opensoar.auth.api_key import generate_api_key
 from opensoar.auth.jwt import require_analyst
 from opensoar.models.analyst import Analyst
 from opensoar.models.api_key import ApiKey
+from opensoar.plugins import dispatch_audit_event
+from opensoar.schemas.audit import AuditEvent
 
 router = APIRouter(prefix="/api-keys", tags=["api-keys"])
 
@@ -54,15 +56,29 @@ async def list_api_keys(
 
 @router.post("", response_model=ApiKeyCreatedResponse, status_code=201)
 async def create_api_key(
+    request: Request,
     body: ApiKeyCreate,
     session: AsyncSession = Depends(get_db),
-    _admin: Analyst = Depends(_require_admin),
+    admin: Analyst = Depends(_require_admin),
 ):
     key, prefix, key_hash = generate_api_key()
     api_key = ApiKey(name=body.name, key_hash=key_hash, prefix=prefix)
     session.add(api_key)
     await session.commit()
     await session.refresh(api_key)
+
+    await dispatch_audit_event(
+        request.app,
+        AuditEvent(
+            category="admin",
+            action="api_key.created",
+            actor_id=admin.id,
+            actor_username=admin.username,
+            target_type="api_key",
+            target_id=str(api_key.id),
+            metadata_json={"name": api_key.name, "prefix": api_key.prefix},
+        ),
+    )
 
     return ApiKeyCreatedResponse(
         id=api_key.id,
@@ -77,8 +93,9 @@ async def create_api_key(
 @router.delete("/{key_id}")
 async def revoke_api_key(
     key_id: uuid.UUID,
+    request: Request,
     session: AsyncSession = Depends(get_db),
-    _admin: Analyst = Depends(_require_admin),
+    admin: Analyst = Depends(_require_admin),
 ):
     result = await session.execute(select(ApiKey).where(ApiKey.id == key_id))
     api_key = result.scalar_one_or_none()
@@ -87,4 +104,17 @@ async def revoke_api_key(
 
     api_key.is_active = False
     await session.commit()
+
+    await dispatch_audit_event(
+        request.app,
+        AuditEvent(
+            category="admin",
+            action="api_key.revoked",
+            actor_id=admin.id,
+            actor_username=admin.username,
+            target_type="api_key",
+            target_id=str(api_key.id),
+            metadata_json={"name": api_key.name, "prefix": api_key.prefix},
+        ),
+    )
     return {"detail": "API key revoked"}

--- a/src/opensoar/api/auth.py
+++ b/src/opensoar/api/auth.py
@@ -8,7 +8,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from opensoar.api.deps import get_db
 from opensoar.auth.jwt import create_access_token, require_analyst
 from opensoar.models.analyst import Analyst
-from opensoar.plugins import get_auth_capabilities
+from opensoar.plugins import dispatch_audit_event, get_auth_capabilities
+from opensoar.schemas.audit import AuditEvent
 from opensoar.schemas.auth import AuthCapabilitiesResponse
 from opensoar.schemas.analyst import (
     AnalystCreate,
@@ -60,6 +61,19 @@ async def register(
     await session.commit()
     await session.refresh(analyst)
 
+    await dispatch_audit_event(
+        request.app,
+        AuditEvent(
+            category="auth",
+            action="analyst.registered",
+            actor_id=analyst.id,
+            actor_username=analyst.username,
+            target_type="analyst",
+            target_id=str(analyst.id),
+            metadata_json={"role": analyst.role},
+        ),
+    )
+
     token = create_access_token(analyst.id, analyst.username)
     return TokenResponse(
         access_token=token,
@@ -85,6 +99,18 @@ async def login(
 
     if not analyst.is_active:
         raise HTTPException(status_code=403, detail="Account is deactivated")
+
+    await dispatch_audit_event(
+        request.app,
+        AuditEvent(
+            category="auth",
+            action="analyst.logged_in",
+            actor_id=analyst.id,
+            actor_username=analyst.username,
+            target_type="analyst",
+            target_id=str(analyst.id),
+        ),
+    )
 
     token = create_access_token(analyst.id, analyst.username)
     return TokenResponse(
@@ -119,8 +145,9 @@ async def list_analysts(
 async def update_analyst(
     analyst_id: str,
     body: AnalystUpdate,
+    request: Request,
     session: AsyncSession = Depends(get_db),
-    _admin: Analyst = Depends(_require_admin),
+    admin: Analyst = Depends(_require_admin),
 ):
     import uuid as _uuid
 
@@ -137,4 +164,17 @@ async def update_analyst(
 
     await session.commit()
     await session.refresh(analyst)
+
+    await dispatch_audit_event(
+        request.app,
+        AuditEvent(
+            category="admin",
+            action="analyst.updated",
+            actor_id=admin.id,
+            actor_username=admin.username,
+            target_type="analyst",
+            target_id=str(analyst.id),
+            metadata_json={"updated_fields": sorted(update_data.keys())},
+        ),
+    )
     return AnalystResponse.model_validate(analyst)

--- a/src/opensoar/plugins.py
+++ b/src/opensoar/plugins.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 import logging
 import os
 from collections.abc import Iterable
@@ -11,6 +12,8 @@ from types import ModuleType
 from typing import Any
 
 from fastapi import FastAPI
+
+from opensoar.schemas.audit import AuditEvent
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +26,8 @@ def initialize_plugin_state(app: FastAPI) -> None:
     """Initialize shared plugin state once so optional packages can extend it."""
     if not hasattr(app.state, "auth_providers"):
         app.state.auth_providers = []
+    if not hasattr(app.state, "audit_sinks"):
+        app.state.audit_sinks = []
     if not hasattr(app.state, "local_auth_enabled"):
         app.state.local_auth_enabled = True
     if not hasattr(app.state, "local_registration_enabled"):
@@ -156,6 +161,19 @@ def register_auth_provider(
         }
     )
     app.state.auth_providers = providers
+
+
+def register_audit_sink(app: FastAPI, sink: Any) -> None:
+    initialize_plugin_state(app)
+    app.state.audit_sinks.append(sink)
+
+
+async def dispatch_audit_event(app: FastAPI, event: AuditEvent) -> None:
+    initialize_plugin_state(app)
+    for sink in list(app.state.audit_sinks):
+        result = sink(event)
+        if inspect.isawaitable(result):
+            await result
 
 
 def get_auth_capabilities(app: FastAPI) -> dict[str, Any]:

--- a/src/opensoar/schemas/audit.py
+++ b/src/opensoar/schemas/audit.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from pydantic import BaseModel, Field
+
+
+class AuditEvent(BaseModel):
+    category: str
+    action: str
+    status: str = "success"
+    actor_id: uuid.UUID | None = None
+    actor_username: str | None = None
+    target_type: str | None = None
+    target_id: str | None = None
+    metadata_json: dict = Field(default_factory=dict)
+    occurred_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -10,6 +10,7 @@ from sqlalchemy import select
 
 from opensoar.auth.jwt import create_access_token, decode_token
 from opensoar.config import settings
+from opensoar.plugins import register_audit_sink
 
 
 # ── JWT token tests ─────────────────────────────────────────
@@ -89,6 +90,35 @@ class TestRegister:
             app.state.local_registration_enabled = original_registration
 
         assert resp.status_code == 403
+
+    async def test_register_emits_audit_event(self, client):
+        from opensoar.main import app
+
+        seen = []
+
+        async def sink(event):
+            seen.append(event)
+
+        original_sinks = list(app.state.audit_sinks)
+        app.state.audit_sinks = []
+        register_audit_sink(app, sink)
+        try:
+            username = f"audit_{uuid.uuid4().hex[:8]}"
+            resp = await client.post(
+                "/api/v1/auth/register",
+                json={
+                    "username": username,
+                    "display_name": "Audit User",
+                    "password": "securepass123",
+                },
+            )
+        finally:
+            app.state.audit_sinks = original_sinks
+
+        assert resp.status_code == 200
+        assert len(seen) == 1
+        assert seen[0].action == "analyst.registered"
+        assert seen[0].category == "auth"
 
 
 # ── Login endpoint ──────────────────────────────────────────
@@ -171,6 +201,39 @@ class TestLogin:
             app.state.local_registration_enabled = original_registration
 
         assert resp.status_code == 403
+
+    async def test_login_emits_audit_event(self, client):
+        from opensoar.main import app
+
+        username = f"login_audit_{uuid.uuid4().hex[:8]}"
+        await client.post(
+            "/api/v1/auth/register",
+            json={
+                "username": username,
+                "display_name": "Login Audit User",
+                "password": "mypassword",
+            },
+        )
+
+        seen = []
+
+        async def sink(event):
+            seen.append(event)
+
+        original_sinks = list(app.state.audit_sinks)
+        app.state.audit_sinks = []
+        register_audit_sink(app, sink)
+        try:
+            resp = await client.post(
+                "/api/v1/auth/login",
+                json={"username": username, "password": "mypassword"},
+            )
+        finally:
+            app.state.audit_sinks = original_sinks
+
+        assert resp.status_code == 200
+        assert len(seen) == 1
+        assert seen[0].action == "analyst.logged_in"
 
 
 # ── /me endpoint ────────────────────────────────────────────

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -6,11 +6,14 @@ from fastapi import FastAPI
 
 from opensoar.plugins import (
     configure_alembic_version_locations,
+    dispatch_audit_event,
     get_auth_capabilities,
     get_plugin_migration_config,
     import_optional_plugin_models,
     load_optional_plugins,
+    register_audit_sink,
 )
+from opensoar.schemas.audit import AuditEvent
 
 
 class FakeEntryPoint:
@@ -142,3 +145,19 @@ def test_configure_alembic_version_locations():
 
     assert result == ("/core/versions", "/ee/versions")
     assert config.values["version_locations"] == "/core/versions:/ee/versions"
+
+
+async def test_dispatch_audit_event_calls_registered_sink():
+    app = FastAPI()
+    seen: list[AuditEvent] = []
+
+    async def sink(event: AuditEvent):
+        seen.append(event)
+
+    register_audit_sink(app, sink)
+    event = AuditEvent(category="auth", action="analyst.logged_in", actor_username="alice")
+
+    await dispatch_audit_event(app, event)
+
+    assert len(seen) == 1
+    assert seen[0].action == "analyst.logged_in"

--- a/tests/test_webhook_auth.py
+++ b/tests/test_webhook_auth.py
@@ -1,6 +1,8 @@
 """Tests for webhook endpoint authentication via API key."""
 from __future__ import annotations
 
+from opensoar.plugins import register_audit_sink
+
 
 class TestWebhookAuth:
     """Webhook endpoints should optionally require an API key via X-API-Key header."""
@@ -141,3 +143,33 @@ class TestApiKeyManagement:
             headers={"X-API-Key": api_key},
         )
         assert resp.status_code == 401
+
+    async def test_api_key_actions_emit_audit_events(self, client, registered_admin):
+        from opensoar.main import app
+
+        seen = []
+
+        async def sink(event):
+            seen.append(event)
+
+        original_sinks = list(app.state.audit_sinks)
+        app.state.audit_sinks = []
+        register_audit_sink(app, sink)
+        try:
+            create = await client.post(
+                "/api/v1/api-keys",
+                json={"name": "audit-key"},
+                headers=registered_admin["headers"],
+            )
+            key_id = create.json()["id"]
+
+            revoke = await client.delete(
+                f"/api/v1/api-keys/{key_id}",
+                headers=registered_admin["headers"],
+            )
+        finally:
+            app.state.audit_sinks = original_sinks
+
+        assert create.status_code == 201
+        assert revoke.status_code == 200
+        assert [event.action for event in seen] == ["api_key.created", "api_key.revoked"]


### PR DESCRIPTION
## What changed
- added a generic `AuditEvent` schema in core
- added plugin-registered audit sinks and async event dispatching
- emitted structured audit events from analyst registration, analyst login, analyst update, API key creation, and API key revocation
- added focused tests for sink dispatch and representative auth/admin event emission

## Why it changed
`opensoar-core` already had alert-scoped activities, but that was not a usable abstraction for enterprise compliance work around auth and admin actions. This PR adds the OSS-safe event contract without coupling core to enterprise persistence.

## Impact
- EE can now consume structured audit events through plugin sinks
- core business logic stays independent from any specific persistence sink
- alert activity remains separate and unchanged

## Validation
- `PATH="$PWD/.venv/bin:$PATH" JWT_SECRET="test-secret-which-is-long-enough-for-hs256" API_KEY_SECRET="test-api-key-secret" .venv/bin/pytest tests/test_plugins.py tests/test_auth.py tests/test_webhook_auth.py -q`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/ruff check src/opensoar/plugins.py src/opensoar/api/auth.py src/opensoar/api/api_keys.py src/opensoar/schemas/audit.py tests/test_plugins.py tests/test_auth.py tests/test_webhook_auth.py`

## Known gaps
- no EE persistence sink yet
- not every alert lifecycle action emits through the new abstraction yet
- no export/reporting layer in core

Closes #6
