### PR TITLE
[codex] Add plugin API-key policy hooks

### DIFF
--- a/src/opensoar/api/webhooks.py
+++ b/src/opensoar/api/webhooks.py
@@ -15,6 +15,7 @@ from opensoar.api.deps import get_db
 from opensoar.auth.api_key import hash_api_key
 from opensoar.ingestion.webhook import process_webhook
 from opensoar.models.api_key import ApiKey
+from opensoar.plugins import dispatch_api_key_validators
 from opensoar.schemas.webhook import WebhookResponse
 
 logger = logging.getLogger(__name__)
@@ -37,6 +38,7 @@ async def _validate_webhook_key(
     session: AsyncSession = Depends(get_db),
     api_key: str | None = Security(_api_key_header),
     x_webhook_signature: str | None = Header(None),
+    required_scope: str = "webhooks:ingest",
 ) -> None:
     """Validate the API key and optional HMAC signature.
 
@@ -70,14 +72,50 @@ async def _validate_webhook_key(
 
     # Update last_used_at
     db_key.last_used_at = datetime.now(timezone.utc)
+    await dispatch_api_key_validators(
+        request.app,
+        api_key=db_key,
+        request=request,
+        required_scope=required_scope,
+    )
     await session.commit()
+
+
+async def _validate_default_webhook_key(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+    api_key: str | None = Security(_api_key_header),
+    x_webhook_signature: str | None = Header(None),
+) -> None:
+    await _validate_webhook_key(
+        request,
+        session=session,
+        api_key=api_key,
+        x_webhook_signature=x_webhook_signature,
+        required_scope="webhooks:ingest",
+    )
+
+
+async def _validate_elastic_webhook_key(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+    api_key: str | None = Security(_api_key_header),
+    x_webhook_signature: str | None = Header(None),
+) -> None:
+    await _validate_webhook_key(
+        request,
+        session=session,
+        api_key=api_key,
+        x_webhook_signature=x_webhook_signature,
+        required_scope="webhooks:ingest:elastic",
+    )
 
 
 @router.post("/alerts", response_model=WebhookResponse)
 async def receive_alert(
     payload: dict[str, Any],
     session: AsyncSession = Depends(get_db),
-    _key: None = Depends(_validate_webhook_key),
+    _key: None = Depends(_validate_default_webhook_key),
 ):
     alert = await process_webhook(session, payload, source="webhook")
 
@@ -108,7 +146,7 @@ async def receive_alert(
 async def receive_elastic_alert(
     payload: dict[str, Any],
     session: AsyncSession = Depends(get_db),
-    _key: None = Depends(_validate_webhook_key),
+    _key: None = Depends(_validate_elastic_webhook_key),
 ):
     alert = await process_webhook(session, payload, source="elastic")
 

--- a/src/opensoar/plugins.py
+++ b/src/opensoar/plugins.py
@@ -28,6 +28,8 @@ def initialize_plugin_state(app: FastAPI) -> None:
         app.state.auth_providers = []
     if not hasattr(app.state, "audit_sinks"):
         app.state.audit_sinks = []
+    if not hasattr(app.state, "api_key_validators"):
+        app.state.api_key_validators = []
     if not hasattr(app.state, "local_auth_enabled"):
         app.state.local_auth_enabled = True
     if not hasattr(app.state, "local_registration_enabled"):
@@ -168,10 +170,29 @@ def register_audit_sink(app: FastAPI, sink: Any) -> None:
     app.state.audit_sinks.append(sink)
 
 
+def register_api_key_validator(app: FastAPI, validator: Any) -> None:
+    initialize_plugin_state(app)
+    app.state.api_key_validators.append(validator)
+
+
 async def dispatch_audit_event(app: FastAPI, event: AuditEvent) -> None:
     initialize_plugin_state(app)
     for sink in list(app.state.audit_sinks):
         result = sink(event)
+        if inspect.isawaitable(result):
+            await result
+
+
+async def dispatch_api_key_validators(
+    app: FastAPI,
+    *,
+    api_key: Any,
+    request: Any,
+    required_scope: str,
+) -> None:
+    initialize_plugin_state(app)
+    for validator in list(app.state.api_key_validators):
+        result = validator(api_key=api_key, request=request, required_scope=required_scope)
         if inspect.isawaitable(result):
             await result
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -7,10 +7,12 @@ from fastapi import FastAPI
 from opensoar.plugins import (
     configure_alembic_version_locations,
     dispatch_audit_event,
+    dispatch_api_key_validators,
     get_auth_capabilities,
     get_plugin_migration_config,
     import_optional_plugin_models,
     load_optional_plugins,
+    register_api_key_validator,
     register_audit_sink,
 )
 from opensoar.schemas.audit import AuditEvent
@@ -161,3 +163,21 @@ async def test_dispatch_audit_event_calls_registered_sink():
 
     assert len(seen) == 1
     assert seen[0].action == "analyst.logged_in"
+
+
+async def test_dispatch_api_key_validators_calls_registered_validator():
+    app = FastAPI()
+    seen = []
+
+    async def validator(*, api_key, request, required_scope):
+        seen.append((api_key, request, required_scope))
+
+    register_api_key_validator(app, validator)
+    await dispatch_api_key_validators(
+        app,
+        api_key="db-key",
+        request="request",
+        required_scope="webhooks:ingest",
+    )
+
+    assert seen == [("db-key", "request", "webhooks:ingest")]

--- a/tests/test_webhook_auth.py
+++ b/tests/test_webhook_auth.py
@@ -1,6 +1,8 @@
 """Tests for webhook endpoint authentication via API key."""
 from __future__ import annotations
 
+from fastapi import HTTPException
+
 from opensoar.plugins import register_audit_sink
 
 
@@ -87,6 +89,35 @@ class TestWebhookAuth:
         matching = [k for k in keys if k["name"] == "track-usage-key"]
         assert len(matching) == 1
         assert matching[0].get("last_used_at") is not None
+
+    async def test_webhook_validator_can_deny_request(self, client, registered_admin):
+        from opensoar.main import app
+        from opensoar.plugins import register_api_key_validator
+
+        resp = await client.post(
+            "/api/v1/api-keys",
+            json={"name": "scoped-key"},
+            headers=registered_admin["headers"],
+        )
+        api_key = resp.json()["key"]
+
+        async def validator(*, api_key, request, required_scope):
+            raise HTTPException(status_code=403, detail=f"Missing scope: {required_scope}")
+
+        original_validators = list(app.state.api_key_validators)
+        app.state.api_key_validators = []
+        register_api_key_validator(app, validator)
+        try:
+            blocked = await client.post(
+                "/api/v1/webhooks/alerts",
+                json={"rule_name": "Blocked Alert", "severity": "low"},
+                headers={"X-API-Key": api_key},
+            )
+        finally:
+            app.state.api_key_validators = original_validators
+
+        assert blocked.status_code == 403
+        assert "Missing scope" in blocked.json()["detail"]
 
 
 class TestApiKeyManagement:


### PR DESCRIPTION
## What changed
- added plugin-registered API key validators in core
- dispatched those validators from the existing webhook API-key validation path
- preserved base API key behavior when no plugin validator is registered
- added focused tests for validator dispatch and request denial

## Why it changed
EE scoped API keys need a clean enforcement hook. This PR gives optional packages a request-aware post-validation policy surface instead of forcing monkeypatches into the webhook auth path.

## Impact
- core API key validation remains unchanged by default
- optional plugins can now deny otherwise valid key-authenticated requests based on scope or other plugin-owned policy
- the current hook is attached to the existing webhook-authenticated surfaces

## Validation
- `PATH="$PWD/.venv/bin:$PATH" JWT_SECRET="test-secret-which-is-long-enough-for-hs256" API_KEY_SECRET="test-api-key-secret" .venv/bin/pytest tests/test_plugins.py tests/test_webhook_auth.py -q`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/ruff check src/opensoar/plugins.py src/opensoar/api/webhooks.py tests/test_plugins.py tests/test_webhook_auth.py`

## Known gaps
- no EE scope persistence yet
- no scope-aware UI on API key management yet
- not every potential future key-authenticated surface uses the hook yet

Closes #12
