### PR TITLE
Add enterprise retention policy management UI

### DIFF
--- a/ui/e2e/enterprise-flows.spec.ts
+++ b/ui/e2e/enterprise-flows.spec.ts
@@ -89,7 +89,7 @@ test('updates scoped API key ownership from enterprise settings', async ({ page 
 
   await page.getByLabel('Scopes').fill('alerts:read, webhooks:ingest')
   await page.getByLabel('Tenant').selectOption({ label: 'Northwind Operations' })
-  await page.getByRole('button', { name: 'Save' }).click()
+  await page.getByRole('button', { name: 'Save', exact: true }).click()
 
   await page.getByRole('button', { name: 'Manage Scope' }).click()
   await expect(page.getByLabel('Scopes')).toHaveValue('alerts:read, webhooks:ingest')
@@ -115,4 +115,18 @@ test('creates and runs a report schedule from enterprise settings', async ({ pag
 
   await page.getByTitle('Run now').click()
   await expect(page.getByText('last: success')).toBeVisible()
+})
+
+test('updates retention policy from enterprise settings', async ({ page }) => {
+  await openEnterpriseSettings(page)
+
+  await expect(page.getByRole('heading', { name: 'Data Retention' })).toBeVisible()
+  await page.getByLabel('Audit Log Retention (Days)').fill('30')
+  await page.getByLabel('Report Run Metadata Retention (Days)').fill('14')
+  await page.getByLabel('Notes').fill('Short retention for staging')
+  await page.getByLabel('Automatically enforce on the background worker').check()
+  await page.getByRole('button', { name: 'Save Retention Policy' }).click()
+  await page.getByRole('button', { name: 'Run Enforcement Now' }).click()
+
+  await expect(page.getByText(/Last enforced/)).toBeVisible()
 })

--- a/ui/e2e/support/mockEnterpriseApi.ts
+++ b/ui/e2e/support/mockEnterpriseApi.ts
@@ -78,6 +78,16 @@ interface ReportScheduleInfo {
   last_run_detail: string | null
 }
 
+interface DataRetentionPolicyInfo {
+  id: string
+  audit_log_retention_days: number | null
+  report_run_retention_days: number | null
+  auto_apply_enabled: boolean
+  last_enforced_at: string | null
+  last_enforcement_summary: Record<string, unknown> | null
+  notes: string | null
+}
+
 interface MockEnterpriseState {
   authenticated: boolean
   analyst: Analyst | null
@@ -88,6 +98,7 @@ interface MockEnterpriseState {
   tenants: TenantInfo[]
   providers: SSOProviderInfo[]
   schedules: ReportScheduleInfo[]
+  dataRetention: DataRetentionPolicyInfo
 }
 
 interface MockEnterpriseOptions {
@@ -100,6 +111,7 @@ interface MockEnterpriseOptions {
   tenants?: TenantInfo[]
   providers?: SSOProviderInfo[]
   schedules?: ReportScheduleInfo[]
+  dataRetention?: DataRetentionPolicyInfo
 }
 
 const now = '2026-04-04T00:00:00.000Z'
@@ -173,6 +185,15 @@ function cloneState(options: MockEnterpriseOptions): MockEnterpriseState {
     ],
     providers: options.providers ?? [],
     schedules: options.schedules ?? [],
+    dataRetention: options.dataRetention ?? {
+      id: 'retention-1',
+      audit_log_retention_days: 365,
+      report_run_retention_days: 90,
+      auto_apply_enabled: false,
+      last_enforced_at: null,
+      last_enforcement_summary: null,
+      notes: null,
+    },
   }
 }
 
@@ -397,6 +418,43 @@ export async function mockEnterpriseApi(
         await fulfillJson(route, schedule, 201)
         return
       }
+    }
+
+    if (pathname === '/api/v1/compliance/data-retention') {
+      if (method === 'GET') {
+        await fulfillJson(route, state.dataRetention)
+        return
+      }
+
+      if (method === 'PUT') {
+        const body = requestBody(route)
+        state.dataRetention = {
+          ...state.dataRetention,
+          audit_log_retention_days: typeof body.audit_log_retention_days === 'number' ? body.audit_log_retention_days : null,
+          report_run_retention_days: typeof body.report_run_retention_days === 'number' ? body.report_run_retention_days : null,
+          auto_apply_enabled: Boolean(body.auto_apply_enabled),
+          notes: typeof body.notes === 'string' ? body.notes : null,
+        }
+        await fulfillJson(route, state.dataRetention)
+        return
+      }
+    }
+
+    if (pathname === '/api/v1/compliance/data-retention/enforce' && method === 'POST') {
+      state.dataRetention = {
+        ...state.dataRetention,
+        last_enforced_at: new Date().toISOString(),
+        last_enforcement_summary: {
+          audit_log_entries_deleted: 3,
+          report_runs_cleared: 1,
+        },
+      }
+      await fulfillJson(route, {
+        audit_log_entries_deleted: 3,
+        report_runs_cleared: 1,
+        enforced_at: state.dataRetention.last_enforced_at,
+      })
+      return
     }
 
     if (pathname.startsWith('/api/v1/compliance/reports/schedules/')) {

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'test-results', 'playwright-report', '.vite']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -290,6 +290,22 @@ export interface ReportScheduleInfo {
   last_run_detail: string | null
 }
 
+export interface DataRetentionPolicyInfo {
+  id: string
+  audit_log_retention_days: number | null
+  report_run_retention_days: number | null
+  auto_apply_enabled: boolean
+  last_enforced_at: string | null
+  last_enforcement_summary: Record<string, unknown> | null
+  notes: string | null
+}
+
+export interface DataRetentionEnforcementInfo {
+  audit_log_entries_deleted: number
+  report_runs_cleared: number
+  enforced_at: string
+}
+
 export interface Observable {
   id: string
   type: string
@@ -521,5 +537,15 @@ export const api = {
     }) => patchJSON<ReportScheduleInfo>(`/compliance/reports/schedules/${id}`, data as Record<string, unknown>),
     remove: (id: string) => deleteJSON(`/compliance/reports/schedules/${id}`),
     run: (id: string) => postJSON<{ detail: string; execution: Record<string, unknown>; schedule: ReportScheduleInfo }>(`/compliance/reports/schedules/${id}/run`, {}),
+  },
+  dataRetention: {
+    get: () => fetchJSON<DataRetentionPolicyInfo>('/compliance/data-retention'),
+    update: (data: {
+      audit_log_retention_days?: number | null
+      report_run_retention_days?: number | null
+      auto_apply_enabled: boolean
+      notes?: string | null
+    }) => putJSON<DataRetentionPolicyInfo>('/compliance/data-retention', data as Record<string, unknown>),
+    enforce: () => postJSON<DataRetentionEnforcementInfo>('/compliance/data-retention/enforce', {}),
   },
 }

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -457,6 +457,13 @@ function EnterpriseTab() {
     tenant_id: '',
     config: '{}',
   })
