### PR TITLE
[codex] Scope alert activities and runs through tenant hooks

### DIFF
--- a/src/opensoar/api/activities.py
+++ b/src/opensoar/api/activities.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from opensoar.api.deps import get_db
-from opensoar.auth.jwt import require_analyst
+from opensoar.auth.jwt import get_current_analyst, require_analyst
+from opensoar.plugins import enforce_tenant_access
 from opensoar.models.activity import Activity
 from opensoar.models.alert import Alert
 from opensoar.models.analyst import Analyst
@@ -21,8 +22,26 @@ async def list_alert_activities(
     alert_id: uuid.UUID,
     limit: int = Query(default=50, le=200),
     offset: int = Query(default=0, ge=0),
+    request: Request = None,
     session: AsyncSession = Depends(get_db),
+    analyst: Analyst | None = Depends(get_current_analyst),
 ):
+    alert = (
+        await session.execute(select(Alert).where(Alert.id == alert_id))
+    ).scalar_one_or_none()
+    if not alert:
+        raise HTTPException(status_code=404, detail="Alert not found")
+
+    await enforce_tenant_access(
+        request.app,
+        resource=alert,
+        resource_type="alert",
+        action="read",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
+
     query = (
         select(Activity)
         .where(Activity.alert_id == alert_id)

--- a/src/opensoar/api/alerts.py
+++ b/src/opensoar/api/alerts.py
@@ -117,8 +117,23 @@ async def get_alert(
 @router.get("/{alert_id}/runs", response_model=PlaybookRunList)
 async def get_alert_runs(
     alert_id: uuid.UUID,
+    request: Request,
     session: AsyncSession = Depends(get_db),
+    analyst: Analyst | None = Depends(get_current_analyst),
 ):
+    alert = (await session.execute(select(Alert).where(Alert.id == alert_id))).scalar_one_or_none()
+    if not alert:
+        raise HTTPException(status_code=404, detail="Alert not found")
+    await enforce_tenant_access(
+        request.app,
+        resource=alert,
+        resource_type="alert",
+        action="read",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
+
     query = select(PlaybookRun).where(PlaybookRun.alert_id == alert_id).order_by(
         PlaybookRun.created_at.desc()
     )

--- a/tests/test_activities_api.py
+++ b/tests/test_activities_api.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from fastapi import HTTPException
+
+from opensoar.plugins import register_tenant_access_validator
+
+
+class TestActivityTenantHooks:
+    async def test_tenant_validator_blocks_alert_activities(self, client, registered_analyst):
+        from opensoar.main import app
+
+        resp = await client.post(
+            "/api/v1/webhooks/alerts",
+            json={"rule_name": "Blocked Activities", "severity": "low", "partner": "globex"},
+        )
+        alert_id = resp.json()["alert_id"]
+
+        async def validator(**kwargs):
+            resource = kwargs.get("resource")
+            if resource is not None and getattr(resource, "partner", None) == "globex":
+                raise HTTPException(status_code=403, detail="Tenant access denied")
+
+        original_validators = list(app.state.tenant_access_validators)
+        app.state.tenant_access_validators = []
+        register_tenant_access_validator(app, validator)
+        try:
+            blocked = await client.get(
+                f"/api/v1/alerts/{alert_id}/activities",
+                headers=registered_analyst["headers"],
+            )
+        finally:
+            app.state.tenant_access_validators = original_validators
+
+        assert blocked.status_code == 403

--- a/tests/test_alerts_api.py
+++ b/tests/test_alerts_api.py
@@ -105,6 +105,31 @@ class TestGetAlert:
 
         assert blocked.status_code == 403
 
+    async def test_tenant_validator_blocks_alert_runs(self, client, registered_analyst):
+        from opensoar.main import app
+        from opensoar.plugins import register_tenant_access_validator
+
+        resp = await client.post(
+            "/api/v1/webhooks/alerts",
+            json={"rule_name": "Blocked Runs", "severity": "low", "partner": "globex"},
+        )
+        alert_id = resp.json()["alert_id"]
+
+        async def validator(**kwargs):
+            resource = kwargs.get("resource")
+            if resource is not None and getattr(resource, "partner", None) == "globex":
+                raise HTTPException(status_code=403, detail="Tenant access denied")
+
+        original_validators = list(app.state.tenant_access_validators)
+        app.state.tenant_access_validators = []
+        register_tenant_access_validator(app, validator)
+        try:
+            blocked = await client.get(f"/api/v1/alerts/{alert_id}/runs", headers=registered_analyst["headers"])
+        finally:
+            app.state.tenant_access_validators = original_validators
+
+        assert blocked.status_code == 403
+
 
 class TestUpdateAlert:
     async def test_update_severity(self, client, sample_alert_via_api, registered_analyst):


### PR DESCRIPTION
## What changed
- applied tenant access checks to alert activity endpoints
- applied tenant access checks to alert playbook-run endpoints
- added focused tests proving tenant validators can block those read surfaces

## Why it changed
The shared tenant hook was already present on alerts, dashboard, incidents, and observables, but alert activity and playbook-run views still leaked alert-adjacent context without the same check.

## Validation
- `PATH="$PWD/.venv/bin:$PATH" JWT_SECRET="test-secret-which-is-long-enough-for-hs256" API_KEY_SECRET="test-api-key-secret" .venv/bin/pytest tests/test_plugins.py tests/test_alerts_api.py tests/test_incidents_api.py tests/test_observables.py tests/test_activities_api.py -q`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/ruff check src/opensoar/api/activities.py src/opensoar/api/alerts.py tests/test_alerts_api.py tests/test_activities_api.py`

## Known gaps
- broader EE integration coverage still lives in the private test suites

Closes #22
