### PR TITLE
Add browser coverage for enterprise settings flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ htmlcov/
 .pytest_cache/
 ui/.vite/
 .vite/
+ui/playwright-report/
+ui/test-results/

--- a/ui/e2e/enterprise-flows.spec.ts
+++ b/ui/e2e/enterprise-flows.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test, type Page } from '@playwright/test'
+
+import { mockEnterpriseApi } from './support/mockEnterpriseApi'
+
+async function openEnterpriseSettings(page: Page): Promise<void> {
+  await mockEnterpriseApi(page)
+  await page.goto('/settings')
+  await page.getByRole('button', { name: 'Enterprise' }).click()
+  await expect(page.getByRole('heading', { name: 'Tenants' })).toBeVisible()
+}
+
+test('shows external provider login for enterprise auth', async ({ page }) => {
+  await mockEnterpriseApi(page, {
+    authenticated: false,
+    analyst: null,
+    authCapabilities: {
+      local_login_enabled: false,
+      local_registration_enabled: false,
+      providers: [
+        {
+          id: 'provider-okta',
+          name: 'Okta Workforce',
+          type: 'oidc',
+          login_url: 'https://login.example.com/auth',
+        },
+      ],
+    },
+  })
+  await page.route('https://login.example.com/auth', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/html',
+      body: '<html><body>okta</body></html>',
+    })
+  })
+
+  await page.goto('/login')
+
+  await expect(page.getByRole('button', { name: 'Continue with Okta Workforce' })).toBeVisible()
+  await expect(page.getByLabel('Username')).toHaveCount(0)
+
+  await page.getByRole('button', { name: 'Continue with Okta Workforce' }).click()
+  await page.waitForURL('https://login.example.com/auth')
+})
+
+test('creates a tenant from enterprise settings', async ({ page }) => {
+  await openEnterpriseSettings(page)
+
+  await page.getByRole('button', { name: 'Add Tenant' }).click()
+  await expect(page.getByRole('heading', { name: 'Create Tenant' })).toBeVisible()
+
+  await page.getByLabel('Name').fill('Acme Managed Defense')
+  await page.getByLabel('Slug').fill('acme-managed-defense')
+  await page.getByLabel('Legacy Partner Key').fill('acme-corp')
+  await page.getByLabel('Partner Aliases').fill('acme, acme-soc')
+  await page.getByRole('button', { name: 'Create' }).click()
+
+  await expect(page.getByText('Acme Managed Defense')).toBeVisible()
+  await expect(page.getByText('acme-managed-defense')).toBeVisible()
+})
+
+test('creates an OIDC provider from enterprise settings', async ({ page }) => {
+  await openEnterpriseSettings(page)
+
+  await page.getByRole('button', { name: 'Add Provider' }).click()
+  await expect(page.getByRole('heading', { name: 'Create OIDC Provider' })).toBeVisible()
+
+  await page.getByLabel('Name').fill('Okta Workforce')
+  await page.getByLabel('Issuer').fill('https://login.example.com')
+  await page.getByLabel('Client ID').fill('okta-client')
+  await page.getByLabel('Client Secret').fill('top-secret')
+  await page.getByLabel('Authorize URL').fill('https://login.example.com/oauth2/v1/authorize')
+  await page.getByLabel('Token URL').fill('https://login.example.com/oauth2/v1/token')
+  await page.getByLabel('Userinfo URL').fill('https://login.example.com/oauth2/v1/userinfo')
+  await page.getByLabel('JWKS URI').fill('https://login.example.com/oauth2/v1/keys')
+  await page.getByLabel('Scope').fill('openid profile email groups')
+  await page.getByLabel('Extra Config (JSON)').fill('{"prompt":"login"}')
+  await page.getByRole('button', { name: 'Create' }).click()
+
+  await expect(page.getByText('Okta Workforce')).toBeVisible()
+  await expect(page.getByText('https://login.example.com')).toBeVisible()
+})
+
+test('updates scoped API key ownership from enterprise settings', async ({ page }) => {
+  await openEnterpriseSettings(page)
+
+  await page.getByRole('button', { name: 'Manage Scope' }).click()
+  await expect(page.getByRole('heading', { name: 'Manage Key Scope' })).toBeVisible()
+
+  await page.getByLabel('Scopes').fill('alerts:read, webhooks:ingest')
+  await page.getByLabel('Tenant').selectOption({ label: 'Northwind Operations' })
+  await page.getByRole('button', { name: 'Save' }).click()
+
+  await page.getByRole('button', { name: 'Manage Scope' }).click()
+  await expect(page.getByLabel('Scopes')).toHaveValue('alerts:read, webhooks:ingest')
+  await expect(page.getByLabel('Tenant')).toHaveValue('tenant-1')
+})
+
+test('creates and runs a report schedule from enterprise settings', async ({ page }) => {
+  await openEnterpriseSettings(page)
+
+  await page.getByRole('button', { name: 'Add Schedule' }).click()
+  await expect(page.getByRole('heading', { name: 'Create Report Schedule' })).toBeVisible()
+
+  await page.getByLabel('Report Type').selectOption('sla_compliance')
+  await page.getByLabel('Format').selectOption('pdf')
+  await page.getByLabel('Cadence').selectOption('daily')
+  await page.getByLabel('Tenant').selectOption({ label: 'Northwind Operations' })
+  await page.getByLabel('Destination Email').fill('soc@example.com')
+  await page.getByLabel('Config (JSON)').fill('{"hour":6}')
+  await page.getByRole('button', { name: 'Create' }).click()
+
+  await expect(page.getByText('sla_compliance · pdf')).toBeVisible()
+  await expect(page.getByText('daily · soc@example.com')).toBeVisible()
+
+  await page.getByTitle('Run now').click()
+  await expect(page.getByText('last: success')).toBeVisible()
+})

