### PR TITLE
Add Prometheus /metrics endpoint

### DIFF
--- a/docs/docs/engineering/architecture.md
+++ b/docs/docs/engineering/architecture.md
@@ -785,6 +785,53 @@ erDiagram
 
 ---
 
+## 9. Observability
+
+### Prometheus Metrics
+
+OpenSOAR exposes a Prometheus scrape endpoint at `GET /metrics` (no `/api/v1`
+prefix, no auth, not rate-limited). The endpoint returns the standard
+Prometheus text exposition format and is safe to scrape at any interval.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `opensoar_http_requests_total` | Counter | `method`, `path`, `status` | Every HTTP request handled by the API (the `/metrics` scrape itself is excluded). |
+| `opensoar_alerts_ingested_total` | Counter | `source` | Incremented on every webhook alert ingest; `source` is `webhook` or `elastic`. |
+| `opensoar_playbook_runs_total` | Counter | `playbook`, `status` | Incremented when a playbook run reaches a terminal state (`success`, `failed`, `cancelled`). |
+| `opensoar_playbook_run_duration_seconds` | Histogram | `playbook` | Duration of each playbook run, recorded by `PlaybookExecutor` when the run completes. |
+
+HTTP request recording is handled by `MetricsMiddleware`
+(`src/opensoar/middleware/metrics.py`). Alert and playbook metrics are emitted
+from the webhook handler and the playbook executor respectively.
+
+```mermaid
+flowchart LR
+    req["HTTP request"] --> mw["MetricsMiddleware"]
+    mw --> handler["Route handler"]
+    handler --> resp["Response"]
+    mw --> http_counter["opensoar_http_requests_total"]
+
+    webhook["Webhook /alerts"] --> alerts_counter["opensoar_alerts_ingested_total"]
+    executor["PlaybookExecutor.execute()"] --> runs_counter["opensoar_playbook_runs_total"]
+    executor --> runs_hist["opensoar_playbook_run_duration_seconds"]
+
+    scrape["Prometheus server"] -->|GET /metrics| endpoint["/metrics endpoint"]
+    endpoint --> registry["CollectorRegistry<br/>(render_metrics)"]
+    http_counter & alerts_counter & runs_counter & runs_hist --> registry
+```
+
+Sample Prometheus scrape config:
+
+```yaml
+scrape_configs:
+  - job_name: opensoar
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["opensoar-api:8000"]
+```
+
+---
+
 ## Tech Stack
 
 | Layer | Technology | Why |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "python-multipart>=0.0.18",
     "bcrypt>=4.2.0",
     "PyJWT>=2.9.0",
+    "prometheus-client>=0.21.0",
 ]
 
 [project.scripts]

--- a/src/opensoar/api/metrics.py
+++ b/src/opensoar/api/metrics.py
@@ -1,0 +1,15 @@
+"""FastAPI router exposing the Prometheus scrape endpoint at /metrics."""
+from __future__ import annotations
+
+from fastapi import APIRouter
+from starlette.responses import Response
+
+from opensoar.middleware.metrics import metrics_content_type, render_metrics
+
+router = APIRouter(tags=["metrics"])
+
+
+@router.get("/metrics", include_in_schema=False)
+async def metrics() -> Response:
+    """Return metrics in Prometheus text exposition format."""
+    return Response(content=render_metrics(), media_type=metrics_content_type())

--- a/src/opensoar/api/webhooks.py
+++ b/src/opensoar/api/webhooks.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from opensoar.api.deps import get_db
 from opensoar.auth.api_key import hash_api_key
 from opensoar.ingestion.webhook import process_webhook
+from opensoar.middleware.metrics import record_alert_ingested
 from opensoar.models.api_key import ApiKey
 from opensoar.plugins import dispatch_api_key_validators
 from opensoar.schemas.webhook import WebhookResponse
@@ -118,6 +119,7 @@ async def receive_alert(
     _key: None = Depends(_validate_default_webhook_key),
 ):
     alert = await process_webhook(session, payload, source="webhook")
+    record_alert_ingested("webhook")
 
     from opensoar.main import get_trigger_engine
 
@@ -149,6 +151,7 @@ async def receive_elastic_alert(
     _key: None = Depends(_validate_elastic_webhook_key),
 ):
     alert = await process_webhook(session, payload, source="elastic")
+    record_alert_ingested("elastic")
 
     from opensoar.main import get_trigger_engine
 

--- a/src/opensoar/core/executor.py
+++ b/src/opensoar/core/executor.py
@@ -14,6 +14,7 @@ from opensoar.core.decorators import (
     RegisteredPlaybook,
     set_execution_context,
 )
