### PR TITLE
[codex] Clarify playbook loading and auth docs

### DIFF
--- a/docs/docs/api/overview.md
+++ b/docs/docs/api/overview.md
@@ -34,6 +34,8 @@ In other words:
 - you can trigger a discovered playbook through the API
 - you cannot upload a new Python playbook through the API today
 
+For the operational loading model, read [Loading and Syncing Playbooks](../playbooks/loading-and-sync.md).
+
 ## Webhook Ingestion
 
 OpenSOAR can ingest alerts through webhook endpoints under `/api/v1/webhooks/...`, then normalize and route them into playbook execution.

--- a/docs/docs/deployment/authentication.md
+++ b/docs/docs/deployment/authentication.md
@@ -1,0 +1,56 @@
+---
+icon: lucide/key-round
+---
+
+# Authentication and SSO
+
+This page answers the practical question: what authentication model exists in the public core today, and where does third-party auth fit?
+
+## Community Edition Today
+
+In a core-only deployment, OpenSOAR currently supports:
+
+- local analyst accounts
+- username/password login
+- JWT-backed UI/API sessions
+- API keys for webhook and integration-style access
+
+This is the default path documented in the public repository and the default local Docker workflow.
+
+## Third-Party Auth Status
+
+Third-party analyst authentication is **not** part of the core-only deployment model.
+
+The current public architecture treats SSO and external identity provider support as an optional enterprise plugin surface rather than a built-in core feature.
+
+Practically, that means:
+
+- if you run only `opensoar-core`, you should expect local username/password auth
+- if an optional enterprise package is installed, that package can extend the auth surface
+- the core login UI can now discover optional external providers through runtime capabilities instead of hardcoded assumptions
+
+## OIDC / Keycloak / Casdoor
+
+The current external-auth direction is OIDC-based provider integration through the optional enterprise path.
+
+For users asking specifically about tools such as:
+
+- Keycloak
+- Casdoor
+- other OIDC-compatible identity providers
+
+the right model is: configure them as OIDC providers through the optional enterprise auth layer, not through a separate core-only auth mode.
+
+## What This Means Operationally
+
+If you are working in the public core today:
+
+1. use local analyst registration and login
+2. use API keys for webhook-style machine access
+3. treat external identity provider support as an optional deployment extension, not as part of the default core bootstrap path
+
+## Related Reading
+
+- [Getting Started](../getting-started.md)
+- [API Overview](../api/overview.md)
+- [Loading and Syncing Playbooks](../playbooks/loading-and-sync.md)

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -70,5 +70,6 @@ Instead:
 
 - Read [Playbooks Overview](playbooks/overview.md)
 - Read [Loading and Syncing Playbooks](playbooks/loading-and-sync.md)
+- Read [Authentication and SSO](deployment/authentication.md) if you need to understand the current local-auth vs external-auth posture
 - Read [Docker Deployment](deployment/docker.md)
 - Review [Playbook Troubleshooting](troubleshooting/playbooks.md)

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -12,11 +12,14 @@ This is the canonical documentation site for OpenSOAR.
 
 - [Getting Started](getting-started.md)
 - [Playbooks](playbooks/overview.md)
+- [Loading and Syncing Playbooks](playbooks/loading-and-sync.md)
 - [Deployment](deployment/docker.md)
+- [Authentication and SSO](deployment/authentication.md)
 - [Engineering](engineering/index.md)
 
 ## Notes
 
 - Playbooks are code-first Python modules loaded from configured directories.
 - The `migrate` service is for database schema migrations, not playbook syncing.
+- Third-party auth is not part of the core-only deployment path; see [Authentication and SSO](deployment/authentication.md) for the current status.
 - If you need a specific topic beyond the four entry points above, use the left navigation.


### PR DESCRIPTION
## What changed
- made playbook loading/sync easier to discover from the docs home and getting-started path
- added a dedicated public docs page for the current authentication and SSO posture
- linked the API overview back to the playbook loading model explicitly

## Why it changed
The remaining public docs issue asked the same set of questions users keep hitting in practice: where the docs live, how playbook loading actually works, whether there is an upload/sync flow, and what the current third-party auth posture is.

## Impact
- the playbook-as-code loading model is easier to find
- the `migrate` service confusion is addressed from the top-level docs flow
- the current local-auth vs optional external-auth posture is now documented explicitly in the public docs

## Validation
- `PATH="$PWD/docs/.venv/bin:$PATH" docs/.venv/bin/zensical build`

## Known gaps
- the docs site still doesn’t cover every enterprise detail in public, by design
- the docs issue thread itself still needs a final public reply pointing to the improved pages

Closes #2
