### PR TITLE
docs: adopt PwnKit Labs umbrella tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,9 @@ Areas where help is most needed:
 
 ---
 
-## Part of the open-source modern SOC
+## Part of PwnKit Labs
 
-OpenSOAR is one piece of a three-part open-source security stack:
+**Open-source adversarial security for the agentic AI era.** OpenSOAR is one piece of the open-source PwnKit Labs stack:
 - **[pwnkit](https://github.com/PwnKit-Labs/pwnkit)** — AI agent pentester (detect)
 - **[foxguard](https://github.com/PwnKit-Labs/foxguard)** — Rust security scanner (prevent)
 - **[opensoar](https://github.com/opensoar-hq/opensoar-core)** — Python-native SOAR platform (respond)


### PR DESCRIPTION
## Summary

Replaces the \"open-source modern SOC\" framing with the PwnKit Labs umbrella tagline:

> **Open-source adversarial security for the agentic AI era.** OpenSOAR is one piece of the open-source PwnKit Labs stack:
> - **pwnkit** — AI agent pentester (detect)
> - **foxguard** — Rust security scanner (prevent)
> - **opensoar** — Python-native SOAR platform (respond)

## Why

The \"modern SOC\" framing was dated and enterprise vendor-speak. The umbrella tagline lands the positioning for PwnKit Labs as a whole — open-source, adversarial-minded, and built for a world where AI agents are writing production code. Consistent with the same section shape now used in the foxguard and pwnkit READMEs.

## Scope

- \`README.md\` — 2 lines changed (heading and lead sentence of the existing umbrella section). Bullets unchanged.

## Refs

Companion PRs in other PwnKit Labs repos:
- foxguard: PwnKit-Labs/foxguard#56
- pwnkit: PwnKit-Labs/pwnkit (new PR)
- pwnkit-cloud: PwnKit-Labs/pwnkit-cloud (new PR)