### PR TITLE
Add tenant ownership controls to playbook and integration admin UI

### DIFF
--- a/ui/e2e/enterprise-flows.spec.ts
+++ b/ui/e2e/enterprise-flows.spec.ts
@@ -162,3 +162,24 @@ test('applies workspace selection to incidents and runs pages', async ({ page })
   await expect(page.getByRole('button', { name: /Northwind Playbook/ })).toBeVisible()
   await expect(page.getByText('Global Playbook')).toHaveCount(0)
 })
+
+test('assigns ownership to a global playbook', async ({ page }) => {
+  await mockEnterpriseApi(page)
+  await page.goto('/playbooks')
+
+  await expect(page.getByText('Global Playbook')).toBeVisible()
+  await page.getByLabel('Assign owner').nth(1).selectOption('northwind')
+  await expect(page.getByText('Owner: northwind')).toBeVisible()
+})
+
+test('assigns ownership to a global integration and shows migration queue', async ({ page }) => {
+  await mockEnterpriseApi(page)
+  await page.goto('/settings')
+
+  await expect(page.getByText('Global Slack')).toBeVisible()
+  await page.getByLabel('Assign owner').first().selectOption('northwind')
+  await expect(page.getByText('owner: northwind')).toBeVisible()
+
+  await page.getByRole('button', { name: 'Enterprise' }).click()
+  await expect(page.getByRole('heading', { name: 'Global Resource Migration' })).toBeVisible()
+})