+from opensoar.middleware.metrics import record_playbook_run
 from opensoar.models.action_result import ActionResult
 from opensoar.models.alert import Alert
 from opensoar.models.playbook import PlaybookDefinition
@@ -109,5 +110,13 @@ class PlaybookExecutor:
             set_execution_context(None)
             run.finished_at = datetime.now(timezone.utc)
             await self.session.commit()
+
+            started = run.started_at or run.finished_at
+            duration = (run.finished_at - started).total_seconds()
+            record_playbook_run(
+                playbook_name=playbook.meta.name,
+                status=run.status,
+                duration_seconds=max(duration, 0.0),
+            )
 
         return run

--- a/src/opensoar/main.py
+++ b/src/opensoar/main.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from starlette.responses import FileResponse
 
+from opensoar.middleware.metrics import MetricsMiddleware
 from opensoar.middleware.rate_limit import RateLimitMiddleware
 from opensoar.api.ai import router as ai_router
 from opensoar.api.actions import router as actions_router
@@ -19,6 +20,7 @@ from opensoar.api.dashboard import router as dashboard_router
 from opensoar.api.health import router as health_router
 from opensoar.api.incidents import router as incidents_router
 from opensoar.api.integrations import router as integrations_router
+from opensoar.api.metrics import router as metrics_router
 from opensoar.api.observables import router as observables_router
 from opensoar.api.playbook_runs import router as runs_router
 from opensoar.api.playbooks import router as playbooks_router
@@ -83,7 +85,11 @@ configure_local_auth(
 )
 
 # ── Middleware ──────────────────────────────────────────────
+# Order matters: Starlette wraps middleware in reverse registration order,
+# so MetricsMiddleware (added last) is the outermost layer and records every
+# request regardless of whether the rate limiter short-circuits with a 429.
 app.add_middleware(RateLimitMiddleware, max_requests=100, window_seconds=60)
+app.add_middleware(MetricsMiddleware)
 
 # ── API routers (must be registered before static file catch-all) ────
 app.include_router(health_router, prefix="/api/v1")
@@ -100,6 +106,9 @@ app.include_router(ai_router, prefix="/api/v1")
 app.include_router(actions_router, prefix="/api/v1")
 app.include_router(api_keys_router, prefix="/api/v1")
 app.include_router(dashboard_router, prefix="/api/v1")
+
+# ── Prometheus scrape endpoint (no /api/v1 prefix) ──────────────────
+app.include_router(metrics_router)
 
 # ── Plugin discovery ────────────────────────────────────────────────
 load_optional_plugins(app)

--- a/src/opensoar/middleware/metrics.py
+++ b/src/opensoar/middleware/metrics.py
@@ -1,0 +1,121 @@
+"""Prometheus metrics — counters, histograms, middleware, and /metrics endpoint.
+
+Exposes an isolated ``CollectorRegistry`` so the application can reset metrics
+between tests without disturbing any global default registry shared with
+other libraries.
+"""
+from __future__ import annotations
+
+import time
+
+from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, Counter, Histogram, generate_latest
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+# The /metrics endpoint itself is excluded from the HTTP request counter so
+# scraping does not inflate its own metric.
+_METRICS_PATH = "/metrics"
+
+# Dedicated registry keeps OpenSOAR metrics separate from any library defaults.
+registry: CollectorRegistry = CollectorRegistry()
+
+http_requests_total: Counter = Counter(
+    "opensoar_http_requests_total",
+    "Total HTTP requests handled by the OpenSOAR API.",
+    ("method", "path", "status"),
+    registry=registry,
+)
+
+alerts_ingested_total: Counter = Counter(
+    "opensoar_alerts_ingested_total",
+    "Total alerts ingested via webhooks grouped by source.",
+    ("source",),
+    registry=registry,
+)
+
+playbook_runs_total: Counter = Counter(
+    "opensoar_playbook_runs_total",
+    "Total playbook executions grouped by playbook name and status.",
+    ("playbook", "status"),
+    registry=registry,
+)
+
+playbook_run_duration_seconds: Histogram = Histogram(
+    "opensoar_playbook_run_duration_seconds",
+    "Duration of playbook executions in seconds.",
+    ("playbook",),
+    registry=registry,
+)
+
+
+def reset_metrics() -> None:
+    """Clear collected samples from every OpenSOAR metric.
+
+    Used by tests so counter/histogram state does not leak between cases.
+    """
+    for metric in (
+        http_requests_total,
+        alerts_ingested_total,
+        playbook_runs_total,
+        playbook_run_duration_seconds,
+    ):
+        # prometheus_client exposes ``_metrics`` as the labelled-child store.
+        metric._metrics.clear()  # noqa: SLF001 — intentional reset for tests
+
+
+def record_http_request(method: str, path: str, status: int) -> None:
+    """Increment the HTTP request counter."""
+    http_requests_total.labels(method=method, path=path, status=str(status)).inc()
+
+
+def record_alert_ingested(source: str) -> None:
+    """Increment the alert ingest counter for a given source."""
+    alerts_ingested_total.labels(source=source).inc()
+
+
+def record_playbook_run(playbook_name: str, status: str, duration_seconds: float) -> None:
+    """Record a completed playbook run (counter + histogram)."""
+    playbook_runs_total.labels(playbook=playbook_name, status=status).inc()
+    playbook_run_duration_seconds.labels(playbook=playbook_name).observe(duration_seconds)
+
+
+def render_metrics() -> bytes:
+    """Render the current registry in Prometheus text exposition format."""
+    return generate_latest(registry)
+
+
+def metrics_content_type() -> str:
+    """Return the Prometheus exposition content-type header value."""
+    return CONTENT_TYPE_LATEST
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    """Starlette middleware that records per-request HTTP metrics.
+
+    The ``/metrics`` path itself is skipped so scraping does not inflate the
+    counter. Request duration is not tracked as a separate histogram yet —
+    only the count is exposed, which is sufficient for basic rate and error
+    monitoring.
+    """
+
+    async def dispatch(self, request: Request, call_next):
+        if request.url.path == _METRICS_PATH:
+            return await call_next(request)
+
+        start = time.monotonic()
+        response: Response | None = None
+        status_code = 500
+        try:
+            response = await call_next(request)
+            status_code = response.status_code
+            return response
+        finally:
+            # Always record, even for exceptions (status defaults to 500).
+            duration = time.monotonic() - start
+            _ = duration  # reserved for future per-request histogram
+            record_http_request(
+                method=request.method,
+                path=request.url.path,
+                status=status_code,
+            )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,9 +127,11 @@ async def client(db_session_factory) -> AsyncGenerator[AsyncClient]:
 
     with patch("opensoar.main.get_trigger_engine", return_value=mock_engine):
         with patch("opensoar.main._trigger_engine", mock_engine):