--- a/ui/e2e/support/mockEnterpriseApi.ts
+++ b/ui/e2e/support/mockEnterpriseApi.ts
@@ -1,0 +1,444 @@
+import type { Page, Route } from '@playwright/test'
+
+interface AuthProviderCapability {
+  id: string
+  name: string
+  type: string
+  login_url: string | null
+}
+
+interface AuthCapabilities {
+  local_login_enabled: boolean
+  local_registration_enabled: boolean
+  providers: AuthProviderCapability[]
+}
+
+interface Analyst {
+  id: string
+  username: string
+  display_name: string
+  email: string | null
+  is_active: boolean
+  role: string
+  created_at: string
+}
+
+interface ApiKeyInfo {
+  id: string
+  name: string
+  prefix: string
+  is_active: boolean
+  created_at: string
+  key?: string
+}
+
+interface ApiKeyScopeInfo {
+  api_key_id: string
+  scopes: string[]
+  tenant_id: string | null
+}
+
+interface TenantInfo {
+  id: string
+  name: string
+  slug: string
+  legacy_partner_key: string | null
+  is_active: boolean
+  config: Record<string, unknown>
+  alert_count: number
+  analyst_count: number
+}
+
+interface SSOProviderInfo {
+  id: string
+  provider_type: string
+  name: string
+  issuer: string
+  client_id: string
+  authorize_url: string
+  token_url: string
+  userinfo_url: string | null
+  jwks_uri: string | null
+  scope: string
+  enabled: boolean
+  extra_config: Record<string, unknown>
+}
+
+interface ReportScheduleInfo {
+  id: string
+  report_type: string
+  format: string
+  cadence: string
+  destination_email: string | null
+  tenant_id: string | null
+  is_active: boolean
+  config: Record<string, unknown>
+  last_run_at: string | null
+  last_run_status: string | null
+  last_run_detail: string | null
+}
+
+interface MockEnterpriseState {
+  authenticated: boolean
+  analyst: Analyst | null
+  authCapabilities: AuthCapabilities
+  analysts: Analyst[]
+  apiKeys: ApiKeyInfo[]
+  apiKeyScopes: Record<string, ApiKeyScopeInfo>
+  tenants: TenantInfo[]
+  providers: SSOProviderInfo[]
+  schedules: ReportScheduleInfo[]
+}
+
+interface MockEnterpriseOptions {
+  authenticated?: boolean
+  analyst?: Analyst | null
+  authCapabilities?: AuthCapabilities
+  analysts?: Analyst[]
+  apiKeys?: ApiKeyInfo[]
+  apiKeyScopes?: Record<string, ApiKeyScopeInfo>
+  tenants?: TenantInfo[]
+  providers?: SSOProviderInfo[]
+  schedules?: ReportScheduleInfo[]
+}
+
+const now = '2026-04-04T00:00:00.000Z'
+
+const defaultAdmin: Analyst = {
+  id: 'analyst-admin',
+  username: 'admin',
+  display_name: 'Admin Analyst',
+  email: 'admin@opensoar.app',
+  is_active: true,
+  role: 'admin',
+  created_at: now,
+}
+
+const defaultAnalyst: Analyst = {
+  id: 'analyst-standard',
+  username: 'standard',
+  display_name: 'Standard Analyst',
+  email: 'analyst@opensoar.app',
+  is_active: true,
+  role: 'analyst',
+  created_at: now,
+}
+
+let idCounter = 1
+
+function nextId(prefix: string): string {
+  idCounter += 1
+  return `${prefix}-${idCounter}`
+}
+
+function cloneState(options: MockEnterpriseOptions): MockEnterpriseState {
+  const apiKeys = options.apiKeys ?? [
+    {
+      id: 'key-1',
+      name: 'Webhook Ingest',
+      prefix: 'osk_live',
+      is_active: true,
+      created_at: now,
+    },
+  ]
+
+  return {
+    authenticated: options.authenticated ?? true,
+    analyst: options.analyst ?? defaultAdmin,
+    authCapabilities: options.authCapabilities ?? {
+      local_login_enabled: true,
+      local_registration_enabled: false,
+      providers: [],
+    },
+    analysts: options.analysts ?? [defaultAdmin, defaultAnalyst],
+    apiKeys,
+    apiKeyScopes: options.apiKeyScopes ?? {
+      [apiKeys[0].id]: {
+        api_key_id: apiKeys[0].id,
+        scopes: ['alerts:read'],
+        tenant_id: null,
+      },
+    },
+    tenants: options.tenants ?? [
+      {
+        id: 'tenant-1',
+        name: 'Northwind Operations',
+        slug: 'northwind-ops',
+        legacy_partner_key: 'northwind',
+        is_active: true,
+        config: {},
+        alert_count: 4,
+        analyst_count: 2,
+      },
+    ],
+    providers: options.providers ?? [],
+    schedules: options.schedules ?? [],
+  }
+}
+
+async function fulfillJson(route: Route, body: unknown, status = 200): Promise<void> {
+  await route.fulfill({
+    status,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  })
+}
+
+function requestBody(route: Route): Record<string, unknown> {
+  return (route.request().postDataJSON() ?? {}) as Record<string, unknown>
+}
+
+function findId(pathname: string): string {
+  return pathname.split('/').at(-1) ?? ''
+}
+
+export async function mockEnterpriseApi(
+  page: Page,
+  options: MockEnterpriseOptions = {},
+): Promise<MockEnterpriseState> {
+  const state = cloneState(options)
+
+  await page.addInitScript((token: string | null) => {
+    if (token) {
+      window.localStorage.setItem('opensoar_token', token)
+      return
+    }
+    window.localStorage.removeItem('opensoar_token')
+  }, state.authenticated ? 'mock-admin-token' : null)
+
+  await page.route('**/api/v1/**', async (route) => {
+    const request = route.request()
+    const method = request.method()
+    const pathname = new URL(request.url()).pathname
+
+    if (method === 'GET' && pathname === '/api/v1/auth/capabilities') {
+      await fulfillJson(route, state.authCapabilities)
+      return
+    }
+
+    if (method === 'GET' && pathname === '/api/v1/auth/me') {
+      if (!state.authenticated || !state.analyst) {
+        await fulfillJson(route, { detail: 'Unauthorized' }, 401)
+        return
+      }
+      await fulfillJson(route, state.analyst)
+      return
+    }
+
+    if (method === 'GET' && pathname === '/api/v1/auth/analysts') {
+      await fulfillJson(route, state.analysts)
+      return
+    }
+
+    if (method === 'GET' && pathname === '/api/v1/api-keys') {
+      await fulfillJson(route, state.apiKeys)
+      return
+    }
+
+    if (pathname.startsWith('/api/v1/api-key-scopes/')) {
+      const keyId = findId(pathname)
+      if (method === 'GET') {
+        await fulfillJson(route, state.apiKeyScopes[keyId] ?? {
+          api_key_id: keyId,
+          scopes: [],
+          tenant_id: null,
+        })
+        return
+      }
+
+      if (method === 'PUT') {
+        const body = requestBody(route)
+        state.apiKeyScopes[keyId] = {
+          api_key_id: keyId,
+          scopes: Array.isArray(body.scopes) ? body.scopes.map(String) : [],
+          tenant_id: typeof body.tenant_id === 'string' ? body.tenant_id : null,
+        }
+        await fulfillJson(route, state.apiKeyScopes[keyId])
+        return
+      }
+    }
+
+    if (pathname === '/api/v1/tenants') {
+      if (method === 'GET') {
+        await fulfillJson(route, state.tenants)
+        return
+      }
+
+      if (method === 'POST') {
+        const body = requestBody(route)
+        const analystIds = Array.isArray(body.analyst_ids) ? body.analyst_ids : []
+        const tenant = {
+          id: nextId('tenant'),
+          name: String(body.name ?? ''),
+          slug: String(body.slug ?? ''),
+          legacy_partner_key: typeof body.legacy_partner_key === 'string' ? body.legacy_partner_key : null,
+          is_active: true,
+          config: typeof body.config === 'object' && body.config ? body.config as Record<string, unknown> : {},
+          alert_count: 0,
+          analyst_count: analystIds.length,
+        }
+        state.tenants.push(tenant)
+        await fulfillJson(route, tenant, 201)
+        return
+      }
+    }
+
+    if (pathname.startsWith('/api/v1/tenants/')) {
+      const tenantId = findId(pathname)
+      const tenant = state.tenants.find((item) => item.id === tenantId)
+      if (!tenant) {
+        await fulfillJson(route, { detail: 'Tenant not found' }, 404)
+        return
+      }
+
+      if (method === 'PATCH') {
+        const body = requestBody(route)
+        Object.assign(tenant, {
+          name: typeof body.name === 'string' ? body.name : tenant.name,
+          slug: typeof body.slug === 'string' ? body.slug : tenant.slug,
+          legacy_partner_key: typeof body.legacy_partner_key === 'string' ? body.legacy_partner_key : tenant.legacy_partner_key,
+          is_active: typeof body.is_active === 'boolean' ? body.is_active : tenant.is_active,
+          config: typeof body.config === 'object' && body.config ? body.config as Record<string, unknown> : tenant.config,
+        })
+        await fulfillJson(route, tenant)
+        return
+      }
+
+      if (method === 'DELETE') {
+        state.tenants = state.tenants.filter((item) => item.id !== tenantId)
+        await fulfillJson(route, { detail: 'Tenant deactivated' })
+        return
+      }
+    }
+
+    if (pathname === '/api/v1/sso/providers') {
+      if (method === 'GET') {
+        await fulfillJson(route, state.providers)
+        return
+      }
+
+      if (method === 'POST') {
+        const body = requestBody(route)
+        const provider = {
+          id: nextId('provider'),
+          provider_type: String(body.provider_type ?? 'oidc'),
+          name: String(body.name ?? ''),
+          issuer: String(body.issuer ?? ''),
+          client_id: String(body.client_id ?? ''),
+          authorize_url: String(body.authorize_url ?? ''),
+          token_url: String(body.token_url ?? ''),
+          userinfo_url: typeof body.userinfo_url === 'string' ? body.userinfo_url : null,
+          jwks_uri: typeof body.jwks_uri === 'string' ? body.jwks_uri : null,
+          scope: typeof body.scope === 'string' ? body.scope : 'openid profile email',
+          enabled: typeof body.enabled === 'boolean' ? body.enabled : true,
+          extra_config: typeof body.extra_config === 'object' && body.extra_config ? body.extra_config as Record<string, unknown> : {},
+        }
+        state.providers.push(provider)
+        await fulfillJson(route, provider, 201)
+        return
+      }
+    }
+
+    if (pathname.startsWith('/api/v1/sso/providers/')) {
+      const providerId = findId(pathname)
+      const provider = state.providers.find((item) => item.id === providerId)
+      if (!provider) {
+        await fulfillJson(route, { detail: 'Provider not found' }, 404)
+        return
+      }
+
+      if (method === 'PATCH') {
+        const body = requestBody(route)
+        Object.assign(provider, {
+          name: typeof body.name === 'string' ? body.name : provider.name,
+          issuer: typeof body.issuer === 'string' ? body.issuer : provider.issuer,
+          client_id: typeof body.client_id === 'string' ? body.client_id : provider.client_id,
+          authorize_url: typeof body.authorize_url === 'string' ? body.authorize_url : provider.authorize_url,
+          token_url: typeof body.token_url === 'string' ? body.token_url : provider.token_url,
+          userinfo_url: typeof body.userinfo_url === 'string' ? body.userinfo_url : provider.userinfo_url,
+          jwks_uri: typeof body.jwks_uri === 'string' ? body.jwks_uri : provider.jwks_uri,
+          scope: typeof body.scope === 'string' ? body.scope : provider.scope,
+          enabled: typeof body.enabled === 'boolean' ? body.enabled : provider.enabled,
+          extra_config: typeof body.extra_config === 'object' && body.extra_config ? body.extra_config as Record<string, unknown> : provider.extra_config,
+        })
+        await fulfillJson(route, provider)
+        return
+      }
+
+      if (method === 'DELETE') {
+        state.providers = state.providers.filter((item) => item.id !== providerId)
+        await fulfillJson(route, { detail: 'OIDC provider deleted' })
+        return
+      }
+    }
+
+    if (pathname === '/api/v1/compliance/reports/schedules') {
+      if (method === 'GET') {
+        await fulfillJson(route, state.schedules)
+        return
+      }
+
+      if (method === 'POST') {
+        const body = requestBody(route)
+        const schedule = {
+          id: nextId('schedule'),
+          report_type: String(body.report_type ?? 'audit_log'),
+          format: String(body.format ?? 'pdf'),
+          cadence: String(body.cadence ?? 'manual'),
+          destination_email: typeof body.destination_email === 'string' ? body.destination_email : null,
+          tenant_id: typeof body.tenant_id === 'string' ? body.tenant_id : null,
+          is_active: typeof body.is_active === 'boolean' ? body.is_active : true,
+          config: typeof body.config === 'object' && body.config ? body.config as Record<string, unknown> : {},
+          last_run_at: null,
+          last_run_status: null,
+          last_run_detail: null,
+        }
+        state.schedules.push(schedule)
+        await fulfillJson(route, schedule, 201)
+        return
+      }
+    }
+
+    if (pathname.startsWith('/api/v1/compliance/reports/schedules/')) {
+      const segments = pathname.split('/')
+      const scheduleId = segments[segments.length - (segments.at(-1) === 'run' ? 2 : 1)] ?? ''
+      const schedule = state.schedules.find((item) => item.id === scheduleId)
+      if (!schedule) {
+        await fulfillJson(route, { detail: 'Report schedule not found' }, 404)
+        return
+      }
+
+      if (method === 'POST' && pathname.endsWith('/run')) {
+        schedule.last_run_at = new Date().toISOString()
+        schedule.last_run_status = 'success'
+        schedule.last_run_detail = `Generated ${schedule.report_type}.${schedule.format}`
+        await fulfillJson(route, {
+          detail: 'Report schedule executed',
+          execution: {
+            filename: `${schedule.report_type}.${schedule.format}`,
+            media_type: schedule.format === 'pdf' ? 'application/pdf' : 'application/json',
+            size: 512,
+          },
+          schedule,
+        })
+        return
+      }
+
+      if (method === 'DELETE') {
+        state.schedules = state.schedules.filter((item) => item.id !== scheduleId)
+        await fulfillJson(route, { detail: 'Report schedule deleted' })
+        return
+      }
+    }
+
+    await fulfillJson(
+      route,
+      {
+        detail: `No mock route for ${method} ${pathname}`,
+      },
+      404,
+    )
+  })
+
+  return state
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/vite": "^4.2.1",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
@@ -602,6 +603,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -1575,7 +1592,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2169,7 +2186,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -3449,6 +3466,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test:e2e": "playwright test",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -21,6 +22,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.2.1",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from '@playwright/test'
+
+const baseURL = 'http://127.0.0.1:4173'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        browserName: 'chromium',
+      },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev -- --host 127.0.0.1 --port 4173 --strictPort',
+    url: baseURL,
+    reuseExistingServer: false,
+  },
+})