--- a/ui/e2e/support/mockEnterpriseApi.ts
+++ b/ui/e2e/support/mockEnterpriseApi.ts
@@ -93,6 +93,29 @@ interface MockEnterpriseState {
   analyst: Analyst | null
   authCapabilities: AuthCapabilities
   analysts: Analyst[]
+  integrations: {
+    id: string
+    integration_type: string
+    name: string
+    partner: string | null
+    enabled: boolean
+    health_status: string | null
+    last_health_check: string | null
+    created_at: string
+  }[]
+  playbooks: {
+    id: string
+    name: string
+    description: string | null
+    partner: string | null
+    module_path: string
+    function_name: string
+    trigger_type: string | null
+    trigger_config: Record<string, unknown>
+    enabled: boolean
+    version: number
+    created_at: string
+  }[]
   apiKeys: ApiKeyInfo[]
   apiKeyScopes: Record<string, ApiKeyScopeInfo>
   tenants: TenantInfo[]
@@ -106,6 +129,29 @@ interface MockEnterpriseOptions {
   analyst?: Analyst | null
   authCapabilities?: AuthCapabilities
   analysts?: Analyst[]
+  integrations?: {
+    id: string
+    integration_type: string
+    name: string
+    partner: string | null
+    enabled: boolean
+    health_status: string | null
+    last_health_check: string | null
+    created_at: string
+  }[]
+  playbooks?: {
+    id: string
+    name: string
+    description: string | null
+    partner: string | null
+    module_path: string
+    function_name: string
+    trigger_type: string | null
+    trigger_config: Record<string, unknown>
+    enabled: boolean
+    version: number
+    created_at: string
+  }[]
   apiKeys?: ApiKeyInfo[]
   apiKeyScopes?: Record<string, ApiKeyScopeInfo>
   tenants?: TenantInfo[]
@@ -163,6 +209,46 @@ function cloneState(options: MockEnterpriseOptions): MockEnterpriseState {
       providers: [],
     },
     analysts: options.analysts ?? [defaultAdmin, defaultAnalyst],
+    integrations: options.integrations ?? [
+      {
+        id: 'integration-1',
+        integration_type: 'slack',
+        name: 'Global Slack',
+        partner: null,
+        enabled: true,
+        health_status: null,
+        last_health_check: null,
+        created_at: now,
+      },
+    ],
+    playbooks: options.playbooks ?? [
+      {
+        id: 'playbook-1',
+        name: 'Northwind Playbook',
+        description: null,
+        partner: 'northwind',
+        module_path: 'playbooks.northwind',
+        function_name: 'run',
+        trigger_type: 'webhook',
+        trigger_config: {},
+        enabled: true,
+        version: 1,
+        created_at: now,
+      },
+      {
+        id: 'playbook-2',
+        name: 'Global Playbook',
+        description: null,
+        partner: null,
+        module_path: 'playbooks.global',
+        function_name: 'run',
+        trigger_type: 'webhook',
+        trigger_config: {},
+        enabled: true,
+        version: 1,
+        created_at: now,
+      },
+    ],
     apiKeys,
     apiKeyScopes: options.apiKeyScopes ?? {
       [apiKeys[0].id]: {
@@ -251,54 +337,56 @@ export async function mockEnterpriseApi(
       return
     }
 
+    if (method === 'GET' && pathname === '/api/v1/integrations') {
+      await fulfillJson(route, state.integrations)
+      return
+    }
+
+    if (pathname.startsWith('/api/v1/integrations/')) {
+      const integrationId = findId(pathname)
+      const integration = state.integrations.find((item) => item.id === integrationId)
+      if (!integration) {
+        await fulfillJson(route, { detail: 'Integration not found' }, 404)
+        return
+      }
+
+      if (method === 'PATCH') {
+        const body = requestBody(route)
+        Object.assign(integration, {
+          partner: typeof body.partner === 'string' ? body.partner : null,
+          enabled: typeof body.enabled === 'boolean' ? body.enabled : integration.enabled,
+        })
+        await fulfillJson(route, integration)
+        return
+      }
+    }
+
     if (method === 'GET' && pathname === '/api/v1/playbooks') {
       const tenantId = new URL(request.url()).searchParams.get('tenant_id')
       const playbooks = tenantId === 'tenant-1'
-        ? [
-            {
-              id: 'playbook-1',
-              name: 'Northwind Playbook',
-              description: null,
-              partner: 'northwind',
-              module_path: 'playbooks.northwind',
-              function_name: 'run',
-              trigger_type: 'webhook',
-              trigger_config: {},
-              enabled: true,
-              version: 1,
-              created_at: now,
-            },
-          ]
-        : [
-            {
-              id: 'playbook-1',
-              name: 'Northwind Playbook',
-              description: null,
-              partner: 'northwind',
-              module_path: 'playbooks.northwind',
-              function_name: 'run',
-              trigger_type: 'webhook',
-              trigger_config: {},
-              enabled: true,
-              version: 1,
-              created_at: now,
-            },
-            {
-              id: 'playbook-2',
-              name: 'Global Playbook',
-              description: null,
-              partner: null,
-              module_path: 'playbooks.global',
-              function_name: 'run',
-              trigger_type: 'webhook',
-              trigger_config: {},
-              enabled: true,
-              version: 1,
-              created_at: now,
-            },
-          ]
+        ? state.playbooks.filter((item) => item.partner === 'northwind')
+        : state.playbooks
       await fulfillJson(route, playbooks)
       return
+    }
+
+    if (pathname.startsWith('/api/v1/playbooks/')) {
+      const playbookId = findId(pathname)
+      const playbook = state.playbooks.find((item) => item.id === playbookId)
+      if (!playbook) {
+        await fulfillJson(route, { detail: 'Playbook not found' }, 404)
+        return
+      }
+
+      if (method === 'PATCH') {
+        const body = requestBody(route)
+        Object.assign(playbook, {
+          partner: typeof body.partner === 'string' ? body.partner : null,
+          enabled: typeof body.enabled === 'boolean' ? body.enabled : playbook.enabled,
+        })
+        await fulfillJson(route, playbook)
+        return
+      }
     }
 
     if (method === 'GET' && pathname === '/api/v1/dashboard/stats') {
@@ -632,6 +720,28 @@ export async function mockEnterpriseApi(
         await fulfillJson(route, state.dataRetention)
         return
       }
+    }
+
+    if (method === 'GET' && pathname === '/api/v1/tenants/admin/global-resources') {
+      await fulfillJson(route, {
+        integrations: state.integrations
+          .filter((item) => item.partner === null)
+          .map((item) => ({
+            id: item.id,
+            name: item.name,
+            resource_type: 'integration',
+            created_at: item.created_at,
+          })),
+        playbooks: state.playbooks
+          .filter((item) => item.partner === null)
+          .map((item) => ({
+            id: item.id,
+            name: item.name,
+            resource_type: 'playbook',
+            created_at: item.created_at,
+          })),
+      })
+      return
     }
 
     if (pathname === '/api/v1/compliance/data-retention/enforce' && method === 'POST') {

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -215,6 +215,7 @@ export interface Integration {
   id: string
   integration_type: string
   name: string
+  partner: string | null
   enabled: boolean
   health_status: string | null
   last_health_check: string | null
@@ -260,6 +261,18 @@ export interface TenantInfo {
   config: Record<string, unknown>
   alert_count: number
   analyst_count: number
+}
+
+export interface GlobalResourceSummary {
+  id: string
+  name: string
+  resource_type: string
+  created_at: string
+}
+
+export interface GlobalResourceInventory {
+  integrations: GlobalResourceSummary[]
+  playbooks: GlobalResourceSummary[]
 }
 
 export interface SSOProviderInfo {
@@ -468,6 +481,7 @@ export const api = {
   },
   tenants: {
     list: () => fetchJSON<TenantInfo[]>('/tenants'),
+    globalResources: () => fetchJSON<GlobalResourceInventory>('/tenants/admin/global-resources'),
     create: (data: {
       name: string
       slug: string

--- a/ui/src/pages/PlaybooksListPage.tsx
+++ b/ui/src/pages/PlaybooksListPage.tsx
@@ -11,8 +11,18 @@ import { Input } from '@/components/ui/Input'
 import { CardSkeleton } from '@/components/ui/Skeleton'
 import { PageTransition, StaggerParent, StaggerChild } from '@/components/ui/PageTransition'
 import { useToast } from '@/components/ui/Toast'
+import { Select } from '@/components/ui/Select'
+import { useAuth } from '@/contexts/AuthContext'
 
-function PlaybookCard({ playbook }: { playbook: Parameters<typeof api.playbooks.update>[1] & { id: string; name: string; description: string | null; module_path: string; function_name: string; trigger_type: string | null; trigger_config: Record<string, unknown>; enabled: boolean; version: number } }) {
+function PlaybookCard({
+  playbook,
+  ownerOptions,
+  canManageOwnership,
+}: {
+  playbook: Parameters<typeof api.playbooks.update>[1] & { id: string; name: string; description: string | null; partner: string | null; module_path: string; function_name: string; trigger_type: string | null; trigger_config: Record<string, unknown>; enabled: boolean; version: number }
+  ownerOptions: { value: string; label: string }[]
+  canManageOwnership: boolean
+}) {
   const queryClient = useQueryClient()
   const toast = useToast()
   const [showTrigger, setShowTrigger] = useState(false)
@@ -31,6 +41,18 @@ function PlaybookCard({ playbook }: { playbook: Parameters<typeof api.playbooks.
     },
     onError: () => {
       toast.error('Failed to trigger playbook', `Could not start ${playbook.name}`)
+    },
+  })
+
+  const ownershipMutation = useMutation({
+    mutationFn: (partner: string) => api.playbooks.update(playbook.id, { partner: partner || null }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['playbooks'] })
+      queryClient.invalidateQueries({ queryKey: ['ee-global-resources'] })
+      toast.success('Playbook ownership updated')
+    },
+    onError: () => {
+      toast.error('Failed to update playbook ownership')
     },
   })
 
@@ -57,6 +79,25 @@ function PlaybookCard({ playbook }: { playbook: Parameters<typeof api.playbooks.
               <span>Module: <code className="text-[11px] px-1 py-0.5 bg-bg rounded text-heading">{playbook.module_path}</code></span>
               <span>Function: <code className="text-[11px] px-1 py-0.5 bg-bg rounded text-heading">{playbook.function_name}</code></span>
             </div>
+
+            <div className="mt-2 text-[11px] text-muted">
+              Owner: {playbook.partner || 'Global / unowned'}
+            </div>
+
+            {canManageOwnership && (
+              <div className="mt-2 max-w-xs">
+                <label htmlFor={`playbook-owner-${playbook.id}`} className="block text-[11px] text-muted mb-1">
+                  Assign owner
+                </label>
+                <Select
+                  id={`playbook-owner-${playbook.id}`}
+                  value={playbook.partner || ''}
+                  onChange={(value) => ownershipMutation.mutate(value)}
+                  options={ownerOptions}
+                  className="w-full"
+                />
+              </div>
+            )}
 
             {playbook.trigger_config && Object.keys(playbook.trigger_config).length > 0 && (
               <div className="mt-2 text-[11px] text-muted">
@@ -106,10 +147,24 @@ function PlaybookCard({ playbook }: { playbook: Parameters<typeof api.playbooks.
 }
 
 export function PlaybooksListPage() {
+  const { analyst } = useAuth()
   const { data: playbooks, isLoading } = useQuery({
     queryKey: ['playbooks'],
     queryFn: api.playbooks.list,
   })
+  const { data: tenants = [] } = useQuery({
+    queryKey: ['playbook-owner-tenants'],
+    queryFn: api.tenants.list,
+    enabled: analyst?.role === 'admin',
+    retry: false,
+  })
+  const ownerOptions = [
+    { value: '', label: 'Global / unowned' },
+    ...tenants.map((tenant) => ({
+      value: tenant.legacy_partner_key || tenant.slug,
+      label: tenant.name,
+    })),
+  ]
 
   if (isLoading) {
     return (
@@ -136,7 +191,11 @@ export function PlaybooksListPage() {
         <StaggerParent className="grid gap-3">
           {playbooks.map((pb) => (
             <StaggerChild key={pb.id}>
-              <PlaybookCard playbook={pb} />
+              <PlaybookCard
+                playbook={pb}
+                ownerOptions={ownerOptions}
+                canManageOwnership={analyst?.role === 'admin'}
+              />
             </StaggerChild>
           ))}
         </StaggerParent>

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -26,6 +26,7 @@ type Tab = 'integrations' | 'api-keys' | 'analysts' | 'enterprise'
 function IntegrationsTab() {
   const queryClient = useQueryClient()
   const toast = useToast()
+  const { analyst } = useAuth()
   const [showDialog, setShowDialog] = useState(false)
   const [form, setForm] = useState({ integration_type: '', name: '', config: '{}' })
 
@@ -37,6 +38,13 @@ function IntegrationsTab() {
   const { data: availableTypes } = useQuery({
     queryKey: ['integration-types'],
     queryFn: api.integrations.types,
+  })
+
+  const { data: tenants = [] } = useQuery({
+    queryKey: ['integration-owner-tenants'],
+    queryFn: api.tenants.list,
+    enabled: analyst?.role === 'admin',
+    retry: false,
   })
 
   const healthMutation = useMutation({
@@ -89,6 +97,19 @@ function IntegrationsTab() {
     },
     onError: () => {
       toast.error('Failed to delete integration')
+    },
+  })
+
+  const ownershipMutation = useMutation({
+    mutationFn: ({ id, partner }: { id: string; partner: string }) =>
+      api.integrations.update(id, { partner: partner || null }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['integrations'] })
+      queryClient.invalidateQueries({ queryKey: ['ee-global-resources'] })
+      toast.success('Integration ownership updated')
+    },
+    onError: () => {
+      toast.error('Failed to update integration ownership')
     },
   })
 
@@ -168,7 +189,29 @@ function IntegrationsTab() {
               <Plug size={14} className="text-muted shrink-0" />
               <div className="flex-1 min-w-0">
                 <div className="text-sm text-heading font-medium">{int.name}</div>
-                <div className="text-[11px] text-muted">{int.integration_type}</div>
+                <div className="text-[11px] text-muted">
+                  {int.integration_type} · owner: {int.partner || 'Global / unowned'}
+                </div>
+                {analyst?.role === 'admin' && (
+                  <div className="mt-2 max-w-xs">
+                    <label htmlFor={`integration-owner-${int.id}`} className="block text-[11px] text-muted mb-1">
+                      Assign owner
+                    </label>
+                    <Select
+                      id={`integration-owner-${int.id}`}
+                      value={int.partner || ''}
+                      onChange={(value) => ownershipMutation.mutate({ id: int.id, partner: value })}
+                      options={[
+                        { value: '', label: 'Global / unowned' },
+                        ...tenants.map((tenant) => ({
+                          value: tenant.legacy_partner_key || tenant.slug,
+                          label: tenant.name,
+                        })),
+                      ]}
+                      className="w-full"
+                    />
+                  </div>
+                )}
               </div>
               {int.health_status && (
                 <span className={`text-[11px] px-2 py-0.5 rounded ${int.health_status === 'healthy' ? 'bg-success/15 text-success' : 'bg-danger/15 text-danger'}`}>
@@ -418,6 +461,12 @@ function EnterpriseTab() {
   const providersQuery = useQuery({
     queryKey: ['ee-sso-providers'],
     queryFn: api.ssoProviders.list,
+    retry: false,
+  })
+
+  const globalResourcesQuery = useQuery({
+    queryKey: ['ee-global-resources'],
+    queryFn: api.tenants.globalResources,
     retry: false,
   })
 
@@ -1045,6 +1094,53 @@ function EnterpriseTab() {
               <Button size="sm" variant="primary" onClick={() => updateRetentionMutation.mutate()}>
                 Save Retention Policy
               </Button>
+            </div>
+          </Card>
+        )}
+      </div>
+
+      <div>
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-sm font-medium text-heading m-0">Global Resource Migration</h3>
+        </div>
+        {globalResourcesQuery.isError ? (
+          <EmptyState
+            icon={<Plug size={28} />}
+            title="Global resource inventory unavailable"
+            description="The migration inventory endpoint is not available in this deployment."
+          />
+        ) : globalResourcesQuery.isLoading ? (
+          <CardSkeleton lines={2} />
+        ) : (
+          <Card className="p-4 space-y-3">
+            <div className="text-xs text-muted">
+              Global / unowned records are still admin-managed. Assign them to a tenant from the Playbooks page or the Integrations tab here.
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <div className="text-[11px] uppercase tracking-wide text-muted mb-2">Playbooks</div>
+                {globalResourcesQuery.data && globalResourcesQuery.data.playbooks.length > 0 ? (
+                  <div className="space-y-1">
+                    {globalResourcesQuery.data.playbooks.map((item) => (
+                      <div key={item.id} className="text-sm text-heading">{item.name}</div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="text-sm text-muted">No unowned playbooks</div>
+                )}
+              </div>
+              <div>
+                <div className="text-[11px] uppercase tracking-wide text-muted mb-2">Integrations</div>
+                {globalResourcesQuery.data && globalResourcesQuery.data.integrations.length > 0 ? (
+                  <div className="space-y-1">
+                    {globalResourcesQuery.data.integrations.map((item) => (
+                      <div key={item.id} className="text-sm text-heading">{item.name}</div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="text-sm text-muted">No unowned integrations</div>
+                )}
+              </div>
             </div>
           </Card>
         )}


### PR DESCRIPTION
## Summary
- add ownership controls to the playbooks page and integrations admin surface
- surface a migration queue for global/unowned resources in enterprise settings
- extend the browser suite to cover playbook and integration ownership assignment

## Verification
- cd ui && npm run lint
- cd ui && npm run test:e2e

Closes #39
Related: opensoar-hq/opensoar-ee#46