+            from opensoar.middleware.metrics import reset_metrics
             from opensoar.middleware.rate_limit import reset_rate_limiter
 
             reset_rate_limiter()
+            reset_metrics()
             transport = ASGITransport(app=app)
             async with AsyncClient(transport=transport, base_url="http://test") as c:
                 yield c

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,140 @@
+"""Tests for the Prometheus /metrics endpoint and metric recording helpers."""
+from __future__ import annotations
+
+import pytest
+
+from opensoar.middleware import metrics as metrics_mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_metrics():
+    """Clear all samples between tests so counters/histograms start at zero."""
+    metrics_mod.reset_metrics()
+    yield
+    metrics_mod.reset_metrics()
+
+
+class TestMetricsRegistry:
+    def test_registry_exposes_expected_metric_names(self):
+        text = metrics_mod.render_metrics().decode("utf-8")
+        for name in (
+            "opensoar_http_requests_total",
+            "opensoar_alerts_ingested_total",
+            "opensoar_playbook_runs_total",
+            "opensoar_playbook_run_duration_seconds",
+        ):
+            assert name in text, f"metric {name} should appear in exposition text"
+
+    def test_content_type_is_prometheus_text_format(self):
+        content_type = metrics_mod.metrics_content_type()
+        assert content_type.startswith("text/plain")
+        assert "version=" in content_type
+
+    def test_record_alert_ingested_increments_counter(self):
+        metrics_mod.record_alert_ingested("webhook")
+        metrics_mod.record_alert_ingested("webhook")
+        metrics_mod.record_alert_ingested("elastic")
+
+        text = metrics_mod.render_metrics().decode("utf-8")
+        assert 'opensoar_alerts_ingested_total{source="webhook"} 2.0' in text
+        assert 'opensoar_alerts_ingested_total{source="elastic"} 1.0' in text
+
+    def test_record_playbook_run_increments_counter_and_histogram(self):
+        metrics_mod.record_playbook_run("triage", "success", 0.25)
+        metrics_mod.record_playbook_run("triage", "failed", 1.5)
+
+        text = metrics_mod.render_metrics().decode("utf-8")
+        assert (
+            'opensoar_playbook_runs_total{playbook="triage",status="success"} 1.0'
+            in text
+        )
+        assert (
+            'opensoar_playbook_runs_total{playbook="triage",status="failed"} 1.0'
+            in text
+        )
+        # Histogram exposes _count and _sum series
+        assert "opensoar_playbook_run_duration_seconds_count" in text
+        assert "opensoar_playbook_run_duration_seconds_sum" in text
+
+
+class TestMetricsEndpoint:
+    async def test_metrics_endpoint_returns_200(self, client):
+        resp = await client.get("/metrics")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/plain")
+
+    async def test_http_requests_counter_increments(self, client):
+        # Hit an endpoint first so there is traffic to observe
+        await client.get("/api/v1/health")
+        await client.get("/api/v1/health")
+
+        resp = await client.get("/metrics")
+        body = resp.text
+        assert "opensoar_http_requests_total" in body
+        # The /metrics endpoint itself is excluded, but /api/v1/health is recorded
+        assert 'path="/api/v1/health"' in body
+        assert 'method="GET"' in body
+        assert 'status="200"' in body
+
+    async def test_metrics_path_excluded_from_counter(self, client):
+        await client.get("/metrics")
+        await client.get("/metrics")
+        resp = await client.get("/metrics")
+        assert 'path="/metrics"' not in resp.text
+
+    async def test_alert_ingest_increments_alerts_counter(self, client):
+        resp = await client.post(
+            "/api/v1/webhooks/alerts",
+            json={"rule_name": "Metrics Test Alert", "severity": "low"},
+        )
+        assert resp.status_code == 200
+
+        metrics_resp = await client.get("/metrics")
+        body = metrics_resp.text
+        assert 'opensoar_alerts_ingested_total{source="webhook"}' in body
+
+
+class TestPlaybookExecutorMetrics:
+    async def test_executor_records_run_metric(self, session):
+        """PlaybookExecutor.execute should observe a run in the histogram and counter."""
+        from opensoar.core.decorators import PlaybookMeta, RegisteredPlaybook
+        from opensoar.core.executor import PlaybookExecutor
+        from opensoar.models.playbook import PlaybookDefinition
+
+        # Register a dummy playbook definition in the DB
+        pb_row = PlaybookDefinition(
+            name="metrics-test-playbook",
+            description="pb for metrics",
+            module_path="tests.test_metrics",
+            function_name="dummy_playbook",
+            trigger_type="manual",
+            trigger_config={},
+            enabled=True,
+        )
+        session.add(pb_row)
+        await session.commit()
+
+        async def dummy(_input):
+            return {"ok": True}
+
+        pb = RegisteredPlaybook(
+            meta=PlaybookMeta(
+                name="metrics-test-playbook",
+                description="pb for metrics",
+                trigger="manual",
+                conditions={},
+            ),
+            func=dummy,
+            module="tests.test_metrics",
+        )
+
+        executor = PlaybookExecutor(session)
+        run = await executor.execute(pb)
+        assert run.status == "success"
+
+        text = metrics_mod.render_metrics().decode("utf-8")
+        assert (
+            'opensoar_playbook_runs_total{playbook="metrics-test-playbook",status="success"} 1.0'
+            in text
+        )
+        assert "opensoar_playbook_run_duration_seconds_count" in text

