### PR TITLE
Enforce tenant access for alert comment create/edit

### DIFF
--- a/src/opensoar/api/activities.py
+++ b/src/opensoar/api/activities.py
@@ -63,6 +63,7 @@ async def list_alert_activities(
 async def add_comment(
     alert_id: uuid.UUID,
     body: CommentCreate,
+    request: Request,
     session: AsyncSession = Depends(get_db),
     analyst: Analyst = Depends(require_analyst),
 ):
@@ -72,6 +73,16 @@ async def add_comment(
     ).scalar_one_or_none()
     if not alert:
         raise HTTPException(status_code=404, detail="Alert not found")
+
+    await enforce_tenant_access(
+        request.app,
+        resource=alert,
+        resource_type="alert",
+        action="update",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
 
     activity = Activity(
         alert_id=alert_id,
@@ -91,10 +102,27 @@ async def edit_comment(
     alert_id: uuid.UUID,
     comment_id: uuid.UUID,
     body: CommentUpdate,
+    request: Request,
     session: AsyncSession = Depends(get_db),
     analyst: Analyst = Depends(require_analyst),
 ):
     """Edit a comment. Only the author can edit. Stores edit history in metadata_json."""
+    alert = (
+        await session.execute(select(Alert).where(Alert.id == alert_id))
+    ).scalar_one_or_none()
+    if not alert:
+        raise HTTPException(status_code=404, detail="Alert not found")
+
+    await enforce_tenant_access(
+        request.app,
+        resource=alert,
+        resource_type="alert",
+        action="update",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
+
     activity = (
         await session.execute(
             select(Activity).where(

--- a/tests/test_activities_api.py
+++ b/tests/test_activities_api.py
@@ -32,3 +32,66 @@ class TestActivityTenantHooks:
             app.state.tenant_access_validators = original_validators
 
         assert blocked.status_code == 403
+
+    async def test_tenant_validator_blocks_alert_comment_create(self, client, registered_analyst):
+        from opensoar.main import app
+
+        created = await client.post(
+            "/api/v1/webhooks/alerts",
+            json={"rule_name": "Blocked Comment Create", "severity": "low", "partner": "globex"},
+        )
+        alert_id = created.json()["alert_id"]
+
+        async def validator(**kwargs):
+            resource = kwargs.get("resource")
+            if resource is not None and getattr(resource, "partner", None) == "globex":
+                raise HTTPException(status_code=403, detail="Tenant access denied")
+
+        original_validators = list(app.state.tenant_access_validators)
+        app.state.tenant_access_validators = []
+        register_tenant_access_validator(app, validator)
+        try:
+            blocked = await client.post(
+                f"/api/v1/alerts/{alert_id}/comments",
+                json={"text": "This should be blocked"},
+                headers=registered_analyst["headers"],
+            )
+        finally:
+            app.state.tenant_access_validators = original_validators
+
+        assert blocked.status_code == 403
+
+    async def test_tenant_validator_blocks_alert_comment_edit(self, client, registered_analyst):
+        from opensoar.main import app
+
+        created = await client.post(
+            "/api/v1/webhooks/alerts",
+            json={"rule_name": "Blocked Comment Edit", "severity": "low", "partner": "globex"},
+        )
+        alert_id = created.json()["alert_id"]
+
+        comment = await client.post(
+            f"/api/v1/alerts/{alert_id}/comments",
+            json={"text": "Original comment"},
+            headers=registered_analyst["headers"],
+        )
+        comment_id = comment.json()["id"]
+
+        async def validator(**kwargs):
+            resource = kwargs.get("resource")
+            if resource is not None and getattr(resource, "partner", None) == "globex":
+                raise HTTPException(status_code=403, detail="Tenant access denied")
+
+        original_validators = list(app.state.tenant_access_validators)
+        app.state.tenant_access_validators = []
+        register_tenant_access_validator(app, validator)
+        try:
+            blocked = await client.patch(
+                f"/api/v1/alerts/{alert_id}/comments/{comment_id}",
+                json={"text": "Edited should be blocked"},
+                headers=registered_analyst["headers"],
+            )
+        finally:
+            app.state.tenant_access_validators = original_validators
+
+        assert blocked.status_code == 403


### PR DESCRIPTION
## Summary
- enforce tenant access on `POST /alerts/{id}/comments`
- enforce tenant access on `PATCH /alerts/{id}/comments/{comment_id}`
- add tenant-hook regression tests that assert `403` when comment create/edit is blocked

## Why
Authenticated access is not sufficient in multi-tenant mode; comment mutation must still be scoped to the parent alert tenant access policy.

Closes #60

## Validation
- `ruff check src/opensoar/api/activities.py tests/test_activities_api.py`
- `pytest tests/test_activities_api.py -q`
- `pytest tests/test_alerts_api.py tests/test_incidents_api.py tests/test_observables.py tests/test_actions.py tests/test_activities_api.py -q`
