### PR TITLE
Fix UI build regression after tenant and ownership API changes

### DIFF
--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -392,7 +392,7 @@ export const api = {
   playbooks: {
     list: (tenantId?: string) => fetchJSON<Playbook[]>(`/playbooks${tenantId ? `?tenant_id=${tenantId}` : ''}`),
     get: (id: string) => fetchJSON<Playbook>(`/playbooks/${id}`),
-    update: (id: string, data: { enabled?: boolean }) =>
+    update: (id: string, data: { enabled?: boolean; partner?: string | null }) =>
       patchJSON<Playbook>(`/playbooks/${id}`, data),
     run: (id: string, data?: { alert_id?: string }) =>
       postJSON<{ message: string; celery_task_id: string }>(`/playbooks/${id}/run`, data || {}),
@@ -421,9 +421,9 @@ export const api = {
   integrations: {
     list: () => fetchJSON<Integration[]>('/integrations'),
     types: () => fetchJSON<{ type: string; display_name: string; description: string }[]>('/integrations/types'),
-    create: (data: { integration_type: string; name: string; config: Record<string, unknown>; enabled?: boolean }) =>
+    create: (data: { integration_type: string; name: string; partner?: string | null; config: Record<string, unknown>; enabled?: boolean }) =>
       postJSON<Integration>('/integrations', data),
-    update: (id: string, data: { name?: string; config?: Record<string, unknown>; enabled?: boolean }) =>
+    update: (id: string, data: { name?: string; partner?: string | null; config?: Record<string, unknown>; enabled?: boolean }) =>
       patchJSON<Integration>(`/integrations/${id}`, data),
     delete: (id: string) => deleteJSON(`/integrations/${id}`),
     healthCheck: (id: string) => postJSON<{ healthy: boolean; message: string; details: Record<string, unknown> | null }>(`/integrations/${id}/health`, {}),

--- a/ui/src/pages/AlertDetailPage.tsx
+++ b/ui/src/pages/AlertDetailPage.tsx
@@ -425,7 +425,7 @@ export function AlertDetailPage() {
 
   const { data: playbooks } = useQuery({
     queryKey: ['playbooks'],
-    queryFn: api.playbooks.list,
+    queryFn: () => api.playbooks.list(),
   })
 
   const { data: availableActions } = useQuery({

--- a/ui/src/pages/PlaybooksListPage.tsx
+++ b/ui/src/pages/PlaybooksListPage.tsx
@@ -150,7 +150,7 @@ export function PlaybooksListPage() {
   const { analyst } = useAuth()
   const { data: playbooks, isLoading } = useQuery({
     queryKey: ['playbooks'],
-    queryFn: api.playbooks.list,
+    queryFn: () => api.playbooks.list(),
   })
   const { data: tenants = [] } = useQuery({
     queryKey: ['playbook-owner-tenants'],

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -20,7 +20,7 @@ export function RunDetailPage() {
 
   const { data: playbooks } = useQuery({
     queryKey: ['playbooks'],
-    queryFn: api.playbooks.list,
+    queryFn: () => api.playbooks.list(),
   })
 
   if (isLoading) {


### PR DESCRIPTION
## Summary
- repair stale React Query call sites for playbook list helpers
- widen the UI update payload typings for ownership-aware playbook/integration updates
- restore a green core UI image build on main

## Verification
- cd ui && npm run lint
- cd ui && npm run build

Related: failed main runs 23980408788, 23981115620, 23981445014