### PR TITLE
Add ownership fields and tenant hooks for playbooks and integrations

### DIFF
--- a/migrations/versions/9d1a2c3b4e55_add_partner_to_integrations_and_playbooks.py
+++ b/migrations/versions/9d1a2c3b4e55_add_partner_to_integrations_and_playbooks.py
@@ -1,0 +1,27 @@
+"""add partner to integrations and playbooks
+
+Revision ID: 9d1a2c3b4e55
+Revises: 6c2d5f4b8e91
+Create Date: 2026-04-04
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "9d1a2c3b4e55"
+down_revision: Union[str, Sequence[str], None] = "6c2d5f4b8e91"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("integration_instances", sa.Column("partner", sa.String(length=100), nullable=True))
+    op.add_column("playbook_definitions", sa.Column("partner", sa.String(length=100), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("playbook_definitions", "partner")
+    op.drop_column("integration_instances", "partner")

--- a/src/opensoar/api/integrations.py
+++ b/src/opensoar/api/integrations.py
@@ -4,13 +4,16 @@ import logging
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from opensoar.api.deps import get_db
+from opensoar.auth.jwt import get_current_analyst
 from opensoar.integrations.loader import IntegrationLoader
+from opensoar.models.analyst import Analyst
 from opensoar.models.integration import IntegrationInstance
+from opensoar.plugins import apply_tenant_access_query, enforce_tenant_access
 from opensoar.schemas.integration import (
     IntegrationCreate,
     IntegrationResponse,
@@ -39,10 +42,22 @@ async def list_available_types():
 
 
 @router.get("", response_model=list[IntegrationResponse])
-async def list_integrations(session: AsyncSession = Depends(get_db)):
-    result = await session.execute(
-        select(IntegrationInstance).order_by(IntegrationInstance.name)
+async def list_integrations(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+    analyst: Analyst | None = Depends(get_current_analyst),
+):
+    query = select(IntegrationInstance).order_by(IntegrationInstance.name)
+    query = await apply_tenant_access_query(
+        request.app,
+        query=query,
+        resource_type="integration",
+        action="list",
+        analyst=analyst,
+        request=request,
+        session=session,
     )
+    result = await session.execute(query)
     integrations = result.scalars().all()
     return [IntegrationResponse.model_validate(i) for i in integrations]
 
@@ -50,13 +65,25 @@ async def list_integrations(session: AsyncSession = Depends(get_db)):
 @router.post("", response_model=IntegrationResponse, status_code=201)
 async def create_integration(
     data: IntegrationCreate,
+    request: Request,
     session: AsyncSession = Depends(get_db),
+    analyst: Analyst | None = Depends(get_current_analyst),
 ):
     integration = IntegrationInstance(
         integration_type=data.integration_type,
         name=data.name,
+        partner=data.partner,
         config=data.config,
         enabled=data.enabled,
+    )
+    await enforce_tenant_access(
+        request.app,
+        resource=integration,
+        resource_type="integration",
+        action="create",
+        analyst=analyst,
+        request=request,
+        session=session,
     )
     session.add(integration)
     await session.commit()
@@ -67,7 +94,9 @@ async def create_integration(
 @router.get("/{integration_id}", response_model=IntegrationResponse)
 async def get_integration(
     integration_id: uuid.UUID,
+    request: Request,
     session: AsyncSession = Depends(get_db),
+    analyst: Analyst | None = Depends(get_current_analyst),
 ):
     result = await session.execute(
         select(IntegrationInstance).where(IntegrationInstance.id == integration_id)
@@ -75,6 +104,15 @@ async def get_integration(
     integration = result.scalar_one_or_none()
     if not integration:
         raise HTTPException(status_code=404, detail="Integration not found")
+    await enforce_tenant_access(
+        request.app,
+        resource=integration,
+        resource_type="integration",
+        action="read",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
     return IntegrationResponse.model_validate(integration)
 
 
@@ -82,7 +120,9 @@ async def get_integration(
 async def update_integration(
     integration_id: uuid.UUID,
     update: IntegrationUpdate,
+    request: Request,
     session: AsyncSession = Depends(get_db),
+    analyst: Analyst | None = Depends(get_current_analyst),
 ):
     result = await session.execute(
         select(IntegrationInstance).where(IntegrationInstance.id == integration_id)
@@ -94,6 +134,15 @@ async def update_integration(
     update_data = update.model_dump(exclude_unset=True)
     for field, value in update_data.items():
         setattr(integration, field, value)
+    await enforce_tenant_access(
+        request.app,
+        resource=integration,
+        resource_type="integration",
+        action="update",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
 
     await session.commit()
     await session.refresh(integration)
@@ -103,7 +152,9 @@ async def update_integration(
 @router.delete("/{integration_id}")
 async def delete_integration(
     integration_id: uuid.UUID,
+    request: Request,
     session: AsyncSession = Depends(get_db),
+    analyst: Analyst | None = Depends(get_current_analyst),
 ):
     result = await session.execute(
         select(IntegrationInstance).where(IntegrationInstance.id == integration_id)
@@ -111,6 +162,15 @@ async def delete_integration(
     integration = result.scalar_one_or_none()
     if not integration:
         raise HTTPException(status_code=404, detail="Integration not found")
+    await enforce_tenant_access(
+        request.app,
+        resource=integration,
+        resource_type="integration",
+        action="delete",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
 
     await session.delete(integration)
     await session.commit()
@@ -120,7 +180,9 @@ async def delete_integration(
 @router.post("/{integration_id}/health")
 async def check_integration_health(
     integration_id: uuid.UUID,
+    request: Request,
     session: AsyncSession = Depends(get_db),
+    analyst: Analyst | None = Depends(get_current_analyst),
 ):
     """Run a health check on an integration and persist the result."""
     result = await session.execute(
@@ -129,6 +191,15 @@ async def check_integration_health(
     integration = result.scalar_one_or_none()
     if not integration:
         raise HTTPException(status_code=404, detail="Integration not found")
+    await enforce_tenant_access(
+        request.app,
+        resource=integration,
+        resource_type="integration",
+        action="health",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
 
     loader = _get_loader()
     connector_cls = loader.get_connector(integration.integration_type)

--- a/src/opensoar/api/playbooks.py
+++ b/src/opensoar/api/playbooks.py
@@ -2,23 +2,39 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from opensoar.api.deps import get_db
+from opensoar.auth.jwt import get_current_analyst
 from opensoar.core.decorators import get_playbook_registry
+from opensoar.models.alert import Alert
+from opensoar.models.analyst import Analyst
 from opensoar.models.playbook import PlaybookDefinition
+from opensoar.plugins import apply_tenant_access_query, enforce_tenant_access
 from opensoar.schemas.playbook import PlaybookResponse, PlaybookRunRequest, PlaybookUpdate
 
 router = APIRouter(prefix="/playbooks", tags=["playbooks"])
 
 
 @router.get("", response_model=list[PlaybookResponse])
-async def list_playbooks(session: AsyncSession = Depends(get_db)):
-    result = await session.execute(
-        select(PlaybookDefinition).order_by(PlaybookDefinition.name)
+async def list_playbooks(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+    analyst: Analyst | None = Depends(get_current_analyst),
+):
+    query = select(PlaybookDefinition).order_by(PlaybookDefinition.name)
+    query = await apply_tenant_access_query(
+        request.app,
+        query=query,
+        resource_type="playbook",
+        action="list",
+        analyst=analyst,
+        request=request,
+        session=session,
     )
+    result = await session.execute(query)
     playbooks = result.scalars().all()
     return [PlaybookResponse.model_validate(pb) for pb in playbooks]
 
@@ -26,7 +42,9 @@ async def list_playbooks(session: AsyncSession = Depends(get_db)):
 @router.get("/{playbook_id}", response_model=PlaybookResponse)
 async def get_playbook(
     playbook_id: uuid.UUID,
+    request: Request,
     session: AsyncSession = Depends(get_db),
+    analyst: Analyst | None = Depends(get_current_analyst),
 ):
     result = await session.execute(
         select(PlaybookDefinition).where(PlaybookDefinition.id == playbook_id)
@@ -34,6 +52,15 @@ async def get_playbook(
     pb = result.scalar_one_or_none()
     if not pb:
         raise HTTPException(status_code=404, detail="Playbook not found")
+    await enforce_tenant_access(
+        request.app,
+        resource=pb,
+        resource_type="playbook",
+        action="read",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
     return PlaybookResponse.model_validate(pb)
 
 
@@ -41,7 +68,9 @@ async def get_playbook(
 async def update_playbook(
     playbook_id: uuid.UUID,
     update: PlaybookUpdate,
+    request: Request,
     session: AsyncSession = Depends(get_db),
+    analyst: Analyst | None = Depends(get_current_analyst),
 ):
     result = await session.execute(
         select(PlaybookDefinition).where(PlaybookDefinition.id == playbook_id)
@@ -53,6 +82,15 @@ async def update_playbook(
     update_data = update.model_dump(exclude_unset=True)
     for field, value in update_data.items():
         setattr(pb, field, value)
+    await enforce_tenant_access(
+        request.app,
+        resource=pb,
+        resource_type="playbook",
+        action="update",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
 
     await session.commit()
     await session.refresh(pb)
@@ -62,8 +100,10 @@ async def update_playbook(
 @router.post("/{playbook_id}/run")
 async def run_playbook(
     playbook_id: uuid.UUID,
-    request: PlaybookRunRequest | None = None,
+    run_request: PlaybookRunRequest | None = None,
+    request: Request = None,
     session: AsyncSession = Depends(get_db),
+    analyst: Analyst | None = Depends(get_current_analyst),
 ):
     result = await session.execute(
         select(PlaybookDefinition).where(PlaybookDefinition.id == playbook_id)
@@ -71,6 +111,15 @@ async def run_playbook(
     pb_def = result.scalar_one_or_none()
     if not pb_def:
         raise HTTPException(status_code=404, detail="Playbook not found")
+    await enforce_tenant_access(
+        request.app,
+        resource=pb_def,
+        resource_type="playbook",
+        action="run",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
 
     registry = get_playbook_registry()
     pb = registry.get(pb_def.name)
@@ -79,7 +128,24 @@ async def run_playbook(
 
     from opensoar.worker.tasks import execute_playbook_task
 
-    alert_id = str(request.alert_id) if request and request.alert_id else None
+    alert_id = str(run_request.alert_id) if run_request and run_request.alert_id else None
+    if run_request and run_request.alert_id:
+        alert = (
+            await session.execute(select(Alert).where(Alert.id == run_request.alert_id))
+        ).scalar_one_or_none()
+        if not alert:
+            raise HTTPException(status_code=404, detail="Alert not found")
+        await enforce_tenant_access(
+            request.app,
+            resource=alert,
+            resource_type="alert",
+            action="read",
+            analyst=analyst,
+            request=request,
+            session=session,
+        )
+        if analyst is not None and analyst.role != "admin" and pb_def.partner != alert.partner:
+            raise HTTPException(status_code=403, detail="Playbook tenant scope does not match alert")
     task = execute_playbook_task.delay(pb_def.name, alert_id)
 
     return {

--- a/src/opensoar/models/integration.py
+++ b/src/opensoar/models/integration.py
@@ -12,6 +12,7 @@ class IntegrationInstance(Base):
 
     integration_type: Mapped[str] = mapped_column(String(100))
     name: Mapped[str] = mapped_column(String(255))
+    partner: Mapped[str | None] = mapped_column(String(100))
     config: Mapped[dict] = mapped_column(JSONB, default=dict)
     enabled: Mapped[bool] = mapped_column(Boolean, default=True)
     health_status: Mapped[str | None] = mapped_column(String(20))

--- a/src/opensoar/models/playbook.py
+++ b/src/opensoar/models/playbook.py
@@ -10,6 +10,7 @@ class PlaybookDefinition(Base):
 
     name: Mapped[str] = mapped_column(String(255), unique=True)
     description: Mapped[str | None] = mapped_column(Text)
+    partner: Mapped[str | None] = mapped_column(String(100))
     module_path: Mapped[str] = mapped_column(String(500))
     function_name: Mapped[str] = mapped_column(String(255))
     trigger_type: Mapped[str | None] = mapped_column(String(50))

--- a/src/opensoar/schemas/integration.py
+++ b/src/opensoar/schemas/integration.py
@@ -10,12 +10,14 @@ from pydantic import BaseModel
 class IntegrationCreate(BaseModel):
     integration_type: str
     name: str
+    partner: str | None = None
     config: dict[str, Any] = {}
     enabled: bool = True
 
 
 class IntegrationUpdate(BaseModel):
     name: str | None = None
+    partner: str | None = None
     config: dict[str, Any] | None = None
     enabled: bool | None = None
 
@@ -24,6 +26,7 @@ class IntegrationResponse(BaseModel):
     id: uuid.UUID
     integration_type: str
     name: str
+    partner: str | None = None
     enabled: bool
     health_status: str | None = None
     last_health_check: datetime | None = None

--- a/src/opensoar/schemas/playbook.py
+++ b/src/opensoar/schemas/playbook.py
@@ -11,6 +11,7 @@ class PlaybookResponse(BaseModel):
     id: uuid.UUID
     name: str
     description: str | None = None
+    partner: str | None = None
     module_path: str
     function_name: str
     trigger_type: str | None = None
@@ -24,6 +25,7 @@ class PlaybookResponse(BaseModel):
 
 class PlaybookUpdate(BaseModel):
     enabled: bool | None = None
+    partner: str | None = None
 
 
 class PlaybookRunRequest(BaseModel):


### PR DESCRIPTION
## Summary
- add nullable ownership to core playbooks and integrations
- thread tenant-access query/resource hooks through the core APIs
- keep existing global records migration-safe as admin-managed objects until assigned

## Verification
- PATH="/Users/peak/coding/tools/opensoar/core/.venv/bin:$PATH" PYTHONPATH="/Users/peak/coding/tools/opensoar/core/src:/Users/peak/coding/tools/opensoar/ee/src" ../core/.venv/bin/pytest tests/test_integrations_api.py tests/test_playbooks_api.py -q
- PYTHONPATH="/Users/peak/coding/tools/opensoar/core/src:/Users/peak/coding/tools/opensoar/ee/src" ../core/.venv/bin/ruff check core/src/opensoar/models/integration.py core/src/opensoar/models/playbook.py core/src/opensoar/schemas/integration.py core/src/opensoar/schemas/playbook.py core/src/opensoar/api/integrations.py core/src/opensoar/api/playbooks.py

Closes #32
Related: opensoar-hq/opensoar-ee#40