### PR TITLE
Publish Helm chart and self-hosted packaging guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Then open [http://localhost:3000](http://localhost:3000).
 
 Docs: [docs.opensoar.app](https://docs.opensoar.app)
 
+Self-hosted packaging: [deploy/README.md](deploy/README.md)
+
 ---
 
 ## Why OpenSOAR?

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,66 @@
+# Self-Hosted Packaging
+
+This directory now owns the public self-hosted packaging entry points for OpenSOAR.
+
+## Deployment Paths
+
+### Docker Compose
+
+For the simplest single-host deployment, use the bundled Compose file:
+
+```bash
+docker compose -f deploy/docker-compose.yml up -d
+```
+
+This path runs:
+
+- `postgres`
+- `redis`
+- `migrate`
+- `api`
+- `worker`
+- `ui`
+
+### Helm
+
+The first Kubernetes packaging slice lives at:
+
+```bash
+helm/opensoar
+```
+
+Install it with:
+
+```bash
+helm install opensoar ./helm/opensoar
+```
+
+The chart currently deploys:
+
+- `postgres` as a single-replica StatefulSet
+- `redis` as a single-replica Deployment
+- `migrate` as a pre-install / pre-upgrade Job
+- `api`
+- `worker`
+- `ui`
+
+## Packaging Caveats
+
+- The chart is intentionally a v0 skeleton, not a HA reference architecture.
+- The current UI image proxies `/api` to the Kubernetes Service named `api`, so the chart assumes one OpenSOAR release per namespace.
+- EE-compatible self-hosted installs should override the `api`, `worker`, and `migrate` images with custom images that include the private `opensoar-ee` package.
+- Secret values in `values.yaml` are placeholders. Use real secrets before production deployment.
+- Elasticsearch / Kibana are not bundled in the Helm chart. Integrate those as external dependencies if your environment needs them.
+
+## Upgrade Posture
+
+- Migrations run as a Helm hook Job before install and upgrade.
+- Persistent data is only defined for Postgres in this first slice.
+- Review image tags carefully before upgrading from `latest` to a pinned release or vice versa.
+
+## Recommended Next Hardening Steps
+
+- externalize Postgres and Redis for production
+- add ingress, TLS, and secret-manager integration
+- pin image tags per release
+- add probes, resource requests/limits, and backup guidance tuned for your environment

--- a/helm/opensoar/Chart.yaml
+++ b/helm/opensoar/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: opensoar
+description: Helm chart for self-hosted OpenSOAR deployments
+type: application
+version: 0.1.0
+appVersion: "latest"

--- a/helm/opensoar/templates/NOTES.txt
+++ b/helm/opensoar/templates/NOTES.txt
@@ -1,0 +1,11 @@
+OpenSOAR has been installed.
+
+The chart currently assumes a single release per namespace because the UI image proxies /api requests to the in-cluster Service named "api".
+
+To access the UI locally:
+
+  kubectl port-forward svc/ui 3000:{{ .Values.ui.service.port }}
+
+Then open:
+
+  http://127.0.0.1:3000

--- a/helm/opensoar/templates/_helpers.tpl
+++ b/helm/opensoar/templates/_helpers.tpl
@@ -1,0 +1,6 @@
+{{- define "opensoar.labels" -}}
+app.kubernetes.io/name: opensoar
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{- end -}}

--- a/helm/opensoar/templates/api.yaml
+++ b/helm/opensoar/templates/api.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  labels:
+{{ include "opensoar.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.api.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.api.service.port }}
+      targetPort: 8000
+  selector:
+    app.kubernetes.io/component: api
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  labels:
+{{ include "opensoar.labels" . | indent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  replicas: {{ .Values.api.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: api
+  template:
+    metadata:
+      labels:
+{{ include "opensoar.labels" . | indent 8 }}
+        app.kubernetes.io/component: api
+    spec:
+      containers:
+        - name: api
+          image: "{{ .Values.images.api.repository }}:{{ .Values.images.api.tag }}"
+          imagePullPolicy: {{ .Values.images.api.pullPolicy }}
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: opensoar-secrets
+                  key: database-url
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: opensoar-secrets
+                  key: redis-url
+            - name: CELERY_BROKER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: opensoar-secrets
+                  key: celery-broker-url
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: opensoar-secrets
+                  key: jwt-secret
+            - name: API_KEY_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: opensoar-secrets
+                  key: api-key-secret
+            - name: PLAYBOOK_DIRS
+              value: {{ .Values.api.playbookDirs | quote }}
+{{- if .Values.api.extraEnv }}
+{{ toYaml .Values.api.extraEnv | indent 12 }}
+{{- end }}
+          ports:
+            - containerPort: 8000
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /docs
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+{{ toYaml .Values.api.resources | indent 12 }}

--- a/helm/opensoar/templates/ingress.yaml
+++ b/helm/opensoar/templates/ingress.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.ui.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ui
+  labels:
+{{ include "opensoar.labels" . | indent 4 }}
+  annotations:
+{{ toYaml .Values.ui.ingress.annotations | indent 4 }}
+spec:
+  {{- if .Values.ui.ingress.className }}
+  ingressClassName: {{ .Values.ui.ingress.className }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ui.ingress.host }}
+      http:
+        paths:
+          - path: {{ .Values.ui.ingress.path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: ui
+                port:
+                  number: {{ .Values.ui.service.port }}
+  {{- if .Values.ui.ingress.tls }}
+  tls:
+{{ toYaml .Values.ui.ingress.tls | indent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/opensoar/templates/migrate-job.yaml
+++ b/helm/opensoar/templates/migrate-job.yaml
@@ -1,0 +1,39 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: migrate
+  labels:
+{{ include "opensoar.labels" . | indent 4 }}
+    app.kubernetes.io/component: migrate
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+{{ include "opensoar.labels" . | indent 8 }}
+        app.kubernetes.io/component: migrate
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: migrate
+          image: "{{ .Values.images.migrate.repository }}:{{ .Values.images.migrate.tag }}"
+          imagePullPolicy: {{ .Values.images.migrate.pullPolicy }}
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: opensoar-secrets
+                  key: database-url
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: opensoar-secrets
+                  key: jwt-secret
+            - name: API_KEY_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: opensoar-secrets
+                  key: api-key-secret

--- a/helm/opensoar/templates/postgres.yaml
+++ b/helm/opensoar/templates/postgres.yaml
@@ -1,0 +1,73 @@
+{{- if .Values.postgres.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+{{ include "opensoar.labels" . | indent 4 }}
+spec:
+  ports:
+    - name: postgres
+      port: {{ .Values.postgres.service.port }}
+      targetPort: 5432
+  selector:
+    app.kubernetes.io/component: postgres
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  labels:
+{{ include "opensoar.labels" . | indent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: postgres
+  template:
+    metadata:
+      labels:
+{{ include "opensoar.labels" . | indent 8 }}
+        app.kubernetes.io/component: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: "{{ .Values.images.postgres.repository }}:{{ .Values.images.postgres.tag }}"
+          imagePullPolicy: {{ .Values.images.postgres.pullPolicy }}
+          env:
+            - name: POSTGRES_DB
+              value: opensoar
+            - name: POSTGRES_USER
+              value: opensoar
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: opensoar-secrets
+                  key: postgres-password
+          ports:
+            - containerPort: 5432
+              name: postgres
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "pg_isready -U opensoar"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+{{ toYaml .Values.postgres.resources | indent 12 }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- if .Values.postgres.persistence.storageClassName }}
+        storageClassName: {{ .Values.postgres.persistence.storageClassName }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgres.persistence.size }}
+{{- end }}

--- a/helm/opensoar/templates/redis.yaml
+++ b/helm/opensoar/templates/redis.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.redis.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+{{ include "opensoar.labels" . | indent 4 }}
+spec:
+  ports:
+    - name: redis
+      port: {{ .Values.redis.service.port }}
+      targetPort: 6379
+  selector:
+    app.kubernetes.io/component: redis
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  labels:
+{{ include "opensoar.labels" . | indent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+{{ include "opensoar.labels" . | indent 8 }}
+        app.kubernetes.io/component: redis
+    spec:
+      containers:
+        - name: redis
+          image: "{{ .Values.images.redis.repository }}:{{ .Values.images.redis.tag }}"
+          imagePullPolicy: {{ .Values.images.redis.pullPolicy }}
+          ports:
+            - containerPort: 6379
+              name: redis
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+{{ toYaml .Values.redis.resources | indent 12 }}
+{{- end }}

--- a/helm/opensoar/templates/secret.yaml
+++ b/helm/opensoar/templates/secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: opensoar-secrets
+  labels:
+{{ include "opensoar.labels" . | indent 4 }}
+type: Opaque
+data:
+  postgres-password: {{ .Values.secrets.postgresPassword | b64enc | quote }}
+  jwt-secret: {{ .Values.secrets.jwtSecret | b64enc | quote }}
+  api-key-secret: {{ .Values.secrets.apiKeySecret | b64enc | quote }}
+  database-url: {{ printf "postgresql+asyncpg://opensoar:%s@postgres:5432/opensoar" .Values.secrets.postgresPassword | b64enc | quote }}
+  redis-url: {{ printf "redis://redis:%d/0" (int .Values.redis.service.port) | b64enc | quote }}
+  celery-broker-url: {{ printf "redis://redis:%d/1" (int .Values.redis.service.port) | b64enc | quote }}

--- a/helm/opensoar/templates/ui.yaml
+++ b/helm/opensoar/templates/ui.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ui
+  labels:
+{{ include "opensoar.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.ui.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.ui.service.port }}
+      targetPort: 80
+  selector:
+    app.kubernetes.io/component: ui
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ui
+  labels:
+{{ include "opensoar.labels" . | indent 4 }}
+    app.kubernetes.io/component: ui
+spec:
+  replicas: {{ .Values.ui.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: ui
+  template:
+    metadata:
+      labels:
+{{ include "opensoar.labels" . | indent 8 }}
+        app.kubernetes.io/component: ui
+    spec:
+      containers:
+        - name: ui
+          image: "{{ .Values.images.ui.repository }}:{{ .Values.images.ui.tag }}"
+          imagePullPolicy: {{ .Values.images.ui.pullPolicy }}
+          ports:
+            - containerPort: 80
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+{{ toYaml .Values.ui.resources | indent 12 }}

--- a/helm/opensoar/templates/worker.yaml
+++ b/helm/opensoar/templates/worker.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+{{ include "opensoar.labels" . | indent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  replicas: {{ .Values.worker.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: worker
+  template:
+    metadata:
+      labels:
+{{ include "opensoar.labels" . | indent 8 }}
+        app.kubernetes.io/component: worker
+    spec:
+      containers:
+        - name: worker
+          image: "{{ .Values.images.worker.repository }}:{{ .Values.images.worker.tag }}"
+          imagePullPolicy: {{ .Values.images.worker.pullPolicy }}
+          command:
+            - celery
+            - -A
+            - opensoar.worker.celery_app
+            - worker
+            - --loglevel=info
+            - --concurrency={{ .Values.worker.concurrency | quote }}
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: opensoar-secrets
+                  key: database-url
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: opensoar-secrets
+                  key: redis-url
+            - name: CELERY_BROKER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: opensoar-secrets
+                  key: celery-broker-url
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: opensoar-secrets
+                  key: jwt-secret
+            - name: API_KEY_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: opensoar-secrets
+                  key: api-key-secret
+            - name: PLAYBOOK_DIRS
+              value: {{ .Values.worker.playbookDirs | quote }}
+{{- if .Values.worker.extraEnv }}
+{{ toYaml .Values.worker.extraEnv | indent 12 }}
+{{- end }}
+          resources:
+{{ toYaml .Values.worker.resources | indent 12 }}

--- a/helm/opensoar/values.yaml
+++ b/helm/opensoar/values.yaml
@@ -1,0 +1,76 @@
+images:
+  api:
+    repository: ghcr.io/opensoar-hq/opensoar-core-api
+    tag: latest
+    pullPolicy: IfNotPresent
+  worker:
+    repository: ghcr.io/opensoar-hq/opensoar-core-worker
+    tag: latest
+    pullPolicy: IfNotPresent
+  migrate:
+    repository: ghcr.io/opensoar-hq/opensoar-core-migrate
+    tag: latest
+    pullPolicy: IfNotPresent
+  ui:
+    repository: ghcr.io/opensoar-hq/opensoar-core-ui
+    tag: latest
+    pullPolicy: IfNotPresent
+  postgres:
+    repository: postgres
+    tag: "16-alpine"
+    pullPolicy: IfNotPresent
+  redis:
+    repository: redis
+    tag: "7-alpine"
+    pullPolicy: IfNotPresent
+
+secrets:
+  postgresPassword: opensoar
+  jwtSecret: change-me
+  apiKeySecret: change-me
+
+api:
+  replicaCount: 1
+  service:
+    type: ClusterIP
+    port: 8000
+  playbookDirs: /app/playbooks
+  extraEnv: []
+  resources: {}
+
+worker:
+  replicaCount: 1
+  concurrency: 4
+  playbookDirs: /app/playbooks
+  extraEnv: []
+  resources: {}
+
+ui:
+  replicaCount: 1
+  service:
+    type: ClusterIP
+    port: 80
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    host: opensoar.local
+    path: /
+    tls: []
+  resources: {}
+
+postgres:
+  enabled: true
+  service:
+    port: 5432
+  persistence:
+    enabled: true
+    size: 10Gi
+    storageClassName: ""
+  resources: {}
+
+redis:
+  enabled: true
+  service:
+    port: 6379
+  resources: {}


### PR DESCRIPTION
## Summary
- add the first Helm chart skeleton under helm/opensoar
- add deploy/README.md as the public self-hosted packaging guide in the active core repo
- link the root README to the new packaging entry point

## Verification
- helm lint helm/opensoar

Closes #28