### PR TITLE
Harden alert/incident write auth and stabilize settings loading

### DIFF
--- a/src/opensoar/api/actions.py
+++ b/src/opensoar/api/actions.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from opensoar.api.deps import get_db
-from opensoar.auth.jwt import get_current_analyst
+from opensoar.auth.jwt import require_analyst
 from opensoar.models.activity import Activity
 from opensoar.models.analyst import Analyst
 from opensoar.schemas.action import (
@@ -60,7 +60,7 @@ async def list_available_actions(ioc_type: str | None = None):
 async def execute_action(
     body: ActionExecuteRequest,
     session: AsyncSession = Depends(get_db),
-    analyst: Analyst | None = Depends(get_current_analyst),
+    analyst: Analyst = Depends(require_analyst),
 ):
     action = next((a for a in AVAILABLE_ACTIONS if a.name == body.action_name), None)
     if not action:
@@ -86,8 +86,8 @@ async def execute_action(
     if body.alert_id:
         activity = Activity(
             alert_id=uuid.UUID(body.alert_id),
-            analyst_id=analyst.id if analyst else None,
-            analyst_username=analyst.username if analyst else None,
+            analyst_id=analyst.id,
+            analyst_username=analyst.username,
             action="manual_action",
             detail=f"Executed {body.action_name} on {body.ioc_type}: {body.ioc_value}",
             metadata_json={

--- a/src/opensoar/api/alerts.py
+++ b/src/opensoar/api/alerts.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from opensoar.api.deps import get_db
 from opensoar.auth.jwt import get_current_analyst, require_analyst
-from opensoar.auth.rbac import Permission, has_permission
+from opensoar.auth.rbac import Permission, has_permission, require_permission
 from opensoar.models.activity import Activity
 from opensoar.models.alert import Alert
 from opensoar.models.analyst import Analyst
@@ -322,7 +322,7 @@ async def update_alert(
     update: AlertUpdate,
     request: Request,
     session: AsyncSession = Depends(get_db),
-    analyst: Analyst | None = Depends(get_current_analyst),
+    analyst: Analyst = Depends(require_permission(Permission.ALERTS_UPDATE)),
 ):
     result = await session.execute(select(Alert).where(Alert.id == alert_id))
     alert = result.scalar_one_or_none()
@@ -436,7 +436,7 @@ async def claim_alert(
     alert_id: uuid.UUID,
     request: Request,
     session: AsyncSession = Depends(get_db),
-    analyst: Analyst | None = Depends(get_current_analyst),
+    analyst: Analyst = Depends(require_permission(Permission.ALERTS_UPDATE)),
 ):
     """Claim an alert for the current analyst."""
     result = await session.execute(select(Alert).where(Alert.id == alert_id))
@@ -453,18 +453,15 @@ async def claim_alert(
         session=session,
     )
 
-    if analyst:
-        alert.assigned_to = analyst.id
-        alert.assigned_username = analyst.username
-        session.add(Activity(
-            alert_id=alert_id,
-            analyst_id=analyst.id,
-            analyst_username=analyst.username,
-            action="claimed",
-            detail=f"Claimed by {analyst.display_name}",
-        ))
-    else:
-        raise HTTPException(status_code=401, detail="Authentication required to claim alerts")
+    alert.assigned_to = analyst.id
+    alert.assigned_username = analyst.username
+    session.add(Activity(
+        alert_id=alert_id,
+        analyst_id=analyst.id,
+        analyst_username=analyst.username,
+        action="claimed",
+        detail=f"Claimed by {analyst.display_name}",
+    ))
 
     if alert.status == "new":
         alert.status = "in_progress"
@@ -486,7 +483,7 @@ async def claim_alert(
 async def bulk_update_alerts(
     body: BulkAlertUpdate,
     session: AsyncSession = Depends(get_db),
-    analyst: Analyst = Depends(require_analyst),
+    analyst: Analyst = Depends(require_permission(Permission.ALERTS_UPDATE)),
 ):
     """Apply a bulk operation to multiple alerts."""
     updated = 0
@@ -574,12 +571,24 @@ async def bulk_update_alerts(
 @router.delete("/{alert_id}")
 async def delete_alert(
     alert_id: uuid.UUID,
+    request: Request,
     session: AsyncSession = Depends(get_db),
+    analyst: Analyst = Depends(require_permission(Permission.ALERTS_DELETE)),
 ):
     result = await session.execute(select(Alert).where(Alert.id == alert_id))
     alert = result.scalar_one_or_none()
     if not alert:
         raise HTTPException(status_code=404, detail="Alert not found")
+
+    await enforce_tenant_access(
+        request.app,
+        resource=alert,
+        resource_type="alert",
+        action="delete",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
 
     await session.delete(alert)
     await session.commit()

--- a/src/opensoar/api/incidents.py
+++ b/src/opensoar/api/incidents.py
@@ -247,7 +247,7 @@ async def update_incident(
     update: IncidentUpdate,
     request: Request,
     session: AsyncSession = Depends(get_db),
-    analyst: Analyst | None = Depends(get_current_analyst),
+    analyst: Analyst = Depends(require_permission(Permission.INCIDENTS_UPDATE)),
 ):
     result = await session.execute(
         select(Incident).where(Incident.id == incident_id)
@@ -353,7 +353,7 @@ async def link_alert(
     body: LinkAlertRequest,
     request: Request,
     session: AsyncSession = Depends(get_db),
-    analyst: Analyst | None = Depends(get_current_analyst),
+    analyst: Analyst = Depends(require_permission(Permission.INCIDENTS_UPDATE)),
 ):
     # Verify incident exists
     result = await session.execute(
@@ -463,7 +463,7 @@ async def unlink_alert(
     alert_id: uuid.UUID,
     request: Request,
     session: AsyncSession = Depends(get_db),
-    analyst: Analyst | None = Depends(get_current_analyst),
+    analyst: Analyst = Depends(require_permission(Permission.INCIDENTS_UPDATE)),
 ):
     result = await session.execute(
         select(IncidentAlert).where(

--- a/src/opensoar/api/observables.py
+++ b/src/opensoar/api/observables.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from opensoar.api.deps import get_db
 from opensoar.auth.jwt import get_current_analyst
+from opensoar.auth.rbac import Permission, require_permission
 from opensoar.plugins import apply_tenant_access_query, enforce_tenant_access
 from opensoar.models.analyst import Analyst
 from opensoar.models.observable import Observable
@@ -71,7 +72,7 @@ async def create_observable(
     data: ObservableCreate,
     request: Request,
     session: AsyncSession = Depends(get_db),
-    analyst: Analyst | None = Depends(get_current_analyst),
+    analyst: Analyst = Depends(require_permission(Permission.OBSERVABLES_MANAGE)),
 ):
     # Dedup by type + value
     existing = await session.execute(
@@ -137,7 +138,7 @@ async def add_enrichment(
     data: EnrichmentCreate,
     request: Request,
     session: AsyncSession = Depends(get_db),
-    analyst: Analyst | None = Depends(get_current_analyst),
+    analyst: Analyst = Depends(require_permission(Permission.OBSERVABLES_MANAGE)),
 ):
     result = await session.execute(
         select(Observable).where(Observable.id == observable_id)

--- a/src/opensoar/config.py
+++ b/src/opensoar/config.py
@@ -52,7 +52,11 @@ class Settings(BaseSettings):
     def effective_celery_broker_url(self) -> str:
         return self.celery_broker_url or self.redis_url
 
-    model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
+    model_config = {
+        "env_file": ".env",
+        "env_file_encoding": "utf-8",
+        "extra": "ignore",
+    }
 
 
 settings = Settings()

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,0 +1,30 @@
+"""Tests for manual action execution API."""
+from __future__ import annotations
+
+
+class TestActionsAPI:
+    async def test_execute_action_requires_auth(self, client):
+        resp = await client.post(
+            "/api/v1/actions/execute",
+            json={
+                "action_name": "unknown_action",
+                "ioc_type": "ips",
+                "ioc_value": "203.0.113.42",
+            },
+        )
+        assert resp.status_code == 401
+
+    async def test_execute_action_with_auth(self, client, registered_analyst):
+        resp = await client.post(
+            "/api/v1/actions/execute",
+            json={
+                "action_name": "unknown_action",
+                "ioc_type": "ips",
+                "ioc_value": "203.0.113.42",
+            },
+            headers=registered_analyst["headers"],
+        )
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["status"] == "failed"
+        assert "Unknown action" in payload["error"]

--- a/tests/test_alerts_api.py
+++ b/tests/test_alerts_api.py
@@ -295,6 +295,14 @@ class TestUpdateAlert:
         )
         assert resp.status_code == 404
 
+    async def test_update_requires_auth(self, client, sample_alert_via_api):
+        alert_id = sample_alert_via_api["alert_id"]
+        resp = await client.patch(
+            f"/api/v1/alerts/{alert_id}",
+            json={"severity": "critical"},
+        )
+        assert resp.status_code == 401
+
     async def test_tenant_validator_blocks_alert_update(self, client, registered_analyst):
         from opensoar.main import app
         from opensoar.plugins import register_tenant_access_validator
@@ -344,17 +352,28 @@ class TestClaimAlert:
 
 
 class TestDeleteAlert:
-    async def test_delete_alert(self, client, sample_alert_via_api):
+    async def test_delete_alert(self, client, sample_alert_via_api, registered_analyst):
         alert_id = sample_alert_via_api["alert_id"]
-        resp = await client.delete(f"/api/v1/alerts/{alert_id}")
+        resp = await client.delete(
+            f"/api/v1/alerts/{alert_id}",
+            headers=registered_analyst["headers"],
+        )
         assert resp.status_code == 200
 
         resp = await client.get(f"/api/v1/alerts/{alert_id}")
         assert resp.status_code == 404
 
-    async def test_delete_nonexistent(self, client):
-        resp = await client.delete(f"/api/v1/alerts/{uuid.uuid4()}")
+    async def test_delete_nonexistent(self, client, registered_analyst):
+        resp = await client.delete(
+            f"/api/v1/alerts/{uuid.uuid4()}",
+            headers=registered_analyst["headers"],
+        )
         assert resp.status_code == 404
+
+    async def test_delete_requires_auth(self, client, sample_alert_via_api):
+        alert_id = sample_alert_via_api["alert_id"]
+        resp = await client.delete(f"/api/v1/alerts/{alert_id}")
+        assert resp.status_code == 401
 
 
 class TestBulkOperations:

--- a/tests/test_incidents_api.py
+++ b/tests/test_incidents_api.py
@@ -72,6 +72,20 @@ class TestIncidentCRUD:
         assert resp.json()["severity"] == "critical"
         assert resp.json()["status"] == "investigating"
 
+    async def test_update_incident_requires_auth(self, client, registered_analyst):
+        create = await client.post(
+            "/api/v1/incidents",
+            json={"title": "Needs Auth", "severity": "low"},
+            headers=registered_analyst["headers"],
+        )
+        incident_id = create.json()["id"]
+
+        resp = await client.patch(
+            f"/api/v1/incidents/{incident_id}",
+            json={"severity": "critical"},
+        )
+        assert resp.status_code == 401
+
     async def test_close_incident(self, client, registered_analyst):
         resp = await client.post(
             "/api/v1/incidents",
@@ -111,6 +125,21 @@ class TestIncidentAlertLinking:
         # Verify alert count
         resp = await client.get(f"/api/v1/incidents/{incident_id}")
         assert resp.json()["alert_count"] >= 1
+
+    async def test_link_alert_requires_auth(self, client, registered_analyst, sample_alert_via_api):
+        create = await client.post(
+            "/api/v1/incidents",
+            json={"title": "Link Auth", "severity": "high"},
+            headers=registered_analyst["headers"],
+        )
+        incident_id = create.json()["id"]
+        alert_id = sample_alert_via_api["alert_id"]
+
+        resp = await client.post(
+            f"/api/v1/incidents/{incident_id}/alerts",
+            json={"alert_id": str(alert_id)},
+        )
+        assert resp.status_code == 401
 
     async def test_list_incident_alerts(self, client, registered_analyst, sample_alert_via_api):
         resp = await client.post(
@@ -152,6 +181,26 @@ class TestIncidentAlertLinking:
             headers=registered_analyst["headers"],
         )
         assert resp.status_code == 200
+
+    async def test_unlink_alert_requires_auth(self, client, registered_analyst, sample_alert_via_api):
+        create = await client.post(
+            "/api/v1/incidents",
+            json={"title": "Unlink Auth", "severity": "low"},
+            headers=registered_analyst["headers"],
+        )
+        incident_id = create.json()["id"]
+        alert_id = sample_alert_via_api["alert_id"]
+
+        await client.post(
+            f"/api/v1/incidents/{incident_id}/alerts",
+            json={"alert_id": str(alert_id)},
+            headers=registered_analyst["headers"],
+        )
+
+        resp = await client.delete(
+            f"/api/v1/incidents/{incident_id}/alerts/{alert_id}",
+        )
+        assert resp.status_code == 401
 
 
 class TestIncidentFiltering:

--- a/tests/test_observables.py
+++ b/tests/test_observables.py
@@ -84,6 +84,27 @@ class TestObservablesCRUD:
         )
         assert resp1.json()["id"] == resp2.json()["id"]
 
+    async def test_create_observable_requires_auth(self, client):
+        resp = await client.post(
+            "/api/v1/observables",
+            json={"type": "ip", "value": "198.51.100.200", "source": "auth-test"},
+        )
+        assert resp.status_code == 401
+
+    async def test_add_enrichment_requires_auth(self, client, registered_analyst):
+        create = await client.post(
+            "/api/v1/observables",
+            json={"type": "ip", "value": "203.0.113.250", "source": "auth-test"},
+            headers=registered_analyst["headers"],
+        )
+        obs_id = create.json()["id"]
+
+        resp = await client.post(
+            f"/api/v1/observables/{obs_id}/enrichments",
+            json={"source": "vt", "data": {"score": 10}, "malicious": True, "score": 10},
+        )
+        assert resp.status_code == 401
+
 
 class TestCorrelationEngine:
     async def test_auto_correlate_by_source_ip(self, client, registered_analyst):


### PR DESCRIPTION
## Summary
- enforce explicit RBAC dependencies on alert and incident mutating endpoints so anonymous callers cannot patch/delete/link/unlink resources in core-only deployments
- enforce authenticated access on observable mutation and manual action execution endpoints
- enforce tenant access on alert comment create/edit endpoints so authenticated users cannot mutate comments outside tenant scope
- add regression tests that assert 401 for unauthenticated write attempts and 403 for tenant-blocked comment mutations
- make settings ignore unrelated .env keys so local helper vars (for port overrides) do not break app/test startup

## Why
Core should remain secure even when no tenant-access plugin is registered, and tenant boundaries should still hold for authenticated users. Optional auth dependencies and missing tenant checks on write paths created avoidable mutation risks.

Closes #57
Closes #59
Closes #60

## Validation
- ruff check src/opensoar/config.py src/opensoar/api/alerts.py src/opensoar/api/incidents.py src/opensoar/api/observables.py src/opensoar/api/actions.py src/opensoar/api/activities.py tests/test_alerts_api.py tests/test_incidents_api.py tests/test_observables.py tests/test_actions.py tests/test_activities_api.py
- pytest tests/test_security_fixes.py::TestJWTSecretValidation::test_nonempty_jwt_secret_passes_validation -q
- pytest tests/test_alerts_api.py tests/test_incidents_api.py tests/test_observables.py tests/test_actions.py tests/test_activities_api.py -q
