### PR TITLE
Apply workspace selection to incidents, runs, and tenant-facing navigation

### DIFF
--- a/src/opensoar/api/playbook_runs.py
+++ b/src/opensoar/api/playbook_runs.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from opensoar.api.deps import get_db
+from opensoar.auth.rbac import Permission, require_permission
+from opensoar.models.analyst import Analyst
 from opensoar.models.playbook_run import PlaybookRun
+from opensoar.plugins import apply_tenant_access_query, enforce_tenant_access
 from opensoar.schemas.playbook_run import PlaybookRunList, PlaybookRunResponse
 
 router = APIRouter(prefix="/runs", tags=["runs"])
@@ -17,9 +20,11 @@ router = APIRouter(prefix="/runs", tags=["runs"])
 async def list_runs(
     status: str | None = None,
     playbook_id: uuid.UUID | None = None,
+    request: Request = None,
     limit: int = Query(default=50, le=200),
     offset: int = Query(default=0, ge=0),
     session: AsyncSession = Depends(get_db),
+    analyst: Analyst = Depends(require_permission(Permission.PLAYBOOKS_READ)),
 ):
     query = select(PlaybookRun).order_by(PlaybookRun.created_at.desc())
     count_query = select(func.count(PlaybookRun.id))
@@ -30,6 +35,25 @@ async def list_runs(
     if playbook_id:
         query = query.where(PlaybookRun.playbook_id == playbook_id)
         count_query = count_query.where(PlaybookRun.playbook_id == playbook_id)
+
+    query = await apply_tenant_access_query(
+        request.app,
+        query=query,
+        resource_type="playbook_run",
+        action="list",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
+    count_query = await apply_tenant_access_query(
+        request.app,
+        query=count_query,
+        resource_type="playbook_run",
+        action="count",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
 
     total = (await session.execute(count_query)).scalar() or 0
     result = await session.execute(query.offset(offset).limit(limit))
@@ -44,7 +68,9 @@ async def list_runs(
 @router.get("/{run_id}", response_model=PlaybookRunResponse)
 async def get_run(
     run_id: uuid.UUID,
+    request: Request,
     session: AsyncSession = Depends(get_db),
+    analyst: Analyst = Depends(require_permission(Permission.PLAYBOOKS_READ)),
 ):
     result = await session.execute(
         select(PlaybookRun).where(PlaybookRun.id == run_id)
@@ -52,4 +78,13 @@ async def get_run(
     run = result.scalar_one_or_none()
     if not run:
         raise HTTPException(status_code=404, detail="Run not found")
+    await enforce_tenant_access(
+        request.app,
+        resource=run,
+        resource_type="playbook_run",
+        action="read",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
     return PlaybookRunResponse.model_validate(run)

--- a/ui/e2e/enterprise-flows.spec.ts
+++ b/ui/e2e/enterprise-flows.spec.ts
@@ -148,3 +148,17 @@ test('selects a workspace from the sidebar switcher', async ({ page }) => {
   await page.getByLabel('Workspace').selectOption('tenant-1')
   await expect(page.getByLabel('Workspace')).toHaveValue('tenant-1')
 })
+
+test('applies workspace selection to incidents and runs pages', async ({ page }) => {
+  await mockEnterpriseApi(page)
+  await page.goto('/settings')
+  await page.getByLabel('Workspace').selectOption('tenant-1')
+
+  await page.goto('/incidents')
+  await expect(page.getByText('Northwind Workspace Incident')).toBeVisible()
+  await expect(page.getByText('Global Incident')).toHaveCount(0)
+
+  await page.goto('/runs')
+  await expect(page.getByRole('button', { name: /Northwind Playbook/ })).toBeVisible()
+  await expect(page.getByText('Global Playbook')).toHaveCount(0)
+})

--- a/ui/e2e/support/mockEnterpriseApi.ts
+++ b/ui/e2e/support/mockEnterpriseApi.ts
@@ -251,6 +251,56 @@ export async function mockEnterpriseApi(
       return
     }
 
+    if (method === 'GET' && pathname === '/api/v1/playbooks') {
+      const tenantId = new URL(request.url()).searchParams.get('tenant_id')
+      const playbooks = tenantId === 'tenant-1'
+        ? [
+            {
+              id: 'playbook-1',
+              name: 'Northwind Playbook',
+              description: null,
+              partner: 'northwind',
+              module_path: 'playbooks.northwind',
+              function_name: 'run',
+              trigger_type: 'webhook',
+              trigger_config: {},
+              enabled: true,
+              version: 1,
+              created_at: now,
+            },
+          ]
+        : [
+            {
+              id: 'playbook-1',
+              name: 'Northwind Playbook',
+              description: null,
+              partner: 'northwind',
+              module_path: 'playbooks.northwind',
+              function_name: 'run',
+              trigger_type: 'webhook',
+              trigger_config: {},
+              enabled: true,
+              version: 1,
+              created_at: now,
+            },
+            {
+              id: 'playbook-2',
+              name: 'Global Playbook',
+              description: null,
+              partner: null,
+              module_path: 'playbooks.global',
+              function_name: 'run',
+              trigger_type: 'webhook',
+              trigger_config: {},
+              enabled: true,
+              version: 1,
+              created_at: now,
+            },
+          ]
+      await fulfillJson(route, playbooks)
+      return
+    }
+
     if (method === 'GET' && pathname === '/api/v1/dashboard/stats') {
       const tenantId = new URL(request.url()).searchParams.get('tenant_id')
       const partner = tenantId === 'tenant-1' ? 'Northwind Operations' : 'All Partners'
@@ -273,6 +323,106 @@ export async function mockEnterpriseApi(
         recent_alerts: [],
         recent_runs: [],
       })
+      return
+    }
+
+    if (method === 'GET' && pathname === '/api/v1/incidents') {
+      const tenantId = new URL(request.url()).searchParams.get('tenant_id')
+      const incidents = tenantId === 'tenant-1'
+        ? [
+            {
+              id: 'incident-1',
+              title: 'Northwind Workspace Incident',
+              description: null,
+              severity: 'high',
+              status: 'open',
+              assigned_to: null,
+              assigned_username: null,
+              tags: null,
+              alert_count: 1,
+              closed_at: null,
+              created_at: now,
+              updated_at: now,
+            },
+          ]
+        : [
+            {
+              id: 'incident-1',
+              title: 'Northwind Workspace Incident',
+              description: null,
+              severity: 'high',
+              status: 'open',
+              assigned_to: null,
+              assigned_username: null,
+              tags: null,
+              alert_count: 1,
+              closed_at: null,
+              created_at: now,
+              updated_at: now,
+            },
+            {
+              id: 'incident-2',
+              title: 'Global Incident',
+              description: null,
+              severity: 'medium',
+              status: 'open',
+              assigned_to: null,
+              assigned_username: null,
+              tags: null,
+              alert_count: 2,
+              closed_at: null,
+              created_at: now,
+              updated_at: now,
+            },
+          ]
+      await fulfillJson(route, { incidents, total: incidents.length })
+      return
+    }
+
+    if (method === 'GET' && pathname === '/api/v1/runs') {
+      const tenantId = new URL(request.url()).searchParams.get('tenant_id')
+      const runs = tenantId === 'tenant-1'
+        ? [
+            {
+              id: 'run-1',
+              playbook_id: 'playbook-1',
+              alert_id: 'alert-1',
+              status: 'completed',
+              started_at: now,
+              finished_at: now,
+              error: null,
+              result: {},
+              action_results: [],
+              created_at: now,
+            },
+          ]
+        : [
+            {
+              id: 'run-1',
+              playbook_id: 'playbook-1',
+              alert_id: 'alert-1',
+              status: 'completed',
+              started_at: now,
+              finished_at: now,
+              error: null,
+              result: {},
+              action_results: [],
+              created_at: now,
+            },
+            {
+              id: 'run-2',
+              playbook_id: 'playbook-2',
+              alert_id: 'alert-2',
+              status: 'failed',
+              started_at: now,
+              finished_at: now,
+              error: 'boom',
+              result: {},
+              action_results: [],
+              created_at: now,
+            },
+          ]
+      await fulfillJson(route, { runs, total: runs.length })
       return
     }
 

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -91,6 +91,7 @@ export interface Playbook {
   id: string
   name: string
   description: string | null
+  partner: string | null
   module_path: string
   function_name: string
   trigger_type: string | null
@@ -376,7 +377,7 @@ export const api = {
       postJSON<BulkOperationResult>('/alerts/bulk', data),
   },
   playbooks: {
-    list: () => fetchJSON<Playbook[]>('/playbooks'),
+    list: (tenantId?: string) => fetchJSON<Playbook[]>(`/playbooks${tenantId ? `?tenant_id=${tenantId}` : ''}`),
     get: (id: string) => fetchJSON<Playbook>(`/playbooks/${id}`),
     update: (id: string, data: { enabled?: boolean }) =>
       patchJSON<Playbook>(`/playbooks/${id}`, data),
@@ -384,10 +385,11 @@ export const api = {
       postJSON<{ message: string; celery_task_id: string }>(`/playbooks/${id}/run`, data || {}),
   },
   runs: {
-    list: (params?: { status?: string; playbook_id?: string; limit?: number; offset?: number }) => {
+    list: (params?: { status?: string; playbook_id?: string; tenant_id?: string; limit?: number; offset?: number }) => {
       const sp = new URLSearchParams()
       if (params?.status) sp.set('status', params.status)
       if (params?.playbook_id) sp.set('playbook_id', params.playbook_id)
+      if (params?.tenant_id) sp.set('tenant_id', params.tenant_id)
       if (params?.limit) sp.set('limit', String(params.limit))
       if (params?.offset) sp.set('offset', String(params.offset))
       const qs = sp.toString()
@@ -429,10 +431,11 @@ export const api = {
       patchJSON<Analyst>(`/auth/analysts/${id}`, data),
   },
   incidents: {
-    list: (params?: { status?: string; severity?: string; limit?: number; offset?: number }) => {
+    list: (params?: { status?: string; severity?: string; tenant_id?: string; limit?: number; offset?: number }) => {
       const qs = new URLSearchParams()
       if (params?.status) qs.set('status', params.status)
       if (params?.severity) qs.set('severity', params.severity)
+      if (params?.tenant_id) qs.set('tenant_id', params.tenant_id)
       if (params?.limit) qs.set('limit', String(params.limit))
       if (params?.offset) qs.set('offset', String(params.offset))
       const q = qs.toString()

--- a/ui/src/pages/IncidentsListPage.tsx
+++ b/ui/src/pages/IncidentsListPage.tsx
@@ -15,6 +15,7 @@ import { EmptyState } from '@/components/ui/EmptyState'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogBody, DialogFooter } from '@/components/ui/Dialog'
 import { PageTransition } from '@/components/ui/PageTransition'
 import { useToast } from '@/components/ui/Toast'
+import { useWorkspace } from '@/contexts/WorkspaceContext'
 import { timeAgo } from '@/lib/utils'
 
 function CreateIncidentDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
@@ -103,14 +104,15 @@ function CreateIncidentDialog({ open, onClose }: { open: boolean; onClose: () =>
 
 export function IncidentsListPage() {
   const navigate = useNavigate()
+  const { selectedTenantId } = useWorkspace()
   const [filters, setFilters] = useState<{ severity?: string; status?: string }>({})
   const [page, setPage] = useState(0)
   const [showCreateDialog, setShowCreateDialog] = useState(false)
   const limit = 50
 
   const { data, isLoading } = useQuery({
-    queryKey: ['incidents', filters, page],
-    queryFn: () => api.incidents.list({ ...filters, limit, offset: page * limit }),
+    queryKey: ['incidents', filters, page, selectedTenantId],
+    queryFn: () => api.incidents.list({ ...filters, tenant_id: selectedTenantId || undefined, limit, offset: page * limit }),
   })
 
   const incidents = data?.incidents ?? []

--- a/ui/src/pages/RunsListPage.tsx
+++ b/ui/src/pages/RunsListPage.tsx
@@ -11,6 +11,7 @@ import { EmptyState } from '@/components/ui/EmptyState'
 import { TableSkeleton } from '@/components/ui/Skeleton'
 import { Pagination } from '@/components/ui/Pagination'
 import { PageTransition } from '@/components/ui/PageTransition'
+import { useWorkspace } from '@/contexts/WorkspaceContext'
 import { timeAgo, formatDuration, cn } from '@/lib/utils'
 
 const STATUS_ICONS: Record<string, React.ReactNode> = {
@@ -90,19 +91,20 @@ function ExpandedRunDetails({ run }: { run: PlaybookRun }) {
 }
 
 export function RunsListPage() {
+  const { selectedTenantId } = useWorkspace()
   const [filters, setFilters] = useState<{ status?: string; playbook_id?: string }>({})
   const [page, setPage] = useState(0)
   const [expandedId, setExpandedId] = useState<string | null>(null)
   const limit = 50
 
   const { data, isLoading } = useQuery({
-    queryKey: ['runs', filters, page],
-    queryFn: () => api.runs.list({ ...filters, limit, offset: page * limit }),
+    queryKey: ['runs', filters, page, selectedTenantId],
+    queryFn: () => api.runs.list({ ...filters, tenant_id: selectedTenantId || undefined, limit, offset: page * limit }),
   })
 
   const { data: playbooks } = useQuery({
-    queryKey: ['playbooks'],
-    queryFn: api.playbooks.list,
+    queryKey: ['playbooks', selectedTenantId],
+    queryFn: () => api.playbooks.list(selectedTenantId || undefined),
   })
 
   const playbookMap = new Map<string, string>()


### PR DESCRIPTION
## Summary
- extend workspace-aware filtering to incidents and runs
- scope the runs page playbook filter to the active workspace
- add browser coverage for workspace filtering on incidents and runs

## Verification
- cd ui && npm run lint && npm run test:e2e

Closes #38
Related: opensoar-hq/opensoar-ee#48