### PR TITLE
docs: drop redundant 'A PwnKit Labs product' callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 <h1 align="center">OpenSOAR</h1>
 <p align="center"><strong>Open-source SOAR platform. Write security automation in Python, not YAML.</strong></p>
-<p align="center"><strong>A PwnKit Labs product.</strong></p>
 
 <p align="center">
   <a href="https://github.com/opensoar-hq/opensoar-core/actions/workflows/build.yml"><img src="https://github.com/opensoar-hq/opensoar-core/actions/workflows/build.yml/badge.svg" alt="CI"></a>


### PR DESCRIPTION
## Summary

Matches the cleanup landed in PwnKit-Labs/foxguard#57 and PwnKit-Labs/pwnkit (pending). Drops the redundant \"A PwnKit Labs product.\" callout near the top of the README. The bottom \"Part of PwnKit Labs\" section (added earlier) is the single source of umbrella branding.

## Changes

- **Dropped** \`<p align=\"center\"><strong>A PwnKit Labs product.</strong></p>\` under the main tagline (one line removed)

## Result

**PwnKit Labs mention count: 3 → 2** (both in the same bottom umbrella section).

## Refs

- PwnKit-Labs/foxguard#57 (the equivalent cleanup in foxguard)
- opensoar-hq/opensoar-core#55 (the original umbrella tagline adoption)