--- a/uv.lock
+++ b/uv.lock
@@ -818,6 +818,7 @@ dependencies = [
     { name = "bcrypt" },
     { name = "celery", extra = ["redis"] },
     { name = "fastapi" },
+    { name = "prometheus-client" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
@@ -844,6 +845,7 @@ requires-dist = [
     { name = "celery", extras = ["redis"], specifier = ">=5.4.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28.0" },
+    { name = "prometheus-client", specifier = ">=0.21.0" },
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pydantic-settings", specifier = ">=2.7.0" },
     { name = "pyjwt", specifier = ">=2.9.0" },
@@ -872,6 +874,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154 },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #62.

## Summary
- Expose a Prometheus scrape endpoint at `GET /metrics` (Prometheus text format, no auth, not rate-limited, excluded from the HTTP counter).
- Four metrics registered in a dedicated `CollectorRegistry`:
  - `opensoar_http_requests_total{method,path,status}` — incremented by a new `MetricsMiddleware` on every request.
  - `opensoar_alerts_ingested_total{source}` — incremented in the webhook handler for `webhook` and `elastic` sources.
  - `opensoar_playbook_runs_total{playbook,status}` — incremented in `PlaybookExecutor` when a run terminates.
  - `opensoar_playbook_run_duration_seconds` — histogram observed alongside the counter.
- Add `prometheus-client` to `pyproject.toml` / `uv.lock`.
- Document the endpoint, labels, and a sample scrape config in `docs/docs/engineering/architecture.md`.

## Test plan
- [x] `ruff check src/ tests/` — clean.
- [x] New `tests/test_metrics.py` covers: registry exposition format, content type, alert counter, playbook counter + histogram, `/metrics` status + content type, HTTP counter increments on real traffic, `/metrics` path excluded from its own counter, alert ingest increments the counter via the real webhook flow, and `PlaybookExecutor` observes a run in the histogram.
- [x] Full suite `pytest tests/` — 279 passed.
- [ ] CI green on this branch (watching).