+  const [retentionForm, setRetentionForm] = useState({
+    audit_log_retention_days: '365',
+    report_run_retention_days: '90',
+    auto_apply_enabled: false,
+    notes: '',
+  })
+  const [retentionDirty, setRetentionDirty] = useState(false)
 
   const { data: keys, isLoading: keysLoading } = useQuery({
     queryKey: ['api-keys'],
@@ -468,6 +475,20 @@ function EnterpriseTab() {
     queryFn: api.reportSchedules.list,
     retry: false,
   })
+
+  const retentionQuery = useQuery({
+    queryKey: ['ee-data-retention'],
+    queryFn: api.dataRetention.get,
+    retry: false,
+  })
+  const effectiveRetentionForm = retentionDirty || !retentionQuery.data
+    ? retentionForm
+    : {
+        audit_log_retention_days: retentionQuery.data.audit_log_retention_days?.toString() ?? '',
+        report_run_retention_days: retentionQuery.data.report_run_retention_days?.toString() ?? '',
+        auto_apply_enabled: retentionQuery.data.auto_apply_enabled,
+        notes: retentionQuery.data.notes ?? '',
+      }
 
   const scopeQuery = useQuery({
     queryKey: ['ee-api-key-scope', selectedKeyId],
@@ -542,6 +563,46 @@ function EnterpriseTab() {
     },
     onError: () => {
       toast.error('Failed to delete report schedule')
+    },
+  })
+
+  const updateRetentionMutation = useMutation({
+    mutationFn: () => api.dataRetention.update({
+      audit_log_retention_days: effectiveRetentionForm.audit_log_retention_days.trim()
+        ? Number(effectiveRetentionForm.audit_log_retention_days)
+        : null,
+      report_run_retention_days: effectiveRetentionForm.report_run_retention_days.trim()
+        ? Number(effectiveRetentionForm.report_run_retention_days)
+        : null,
+      auto_apply_enabled: effectiveRetentionForm.auto_apply_enabled,
+      notes: effectiveRetentionForm.notes.trim() || null,
+    }),
+    onSuccess: (data) => {
+      setRetentionForm({
+        audit_log_retention_days: data.audit_log_retention_days?.toString() ?? '',
+        report_run_retention_days: data.report_run_retention_days?.toString() ?? '',
+        auto_apply_enabled: data.auto_apply_enabled,
+        notes: data.notes ?? '',
+      })
+      setRetentionDirty(false)
+      queryClient.invalidateQueries({ queryKey: ['ee-data-retention'] })
+      toast.success('Retention policy saved')
+    },
+    onError: () => {
+      toast.error('Failed to save retention policy')
+    },
+  })
+
+  const runRetentionMutation = useMutation({
+    mutationFn: () => api.dataRetention.enforce(),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['ee-data-retention'] })
+      toast.success(
+        `Retention applied (${data.audit_log_entries_deleted} audit entries, ${data.report_runs_cleared} schedule runs)`,
+      )
+    },
+    onError: () => {
+      toast.error('Failed to run retention policy')
     },
   })
 
