### PR TITLE
[codex] Make docs dark-mode only

### DIFF
--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -322,18 +322,9 @@ features = [
 # - https://zensical.org/docs/setup/colors/
 # ----------------------------------------------------------------------------
 [[project.theme.palette]]
-scheme = "default"
-palette.primary = "blue-grey"
-palette.accent = "green"
-toggle.icon = "lucide/sun"
-toggle.name = "Switch to dark mode"
-
-[[project.theme.palette]]
 scheme = "slate"
 palette.primary = "black"
 palette.accent = "green"
-toggle.icon = "lucide/moon"
-toggle.name = "Switch to light mode"
 
 # ----------------------------------------------------------------------------
 # The "extra" section contains miscellaneous settings.


### PR DESCRIPTION
## What changed
- removed the light/dark palette toggle from the docs theme config
- kept a single dark theme for the public docs site

## Why it changed
The docs and product visual language are already dark-first. Keeping a light-mode toggle created a second mode that the docs styling was not really designed around.

## Validation
- `PATH="$PWD/docs/.venv/bin:$PATH" docs/.venv/bin/zensical build`
