### PR TITLE
[codex] Add tenant access hooks for incidents and observables

### DIFF
--- a/src/opensoar/api/incidents.py
+++ b/src/opensoar/api/incidents.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from opensoar.api.deps import get_db
 from opensoar.auth.jwt import get_current_analyst
 from opensoar.auth.rbac import Permission, require_permission
+from opensoar.plugins import apply_tenant_access_query, enforce_tenant_access
 from opensoar.models.alert import Alert
 from opensoar.models.analyst import Analyst
 from opensoar.models.incident import Incident
@@ -41,7 +42,9 @@ async def _incident_response(
 
 @router.get("/suggestions")
 async def incident_suggestions(
+    request: Request,
     session: AsyncSession = Depends(get_db),
+    analyst: Analyst | None = Depends(get_current_analyst),
 ):
     """Basic correlation: group unlinked alerts by source_ip, return groups with 2+ alerts."""
     # Find alerts that have no incident link
@@ -53,6 +56,15 @@ async def incident_suggestions(
         .group_by(Alert.source_ip)
         .having(func.count(Alert.id) >= 2)
     )
+    query = await apply_tenant_access_query(
+        request.app,
+        query=query,
+        resource_type="alert",
+        action="incident_suggestions",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
     result = await session.execute(query)
     groups = []
     for row in result.all():
@@ -62,6 +74,15 @@ async def incident_suggestions(
             .where(Alert.source_ip == row.source_ip)
             .where(Alert.id.notin_(linked_alert_ids))
             .order_by(Alert.created_at.desc())
+        )
+        alerts_query = await apply_tenant_access_query(
+            request.app,
+            query=alerts_query,
+            resource_type="alert",
+            action="incident_suggestions",
+            analyst=analyst,
+            request=request,
+            session=session,
         )
         alerts_result = await session.execute(alerts_query)
         alerts = alerts_result.scalars().all()
@@ -79,7 +100,9 @@ async def list_incidents(
     severity: str | None = None,
     limit: int = Query(default=50, le=200),
     offset: int = Query(default=0, ge=0),
+    request: Request = None,
     session: AsyncSession = Depends(get_db),
+    analyst: Analyst | None = Depends(get_current_analyst),
 ):
     query = select(Incident).order_by(Incident.created_at.desc())
     count_query = select(func.count(Incident.id))
@@ -90,6 +113,25 @@ async def list_incidents(
     if severity:
         query = query.where(Incident.severity == severity)
         count_query = count_query.where(Incident.severity == severity)
+
+    query = await apply_tenant_access_query(
+        request.app,
+        query=query,
+        resource_type="incident",
+        action="list",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
+    count_query = await apply_tenant_access_query(
+        request.app,
+        query=count_query,
+        resource_type="incident",
+        action="count",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
 
     total = (await session.execute(count_query)).scalar() or 0
     result = await session.execute(query.offset(offset).limit(limit))
@@ -123,21 +165,7 @@ async def create_incident(
 @router.get("/{incident_id}", response_model=IncidentResponse)
 async def get_incident(
     incident_id: uuid.UUID,
-    session: AsyncSession = Depends(get_db),
-):
-    result = await session.execute(
-        select(Incident).where(Incident.id == incident_id)
-    )
-    incident = result.scalar_one_or_none()
-    if not incident:
-        raise HTTPException(status_code=404, detail="Incident not found")
-    return await _incident_response(session, incident)
-
-
-@router.patch("/{incident_id}", response_model=IncidentResponse)
-async def update_incident(
-    incident_id: uuid.UUID,
-    update: IncidentUpdate,
+    request: Request,
     session: AsyncSession = Depends(get_db),
     analyst: Analyst | None = Depends(get_current_analyst),
 ):
@@ -147,6 +175,41 @@ async def update_incident(
     incident = result.scalar_one_or_none()
     if not incident:
         raise HTTPException(status_code=404, detail="Incident not found")
+    await enforce_tenant_access(
+        request.app,
+        resource=incident,
+        resource_type="incident",
+        action="read",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
+    return await _incident_response(session, incident)
+
+
+@router.patch("/{incident_id}", response_model=IncidentResponse)
+async def update_incident(
+    incident_id: uuid.UUID,
+    update: IncidentUpdate,
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+    analyst: Analyst | None = Depends(get_current_analyst),
+):
+    result = await session.execute(
+        select(Incident).where(Incident.id == incident_id)
+    )
+    incident = result.scalar_one_or_none()
+    if not incident:
+        raise HTTPException(status_code=404, detail="Incident not found")
+    await enforce_tenant_access(
+        request.app,
+        resource=incident,
+        resource_type="incident",
+        action="update",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
 
     update_data = update.model_dump(exclude_unset=True)
 
@@ -182,6 +245,7 @@ async def update_incident(
 async def link_alert(
     incident_id: uuid.UUID,
     body: LinkAlertRequest,
+    request: Request,
     session: AsyncSession = Depends(get_db),
     analyst: Analyst | None = Depends(get_current_analyst),
 ):
@@ -189,14 +253,34 @@ async def link_alert(
     result = await session.execute(
         select(Incident).where(Incident.id == incident_id)
     )
-    if not result.scalar_one_or_none():
+    incident = result.scalar_one_or_none()
+    if not incident:
         raise HTTPException(status_code=404, detail="Incident not found")
+    await enforce_tenant_access(
+        request.app,
+        resource=incident,
+        resource_type="incident",
+        action="update",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
 
     # Verify alert exists
     alert_uuid = uuid.UUID(body.alert_id)
     result = await session.execute(select(Alert).where(Alert.id == alert_uuid))
-    if not result.scalar_one_or_none():
+    alert = result.scalar_one_or_none()
+    if not alert:
         raise HTTPException(status_code=404, detail="Alert not found")
+    await enforce_tenant_access(
+        request.app,
+        resource=alert,
+        resource_type="alert",
+        action="read",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
 
     # Check if already linked
     existing = await session.execute(
@@ -217,20 +301,41 @@ async def link_alert(
 @router.get("/{incident_id}/alerts")
 async def list_incident_alerts(
     incident_id: uuid.UUID,
+    request: Request,
     session: AsyncSession = Depends(get_db),
+    analyst: Analyst | None = Depends(get_current_analyst),
 ):
     # Verify incident exists
     result = await session.execute(
         select(Incident).where(Incident.id == incident_id)
     )
-    if not result.scalar_one_or_none():
+    incident = result.scalar_one_or_none()
+    if not incident:
         raise HTTPException(status_code=404, detail="Incident not found")
+    await enforce_tenant_access(
+        request.app,
+        resource=incident,
+        resource_type="incident",
+        action="read",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
 
     query = (
         select(Alert)
         .join(IncidentAlert, IncidentAlert.alert_id == Alert.id)
         .where(IncidentAlert.incident_id == incident_id)
         .order_by(Alert.created_at.desc())
+    )
+    query = await apply_tenant_access_query(
+        request.app,
+        query=query,
+        resource_type="alert",
+        action="list",
+        analyst=analyst,
+        request=request,
+        session=session,
     )
     result = await session.execute(query)
     alerts = result.scalars().all()
@@ -241,6 +346,7 @@ async def list_incident_alerts(
 async def unlink_alert(
     incident_id: uuid.UUID,
     alert_id: uuid.UUID,
+    request: Request,
     session: AsyncSession = Depends(get_db),
     analyst: Analyst | None = Depends(get_current_analyst),
 ):
@@ -253,6 +359,15 @@ async def unlink_alert(
     link = result.scalar_one_or_none()
     if not link:
         raise HTTPException(status_code=404, detail="Link not found")
+    await enforce_tenant_access(
+        request.app,
+        resource=link,
+        resource_type="incident_alert",
+        action="update",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
 
     await session.delete(link)
     await session.commit()

--- a/src/opensoar/api/observables.py
+++ b/src/opensoar/api/observables.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from opensoar.api.deps import get_db
 from opensoar.auth.jwt import get_current_analyst
+from opensoar.plugins import apply_tenant_access_query, enforce_tenant_access
 from opensoar.models.analyst import Analyst
 from opensoar.models.observable import Observable
 from opensoar.schemas.observable import (
@@ -25,7 +26,9 @@ async def list_observables(
     type: str | None = None,
     limit: int = Query(default=50, le=200),
     offset: int = Query(default=0, ge=0),
+    request: Request = None,
     session: AsyncSession = Depends(get_db),
+    analyst: Analyst | None = Depends(get_current_analyst),
 ):
     query = select(Observable).order_by(Observable.created_at.desc())
     count_query = select(func.count(Observable.id))
@@ -33,6 +36,25 @@ async def list_observables(
     if type:
         query = query.where(Observable.type == type)
         count_query = count_query.where(Observable.type == type)
+
+    query = await apply_tenant_access_query(
+        request.app,
+        query=query,
+        resource_type="observable",
+        action="list",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
+    count_query = await apply_tenant_access_query(
+        request.app,
+        query=count_query,
+        resource_type="observable",
+        action="count",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
 
     total = (await session.execute(count_query)).scalar() or 0
     result = await session.execute(query.offset(offset).limit(limit))
@@ -47,6 +69,7 @@ async def list_observables(
 @router.post("", response_model=ObservableResponse, status_code=201)
 async def create_observable(
     data: ObservableCreate,
+    request: Request,
     session: AsyncSession = Depends(get_db),
     analyst: Analyst | None = Depends(get_current_analyst),
 ):
@@ -68,6 +91,15 @@ async def create_observable(
         alert_id=uuid.UUID(data.alert_id) if data.alert_id else None,
         incident_id=uuid.UUID(data.incident_id) if data.incident_id else None,
     )
+    await enforce_tenant_access(
+        request.app,
+        resource=obs,
+        resource_type="observable",
+        action="create",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
     session.add(obs)
     await session.commit()
     await session.refresh(obs)
@@ -77,21 +109,7 @@ async def create_observable(
 @router.get("/{observable_id}", response_model=ObservableResponse)
 async def get_observable(
     observable_id: uuid.UUID,
-    session: AsyncSession = Depends(get_db),
-):
-    result = await session.execute(
-        select(Observable).where(Observable.id == observable_id)
-    )
-    obs = result.scalar_one_or_none()
-    if not obs:
-        raise HTTPException(status_code=404, detail="Observable not found")
-    return ObservableResponse.model_validate(obs)
-
-
-@router.post("/{observable_id}/enrichments", response_model=ObservableResponse)
-async def add_enrichment(
-    observable_id: uuid.UUID,
-    data: EnrichmentCreate,
+    request: Request,
     session: AsyncSession = Depends(get_db),
     analyst: Analyst | None = Depends(get_current_analyst),
 ):
@@ -101,6 +119,41 @@ async def add_enrichment(
     obs = result.scalar_one_or_none()
     if not obs:
         raise HTTPException(status_code=404, detail="Observable not found")
+    await enforce_tenant_access(
+        request.app,
+        resource=obs,
+        resource_type="observable",
+        action="read",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
+    return ObservableResponse.model_validate(obs)
+
+
+@router.post("/{observable_id}/enrichments", response_model=ObservableResponse)
+async def add_enrichment(
+    observable_id: uuid.UUID,
+    data: EnrichmentCreate,
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+    analyst: Analyst | None = Depends(get_current_analyst),
+):
+    result = await session.execute(
+        select(Observable).where(Observable.id == observable_id)
+    )
+    obs = result.scalar_one_or_none()
+    if not obs:
+        raise HTTPException(status_code=404, detail="Observable not found")
+    await enforce_tenant_access(
+        request.app,
+        resource=obs,
+        resource_type="observable",
+        action="update",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
 
     enrichment_entry = {
         "source": data.source,

--- a/tests/test_incidents_api.py
+++ b/tests/test_incidents_api.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 
 import uuid
 
+from fastapi import HTTPException
+
+from opensoar.plugins import register_tenant_access_validator
 
 class TestIncidentCRUD:
     async def test_create_incident(self, client, registered_analyst):
@@ -175,3 +178,66 @@ class TestIncidentFiltering:
         assert resp.status_code == 200
         for inc in resp.json()["incidents"]:
             assert inc["severity"] == "critical"
+
+    async def test_tenant_validator_filters_incident_list(self, client, registered_analyst):
+        from opensoar.main import app
+        from opensoar.models.incident import Incident
+
+        await client.post(
+            "/api/v1/incidents",
+            json={"title": "Scoped Incident", "severity": "low"},
+            headers=registered_analyst["headers"],
+        )
+        await client.post(
+            "/api/v1/incidents",
+            json={"title": "Blocked Incident", "severity": "low"},
+            headers=registered_analyst["headers"],
+        )
+
+        async def validator(**kwargs):
+            query = kwargs.get("query")
+            if query is not None and kwargs["resource_type"] == "incident":
+                return query.where(Incident.title == "Scoped Incident")
+            return None
+
+        original_validators = list(app.state.tenant_access_validators)
+        app.state.tenant_access_validators = []
+        register_tenant_access_validator(app, validator)
+        try:
+            resp = await client.get("/api/v1/incidents", headers=registered_analyst["headers"])
+        finally:
+            app.state.tenant_access_validators = original_validators
+
+        assert resp.status_code == 200
+        assert {incident["title"] for incident in resp.json()["incidents"]} == {"Scoped Incident"}
+
+    async def test_tenant_validator_blocks_incident_detail_and_update(self, client, registered_analyst):
+        from opensoar.main import app
+
+        create = await client.post(
+            "/api/v1/incidents",
+            json={"title": "Blocked Incident Detail", "severity": "low"},
+            headers=registered_analyst["headers"],
+        )
+        incident_id = create.json()["id"]
+
+        async def validator(**kwargs):
+            resource = kwargs.get("resource")
+            if resource is not None and getattr(resource, "title", "").startswith("Blocked"):
+                raise HTTPException(status_code=403, detail="Tenant access denied")
+
+        original_validators = list(app.state.tenant_access_validators)
+        app.state.tenant_access_validators = []
+        register_tenant_access_validator(app, validator)
+        try:
+            detail = await client.get(f"/api/v1/incidents/{incident_id}", headers=registered_analyst["headers"])
+            update = await client.patch(
+                f"/api/v1/incidents/{incident_id}",
+                json={"severity": "critical"},
+                headers=registered_analyst["headers"],
+            )
+        finally:
+            app.state.tenant_access_validators = original_validators
+
+        assert detail.status_code == 403
+        assert update.status_code == 403

--- a/tests/test_observables.py
+++ b/tests/test_observables.py
@@ -1,6 +1,9 @@
 """Tests for observable tracking and enrichment."""
 from __future__ import annotations
 
+from fastapi import HTTPException
+
+from opensoar.plugins import register_tenant_access_validator
 
 class TestObservablesCRUD:
     async def test_create_observable(self, client, registered_analyst):
@@ -103,3 +106,68 @@ class TestCorrelationEngine:
         assert resp.status_code == 200
         suggestions = resp.json()
         assert isinstance(suggestions, list)
+
+
+class TestObservableTenantHooks:
+    async def test_tenant_validator_filters_observable_list(self, client, registered_analyst):
+        from opensoar.main import app
+        from opensoar.models.observable import Observable
+
+        await client.post(
+            "/api/v1/observables",
+            json={"type": "ip", "value": "203.0.113.42", "source": "tenant-test"},
+            headers=registered_analyst["headers"],
+        )
+        await client.post(
+            "/api/v1/observables",
+            json={"type": "ip", "value": "198.51.100.1", "source": "tenant-test"},
+            headers=registered_analyst["headers"],
+        )
+
+        async def validator(**kwargs):
+            query = kwargs.get("query")
+            if query is not None and kwargs["resource_type"] == "observable":
+                return query.where(Observable.value == "203.0.113.42")
+            return None
+
+        original_validators = list(app.state.tenant_access_validators)
+        app.state.tenant_access_validators = []
+        register_tenant_access_validator(app, validator)
+        try:
+            resp = await client.get("/api/v1/observables", headers=registered_analyst["headers"])
+        finally:
+            app.state.tenant_access_validators = original_validators
+
+        assert resp.status_code == 200
+        assert {obs["value"] for obs in resp.json()["observables"]} == {"203.0.113.42"}
+
+    async def test_tenant_validator_blocks_observable_detail_and_enrichment(self, client, registered_analyst):
+        from opensoar.main import app
+
+        create = await client.post(
+            "/api/v1/observables",
+            json={"type": "ip", "value": "198.51.100.77", "source": "block-test"},
+            headers=registered_analyst["headers"],
+        )
+        obs_id = create.json()["id"]
+
+        async def validator(**kwargs):
+            resource = kwargs.get("resource")
+            if resource is not None and getattr(resource, "value", None) == "198.51.100.77":
+                raise HTTPException(status_code=403, detail="Tenant access denied")
+
+        original_validators = list(app.state.tenant_access_validators)
+        app.state.tenant_access_validators = []
+        register_tenant_access_validator(app, validator)
+        try:
+            detail = await client.get(f"/api/v1/observables/{obs_id}", headers=registered_analyst["headers"])
+            enrich = await client.post(
+                f"/api/v1/observables/{obs_id}/enrichments",
+                json={"source": "vt", "data": {"score": 5}},
+                headers=registered_analyst["headers"],
+            )
+        finally:
+            app.state.tenant_access_validators = original_validators
+
+        assert detail.status_code == 403
+        assert enrich.status_code == 403


### PR DESCRIPTION
## What changed
- threaded the existing tenant query/object hook pattern through incidents
- threaded the same hook pattern through observables
- added focused tests for incident query filtering, incident denial, observable list filtering, and observable denial

## Why it changed
EE still needed a clean extension point for tenant-aware incident and observable enforcement. This PR reuses the same hook contract already proven on alerts and dashboard surfaces.

## Validation
- `PATH="$PWD/.venv/bin:$PATH" JWT_SECRET="test-secret-which-is-long-enough-for-hs256" API_KEY_SECRET="test-api-key-secret" .venv/bin/pytest tests/test_plugins.py tests/test_incidents_api.py tests/test_observables.py -q`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/ruff check src/opensoar/api/incidents.py src/opensoar/api/observables.py tests/test_incidents_api.py tests/test_observables.py`

## Known gaps
- no actual EE validator behavior in core tests beyond mocked hook outcomes
- broader tenant-native schema relationships are still an EE concern

Closes #20