@@ -896,6 +957,93 @@ function EnterpriseTab() {
           </Card>
         ) : (
           <EmptyState icon={<CalendarDays size={28} />} title="No schedules" description="Create a report schedule to automate exports" />
+        )}
+      </div>
+
+      <div>
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-sm font-medium text-heading m-0">Data Retention</h3>
+        </div>
+        {retentionQuery.isError ? (
+          <EmptyState
+            icon={<Shield size={28} />}
+            title="Retention management unavailable"
+            description="The enterprise retention endpoints are not available in this deployment."
+          />
+        ) : retentionQuery.isLoading ? (
+          <CardSkeleton lines={2} />
+        ) : (
+          <Card className="p-4 space-y-4">
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <Label htmlFor="retention-audit-days">Audit Log Retention (Days)</Label>
+                <Input
+                  id="retention-audit-days"
+                  type="number"
+                  min={1}
+                  value={effectiveRetentionForm.audit_log_retention_days}
+                  onChange={(e) => {
+                    setRetentionDirty(true)
+                    setRetentionForm({ ...effectiveRetentionForm, audit_log_retention_days: e.target.value })
+                  }}
+                  placeholder="365"
+                />
+              </div>
+              <div>
+                <Label htmlFor="retention-report-days">Report Run Metadata Retention (Days)</Label>
+                <Input
+                  id="retention-report-days"
+                  type="number"
+                  min={1}
+                  value={effectiveRetentionForm.report_run_retention_days}
+                  onChange={(e) => {
+                    setRetentionDirty(true)
+                    setRetentionForm({ ...effectiveRetentionForm, report_run_retention_days: e.target.value })
+                  }}
+                  placeholder="90"
+                />
+              </div>
+            </div>
+            <div>
+              <Label htmlFor="retention-notes">Notes</Label>
+              <Textarea
+                id="retention-notes"
+                value={effectiveRetentionForm.notes}
+                onChange={(e) => {
+                  setRetentionDirty(true)
+                  setRetentionForm({ ...effectiveRetentionForm, notes: e.target.value })
+                }}
+                rows={3}
+                placeholder="Document retention rationale or exceptions"
+              />
+            </div>
+            <label className="flex items-center gap-2 text-sm text-text">
+              <input
+                type="checkbox"
+                checked={effectiveRetentionForm.auto_apply_enabled}
+                onChange={(e) => {
+                  setRetentionDirty(true)
+                  setRetentionForm({ ...effectiveRetentionForm, auto_apply_enabled: e.target.checked })
+                }}
+              />
+              Automatically enforce on the background worker
+            </label>
+            {retentionQuery.data?.last_enforced_at ? (
+              <div className="text-[11px] text-muted">
+                Last enforced {new Date(retentionQuery.data.last_enforced_at).toLocaleString()}
+              </div>
+            ) : (
+              <div className="text-[11px] text-muted">Retention has not been enforced yet.</div>
+            )}
+            <div className="flex items-center justify-end gap-2">
+              <Button size="sm" variant="ghost" onClick={() => runRetentionMutation.mutate()}>
+                Run Enforcement Now
+              </Button>
+              <Button size="sm" variant="primary" onClick={() => updateRetentionMutation.mutate()}>
+                Save Retention Policy
+              </Button>
+            </div>
+          </Card>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- add enterprise retention policy controls to core/ui settings
- wire the UI to the EE data-retention API
- extend the Playwright enterprise suite and mock EE API for the new flow

## Verification
- cd ui && npm run lint
- cd ui && npm run build
- cd ui && npm run test:e2e

Closes #29
Related: opensoar-hq/opensoar-ee#38