### PR TITLE
Add tenant workspace selector and tenant-aware dashboard filtering

### DIFF
--- a/src/opensoar/api/alerts.py
+++ b/src/opensoar/api/alerts.py
@@ -36,6 +36,7 @@ async def list_alerts(
     severity: str | None = None,
     source: str | None = None,
     partner: str | None = None,
+    tenant_id: str | None = None,
     determination: str | None = None,
     limit: int = Query(default=50, le=200),
     offset: int = Query(default=0, ge=0),

--- a/src/opensoar/api/dashboard.py
+++ b/src/opensoar/api/dashboard.py
@@ -21,6 +21,7 @@ router = APIRouter(prefix="/dashboard", tags=["dashboard"])
 @router.get("/stats")
 async def dashboard_stats(
     request: Request,
+    tenant_id: str | None = None,
     session: AsyncSession = Depends(get_db),
     analyst: Analyst | None = Depends(get_current_analyst),
 ):

--- a/ui/e2e/enterprise-flows.spec.ts
+++ b/ui/e2e/enterprise-flows.spec.ts
@@ -136,7 +136,15 @@ test('updates an analyst role to playbook author', async ({ page }) => {
   await page.goto('/settings')
   await page.getByRole('button', { name: 'Analysts' }).click()
 
-  const roleSelect = page.locator('select').first()
+  const roleSelect = page.locator('select').nth(1)
   await roleSelect.selectOption('playbook_author')
   await expect(roleSelect).toHaveValue('playbook_author')
+})
+
+test('selects a workspace from the sidebar switcher', async ({ page }) => {
+  await mockEnterpriseApi(page)
+  await page.goto('/settings')
+
+  await page.getByLabel('Workspace').selectOption('tenant-1')
+  await expect(page.getByLabel('Workspace')).toHaveValue('tenant-1')
 })

--- a/ui/e2e/support/mockEnterpriseApi.ts
+++ b/ui/e2e/support/mockEnterpriseApi.ts
@@ -251,6 +251,31 @@ export async function mockEnterpriseApi(
       return
     }
 
+    if (method === 'GET' && pathname === '/api/v1/dashboard/stats') {
+      const tenantId = new URL(request.url()).searchParams.get('tenant_id')
+      const partner = tenantId === 'tenant-1' ? 'Northwind Operations' : 'All Partners'
+      await fulfillJson(route, {
+        alerts_by_severity: { high: 1 },
+        alerts_by_status: { new: 1 },
+        alerts_by_partner: { [partner]: 1 },
+        alerts_by_determination: { unknown: 1 },
+        open_by_partner: { [partner]: 1 },
+        mttr_by_partner: { [partner]: 3600 },
+        total_alerts: 1,
+        total_runs: 1,
+        open_alerts: 1,
+        alerts_today: 1,
+        active_runs: 0,
+        unassigned_count: 1,
+        mttr_seconds: 3600,
+        priority_queue: [],
+        my_alerts: [],
+        recent_alerts: [],
+        recent_runs: [],
+      })
+      return
+    }
+
     if (pathname.startsWith('/api/v1/auth/analysts/')) {
       const analystId = findId(pathname)
       const analyst = state.analysts.find((item) => item.id === analystId)

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AuthProvider, useAuth } from '@/contexts/AuthContext'
+import { WorkspaceProvider } from '@/contexts/WorkspaceContext'
 import { ToastProvider } from '@/components/ui/Toast'
 import { AppLayout } from '@/layouts/AppLayout'
 import { DashboardPage } from '@/pages/DashboardPage'
@@ -61,24 +62,26 @@ export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
-        <ToastProvider>
-          <BrowserRouter>
-            <Routes>
-              <Route path="/login" element={<PublicOnly><LoginPage /></PublicOnly>} />
-              <Route element={<RequireAuth><AppLayout /></RequireAuth>}>
-                <Route index element={<DashboardPage />} />
-                <Route path="alerts" element={<AlertsListPage />} />
-                <Route path="alerts/:id" element={<AlertDetailPage />} />
-                <Route path="runs" element={<RunsListPage />} />
-                <Route path="runs/:id" element={<RunDetailPage />} />
-                <Route path="incidents" element={<IncidentsListPage />} />
-                <Route path="incidents/:id" element={<IncidentDetailPage />} />
-                <Route path="playbooks" element={<PlaybooksListPage />} />
-                <Route path="settings" element={<SettingsPage />} />
-              </Route>
-            </Routes>
-          </BrowserRouter>
-        </ToastProvider>
+        <WorkspaceProvider>
+          <ToastProvider>
+            <BrowserRouter>
+              <Routes>
+                <Route path="/login" element={<PublicOnly><LoginPage /></PublicOnly>} />
+                <Route element={<RequireAuth><AppLayout /></RequireAuth>}>
+                  <Route index element={<DashboardPage />} />
+                  <Route path="alerts" element={<AlertsListPage />} />
+                  <Route path="alerts/:id" element={<AlertDetailPage />} />
+                  <Route path="runs" element={<RunsListPage />} />
+                  <Route path="runs/:id" element={<RunDetailPage />} />
+                  <Route path="incidents" element={<IncidentsListPage />} />
+                  <Route path="incidents/:id" element={<IncidentDetailPage />} />
+                  <Route path="playbooks" element={<PlaybooksListPage />} />
+                  <Route path="settings" element={<SettingsPage />} />
+                </Route>
+              </Routes>
+            </BrowserRouter>
+          </ToastProvider>
+        </WorkspaceProvider>
       </AuthProvider>
     </QueryClientProvider>
   )

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -349,12 +349,13 @@ export const api = {
       postJSON<WebhookResponse>('/webhooks/alerts', payload),
   },
   alerts: {
-    list: (params?: { status?: string; severity?: string; source?: string; partner?: string; determination?: string; search?: string; limit?: number; offset?: number }) => {
+    list: (params?: { status?: string; severity?: string; source?: string; partner?: string; tenant_id?: string; determination?: string; search?: string; limit?: number; offset?: number }) => {
       const sp = new URLSearchParams()
       if (params?.status) sp.set('status', params.status)
       if (params?.severity) sp.set('severity', params.severity)
       if (params?.source) sp.set('source', params.source)
       if (params?.partner) sp.set('partner', params.partner)
+      if (params?.tenant_id) sp.set('tenant_id', params.tenant_id)
       if (params?.determination) sp.set('determination', params.determination)
       if (params?.limit) sp.set('limit', String(params.limit))
       if (params?.offset) sp.set('offset', String(params.offset))
@@ -515,7 +516,7 @@ export const api = {
     remove: (id: string) => deleteJSON(`/sso/providers/${id}`),
   },
   dashboard: {
-    stats: () => fetchJSON<DashboardStats>('/dashboard/stats'),
+    stats: (tenantId?: string) => fetchJSON<DashboardStats>(`/dashboard/stats${tenantId ? `?tenant_id=${tenantId}` : ''}`),
   },
   reportSchedules: {
     list: () => fetchJSON<ReportScheduleInfo[]>('/compliance/reports/schedules'),

--- a/ui/src/contexts/WorkspaceContext.tsx
+++ b/ui/src/contexts/WorkspaceContext.tsx
@@ -1,0 +1,60 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { useQuery } from '@tanstack/react-query'
+
+import { api, type TenantInfo } from '@/api'
+import { useAuth } from '@/contexts/AuthContext'
+
+interface WorkspaceContextType {
+  tenants: TenantInfo[]
+  selectedTenantId: string
+  setSelectedTenantId: (tenantId: string) => void
+}
+
+const STORAGE_KEY = 'opensoar_active_tenant'
+const WorkspaceContext = createContext<WorkspaceContextType | null>(null)
+
+export function WorkspaceProvider({ children }: { children: ReactNode }) {
+  const { analyst } = useAuth()
+  const [selectedTenantIdState, setSelectedTenantIdState] = useState(
+    () => localStorage.getItem(STORAGE_KEY) ?? '',
+  )
+
+  const { data: tenants = [] } = useQuery({
+    queryKey: ['workspace-tenants', analyst?.id],
+    queryFn: api.tenants.list,
+    enabled: Boolean(analyst),
+    retry: false,
+  })
+
+  const selectedTenantId = useMemo(() => {
+    if (!selectedTenantIdState) return ''
+    return tenants.some((tenant) => tenant.id === selectedTenantIdState) ? selectedTenantIdState : ''
+  }, [selectedTenantIdState, tenants])
+
+  useEffect(() => {
+    if (selectedTenantId) {
+      localStorage.setItem(STORAGE_KEY, selectedTenantId)
+      return
+    }
+    localStorage.removeItem(STORAGE_KEY)
+  }, [selectedTenantId])
+
+  return (
+    <WorkspaceContext.Provider
+      value={{
+        tenants,
+        selectedTenantId,
+        setSelectedTenantId: setSelectedTenantIdState,
+      }}
+    >
+      {children}
+    </WorkspaceContext.Provider>
+  )
+}
+
+export function useWorkspace() {
+  const ctx = useContext(WorkspaceContext)
+  if (!ctx) throw new Error('useWorkspace must be used within WorkspaceProvider')
+  return ctx
+}

--- a/ui/src/layouts/AppLayout.tsx
+++ b/ui/src/layouts/AppLayout.tsx
@@ -7,6 +7,7 @@ import {
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useAuth } from '@/contexts/AuthContext'
+import { useWorkspace } from '@/contexts/WorkspaceContext'
 import {
   Sidebar,
   SidebarBody,
@@ -14,6 +15,7 @@ import {
   SidebarLabel,
   useSidebar,
 } from '@/components/ui/Sidebar'
+import { Select } from '@/components/ui/Select'
 
 const navItems = [
   { to: '/', label: 'Dashboard', icon: <LayoutDashboard size={18} />, end: true },
@@ -25,6 +27,7 @@ const navItems = [
 
 function SidebarContent() {
   const { analyst, logout } = useAuth()
+  const { tenants, selectedTenantId, setSelectedTenantId } = useWorkspace()
   const { open, animate } = useSidebar()
 
   return (
@@ -47,6 +50,31 @@ function SidebarContent() {
 
       {/* Nav */}
       <div className="flex flex-col flex-1 overflow-y-auto overflow-x-hidden mt-2">
+        {tenants.length > 0 && (
+          <div className="px-2 mb-3">
+            <motion.div
+              animate={{
+                display: animate ? (open ? 'block' : 'none') : 'block',
+                opacity: animate ? (open ? 1 : 0) : 1,
+              }}
+              transition={{ duration: 0.15 }}
+            >
+              <label htmlFor="workspace-switcher" className="block text-[11px] uppercase tracking-wide text-muted mb-1.5">
+                Workspace
+              </label>
+              <Select
+                id="workspace-switcher"
+                value={selectedTenantId}
+                onChange={setSelectedTenantId}
+                options={[
+                  { value: '', label: analyst?.role === 'admin' ? 'All tenants' : 'All workspaces' },
+                  ...tenants.map((tenant) => ({ value: tenant.id, label: tenant.name })),
+                ]}
+                className="w-full"
+              />
+            </motion.div>
+          </div>
+        )}
         <SidebarLabel>Navigation</SidebarLabel>
         <div className="flex flex-col gap-0.5">
           {navItems.map((item) => (

--- a/ui/src/pages/AlertsListPage.tsx
+++ b/ui/src/pages/AlertsListPage.tsx
@@ -18,6 +18,7 @@ import { Tooltip } from '@/components/ui/Tooltip'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogBody, DialogFooter } from '@/components/ui/Dialog'
 import { PageTransition } from '@/components/ui/PageTransition'
 import { useToast } from '@/components/ui/Toast'
+import { useWorkspace } from '@/contexts/WorkspaceContext'
 import { cn, timeAgo } from '@/lib/utils'
 
 function CreateAlertDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
@@ -188,6 +189,7 @@ function CreateAlertDialog({ open, onClose }: { open: boolean; onClose: () => vo
 export function AlertsListPage() {
   const queryClient = useQueryClient()
   const navigate = useNavigate()
+  const { selectedTenantId } = useWorkspace()
   const [filters, setFilters] = useState<{ severity?: string; status?: string; partner?: string; search?: string }>({})
   const [page, setPage] = useState(0)
   const [selected, setSelected] = useState<Set<string>>(new Set())
@@ -197,8 +199,8 @@ export function AlertsListPage() {
   const selectionActive = selected.size > 0
 
   const { data, isLoading } = useQuery({
-    queryKey: ['alerts', filters, page],
-    queryFn: () => api.alerts.list({ ...filters, limit, offset: page * limit }),
+    queryKey: ['alerts', filters, page, selectedTenantId],
+    queryFn: () => api.alerts.list({ ...filters, tenant_id: selectedTenantId || undefined, limit, offset: page * limit }),
   })
 
   const bulkMutation = useMutation({

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -12,6 +12,7 @@ import { StatSkeleton, CardSkeleton } from '@/components/ui/Skeleton'
 import { EmptyState } from '@/components/ui/EmptyState'
 import { PageTransition, StaggerParent, StaggerChild } from '@/components/ui/PageTransition'
 import { useAuth } from '@/contexts/AuthContext'
+import { useWorkspace } from '@/contexts/WorkspaceContext'
 import { timeAgo } from '@/lib/utils'
 import { SeverityDonut } from '@/components/dashboard/SeverityDonut'
 import { ActivitySparkline } from '@/components/dashboard/ActivitySparkline'
@@ -77,9 +78,10 @@ function DashboardSkeleton() {
 
 export function DashboardPage() {
   const { analyst } = useAuth()
+  const { selectedTenantId } = useWorkspace()
   const { data, isLoading } = useQuery({
-    queryKey: ['dashboard'],
-    queryFn: api.dashboard.stats,
+    queryKey: ['dashboard', selectedTenantId],
+    queryFn: () => api.dashboard.stats(selectedTenantId || undefined),
   })
 
   if (isLoading) {


### PR DESCRIPTION
## Summary
- add a workspace selector to the shared UI shell
- thread tenant-aware filtering into dashboard and alert-list requests
- extend the Playwright enterprise suite to cover workspace selection

## Verification
- cd ui && npm run lint && npm run test:e2e

Closes #36
Related: opensoar-hq/opensoar-ee#36