--- a/ui/src/components/ui/Select.tsx
+++ b/ui/src/components/ui/Select.tsx
@@ -1,15 +1,19 @@
 import { cn } from '@/lib/utils'
 
 interface SelectProps {
+  id?: string
+  name?: string
   value: string
   onChange: (value: string) => void
   options: { value: string; label: string }[]
   className?: string
 }
 
-export function Select({ value, onChange, options, className }: SelectProps) {
+export function Select({ id, name, value, onChange, options, className }: SelectProps) {
   return (
     <select
+      id={id}
+      name={name}
       value={value}
       onChange={(e) => onChange(e.target.value)}
       className={cn(

--- a/ui/src/components/ui/Sidebar.tsx
+++ b/ui/src/components/ui/Sidebar.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import React, { useState, createContext, useContext } from 'react'
 import { NavLink } from 'react-router'
 import { AnimatePresence, motion } from 'framer-motion'

--- a/ui/src/components/ui/Toast.tsx
+++ b/ui/src/components/ui/Toast.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { createContext, useContext, useState, useCallback, type ReactNode } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { CheckCircle, XCircle, AlertTriangle, Info, X } from 'lucide-react'

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -41,7 +41,7 @@ function IntegrationsTab() {
 
   const healthMutation = useMutation({
     mutationFn: (id: string) => api.integrations.healthCheck(id),
-    onSuccess: (_data, _id) => {
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['integrations'] })
     },
     onError: () => {
@@ -910,16 +910,18 @@ function EnterpriseTab() {
             ) : (
               <>
                 <div>
-                  <Label>Scopes</Label>
+                  <Label htmlFor="enterprise-scope-scopes">Scopes</Label>
                   <Input
+                    id="enterprise-scope-scopes"
                     value={scopeText || (scopeQuery.data?.scopes.join(', ') ?? '')}
                     onChange={(e) => setScopeText(e.target.value)}
                     placeholder="webhooks:ingest, webhooks:ingest:elastic"
                   />
                 </div>
                 <div>
-                  <Label>Tenant</Label>
+                  <Label htmlFor="enterprise-scope-tenant">Tenant</Label>
                   <Select
+                    id="enterprise-scope-tenant"
                     value={scopeTenantId || scopeQuery.data?.tenant_id || ''}
                     onChange={(v) => setScopeTenantId(v)}
                     options={[
@@ -954,25 +956,27 @@ function EnterpriseTab() {
           <DialogBody className="space-y-3">
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <Label>Name</Label>
-                <Input value={tenantForm.name} onChange={(e) => setTenantForm({ ...tenantForm, name: e.target.value })} />
+                <Label htmlFor="tenant-name">Name</Label>
+                <Input id="tenant-name" value={tenantForm.name} onChange={(e) => setTenantForm({ ...tenantForm, name: e.target.value })} />
               </div>
               <div>
-                <Label>Slug</Label>
-                <Input value={tenantForm.slug} onChange={(e) => setTenantForm({ ...tenantForm, slug: e.target.value })} />
+                <Label htmlFor="tenant-slug">Slug</Label>
+                <Input id="tenant-slug" value={tenantForm.slug} onChange={(e) => setTenantForm({ ...tenantForm, slug: e.target.value })} />
               </div>
             </div>
             <div>
-              <Label>Legacy Partner Key</Label>
+              <Label htmlFor="tenant-legacy-partner-key">Legacy Partner Key</Label>
               <Input
+                id="tenant-legacy-partner-key"
                 value={tenantForm.legacy_partner_key}
                 onChange={(e) => setTenantForm({ ...tenantForm, legacy_partner_key: e.target.value })}
                 placeholder="acme-corp"
               />
             </div>
             <div>
-              <Label>Partner Aliases</Label>
+              <Label htmlFor="tenant-partner-aliases">Partner Aliases</Label>
               <Input
+                id="tenant-partner-aliases"
                 value={tenantForm.partner_aliases}
                 onChange={(e) => setTenantForm({ ...tenantForm, partner_aliases: e.target.value })}
                 placeholder="alias-one, alias-two"
@@ -1036,22 +1040,23 @@ function EnterpriseTab() {
           <DialogBody className="space-y-3">
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <Label>Name</Label>
-                <Input value={providerForm.name} onChange={(e) => setProviderForm({ ...providerForm, name: e.target.value })} />
+                <Label htmlFor="provider-name">Name</Label>
+                <Input id="provider-name" value={providerForm.name} onChange={(e) => setProviderForm({ ...providerForm, name: e.target.value })} />
               </div>
               <div>
-                <Label>Issuer</Label>
-                <Input value={providerForm.issuer} onChange={(e) => setProviderForm({ ...providerForm, issuer: e.target.value })} />
+                <Label htmlFor="provider-issuer">Issuer</Label>
+                <Input id="provider-issuer" value={providerForm.issuer} onChange={(e) => setProviderForm({ ...providerForm, issuer: e.target.value })} />
               </div>
             </div>
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <Label>Client ID</Label>
-                <Input value={providerForm.client_id} onChange={(e) => setProviderForm({ ...providerForm, client_id: e.target.value })} />
+                <Label htmlFor="provider-client-id">Client ID</Label>
+                <Input id="provider-client-id" value={providerForm.client_id} onChange={(e) => setProviderForm({ ...providerForm, client_id: e.target.value })} />
               </div>
               <div>
-                <Label>Client Secret</Label>
+                <Label htmlFor="provider-client-secret">Client Secret</Label>
                 <Input
+                  id="provider-client-secret"
                   type="password"
                   value={providerForm.client_secret}
                   onChange={(e) => setProviderForm({ ...providerForm, client_secret: e.target.value })}
@@ -1061,31 +1066,32 @@ function EnterpriseTab() {
             </div>
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <Label>Authorize URL</Label>
-                <Input value={providerForm.authorize_url} onChange={(e) => setProviderForm({ ...providerForm, authorize_url: e.target.value })} />
+                <Label htmlFor="provider-authorize-url">Authorize URL</Label>
+                <Input id="provider-authorize-url" value={providerForm.authorize_url} onChange={(e) => setProviderForm({ ...providerForm, authorize_url: e.target.value })} />
               </div>
               <div>
-                <Label>Token URL</Label>
-                <Input value={providerForm.token_url} onChange={(e) => setProviderForm({ ...providerForm, token_url: e.target.value })} />
+                <Label htmlFor="provider-token-url">Token URL</Label>
+                <Input id="provider-token-url" value={providerForm.token_url} onChange={(e) => setProviderForm({ ...providerForm, token_url: e.target.value })} />
               </div>
             </div>
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <Label>Userinfo URL</Label>
-                <Input value={providerForm.userinfo_url} onChange={(e) => setProviderForm({ ...providerForm, userinfo_url: e.target.value })} />
+                <Label htmlFor="provider-userinfo-url">Userinfo URL</Label>
+                <Input id="provider-userinfo-url" value={providerForm.userinfo_url} onChange={(e) => setProviderForm({ ...providerForm, userinfo_url: e.target.value })} />
               </div>
               <div>
-                <Label>JWKS URI</Label>
-                <Input value={providerForm.jwks_uri} onChange={(e) => setProviderForm({ ...providerForm, jwks_uri: e.target.value })} />
+                <Label htmlFor="provider-jwks-uri">JWKS URI</Label>
+                <Input id="provider-jwks-uri" value={providerForm.jwks_uri} onChange={(e) => setProviderForm({ ...providerForm, jwks_uri: e.target.value })} />
               </div>
             </div>
             <div>
-              <Label>Scope</Label>
-              <Input value={providerForm.scope} onChange={(e) => setProviderForm({ ...providerForm, scope: e.target.value })} />
+              <Label htmlFor="provider-scope">Scope</Label>
+              <Input id="provider-scope" value={providerForm.scope} onChange={(e) => setProviderForm({ ...providerForm, scope: e.target.value })} />
             </div>
             <div>
-              <Label>Extra Config (JSON)</Label>
+              <Label htmlFor="provider-extra-config">Extra Config (JSON)</Label>
               <Textarea
+                id="provider-extra-config"
                 value={providerForm.extra_config}
                 onChange={(e) => setProviderForm({ ...providerForm, extra_config: e.target.value })}
                 rows={4}
@@ -1110,8 +1116,9 @@ function EnterpriseTab() {
           <DialogBody className="space-y-3">
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <Label>Report Type</Label>
+                <Label htmlFor="schedule-report-type">Report Type</Label>
                 <Select
+                  id="schedule-report-type"
                   value={scheduleForm.report_type}
                   onChange={(v) => setScheduleForm({ ...scheduleForm, report_type: v })}
                   options={[
@@ -1122,8 +1129,9 @@ function EnterpriseTab() {
                 />
               </div>
               <div>
-                <Label>Format</Label>
+                <Label htmlFor="schedule-format">Format</Label>
                 <Select
+                  id="schedule-format"
                   value={scheduleForm.format}
                   onChange={(v) => setScheduleForm({ ...scheduleForm, format: v })}
                   options={[
@@ -1137,8 +1145,9 @@ function EnterpriseTab() {
             </div>
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <Label>Cadence</Label>
+                <Label htmlFor="schedule-cadence">Cadence</Label>
                 <Select
+                  id="schedule-cadence"
                   value={scheduleForm.cadence}
                   onChange={(v) => setScheduleForm({ ...scheduleForm, cadence: v })}
                   options={[
@@ -1150,8 +1159,9 @@ function EnterpriseTab() {
                 />
               </div>
               <div>
-                <Label>Tenant</Label>
+                <Label htmlFor="schedule-tenant">Tenant</Label>
                 <Select
+                  id="schedule-tenant"
                   value={scheduleForm.tenant_id}
                   onChange={(v) => setScheduleForm({ ...scheduleForm, tenant_id: v })}
                   options={[
@@ -1166,16 +1176,18 @@ function EnterpriseTab() {
               </div>
             </div>
             <div>
-              <Label>Destination Email</Label>
+              <Label htmlFor="schedule-destination-email">Destination Email</Label>
               <Input
+                id="schedule-destination-email"
                 value={scheduleForm.destination_email}
                 onChange={(e) => setScheduleForm({ ...scheduleForm, destination_email: e.target.value })}
                 placeholder="soc@example.com"
               />
             </div>
             <div>
-              <Label>Config (JSON)</Label>
+              <Label htmlFor="schedule-config">Config (JSON)</Label>
               <Textarea
+                id="schedule-config"
                 value={scheduleForm.config}
                 onChange={(e) => setScheduleForm({ ...scheduleForm, config: e.target.value })}
                 rows={3}


### PR DESCRIPTION
## Summary
- add a Playwright browser test lane to core/ui
- cover enterprise login rendering plus tenant, OIDC provider, scoped API key, and report schedule flows
- add stable label associations for enterprise forms and ignore Playwright artifacts in git

## Verification
- cd ui && npm run lint
- cd ui && npm run build
- cd ui && npm run test:e2e

Closes #26
Related: opensoar-hq/opensoar-ee#34