### PR TITLE
Add TTL-based enrichment cache with tenant-scoped invalidation

### DIFF
--- a/src/opensoar/api/observables.py
+++ b/src/opensoar/api/observables.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from opensoar.api.deps import get_db
 from opensoar.auth.jwt import get_current_analyst
 from opensoar.auth.rbac import Permission, require_permission
+from opensoar.integrations import cache as _cache_module
 from opensoar.plugins import apply_tenant_access_query, enforce_tenant_access
 from opensoar.models.analyst import Analyst
 from opensoar.models.observable import Observable
@@ -171,3 +172,56 @@ async def add_enrichment(
     await session.commit()
     await session.refresh(obs)
     return ObservableResponse.model_validate(obs)
+
+
+@router.delete("/{observable_id}/enrichments/{source}")
+async def invalidate_observable_enrichment(
+    observable_id: uuid.UUID,
+    source: str,
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+    analyst: Analyst = Depends(require_permission(Permission.OBSERVABLES_MANAGE)),
+):
+    """Drop cached enrichment + stored record for ``(observable, source)``.
+
+    Useful when an upstream vendor's verdict has changed and analysts want to
+    re-enrich immediately. Tenant-scoped — the plugin access validators run
+    before any state changes.
+    """
+    result = await session.execute(
+        select(Observable).where(Observable.id == observable_id)
+    )
+    obs = result.scalar_one_or_none()
+    if not obs:
+        raise HTTPException(status_code=404, detail="Observable not found")
+
+    await enforce_tenant_access(
+        request.app,
+        resource=obs,
+        resource_type="observable",
+        action="update",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
+
+    cache = _cache_module.get_default_cache()
+    cleared = await cache.invalidate(source, obs.type, obs.value)
+
+    # Remove any stored enrichment entries for this source from the JSONB list.
+    current_enrichments = list(obs.enrichments or [])
+    remaining = [e for e in current_enrichments if e.get("source") != source]
+    removed_records = len(current_enrichments) - len(remaining)
+    obs.enrichments = remaining
+    if not remaining:
+        obs.enrichment_status = "pending"
+
+    await session.commit()
+    await session.refresh(obs)
+
+    return {
+        "observable_id": str(obs.id),
+        "source": source,
+        "cache_cleared": cleared,
+        "records_removed": removed_records,
+    }

--- a/src/opensoar/config.py
+++ b/src/opensoar/config.py
@@ -34,6 +34,12 @@ class Settings(BaseSettings):
     llm_model: str | None = None
     debug: bool = False
 
+    # Enrichment cache TTLs (seconds). See opensoar.integrations.cache.
+    enrichment_cache_ttl_default: int = 3600
+    enrichment_cache_ttl_virustotal: int = 24 * 3600
+    enrichment_cache_ttl_abuseipdb: int = 12 * 3600
+    enrichment_cache_ttl_greynoise: int = 6 * 3600
+
     @property
     def playbook_directories(self) -> list[str]:
         return [d.strip() for d in self.playbook_dirs.split(",") if d.strip()]

--- a/src/opensoar/integrations/abuseipdb/connector.py
+++ b/src/opensoar/integrations/abuseipdb/connector.py
@@ -5,7 +5,10 @@ from typing import Any
 import aiohttp
 
 from opensoar.core.decorators import action
+from opensoar.integrations import cache as _cache_module
 from opensoar.integrations.base import ActionDefinition, HealthCheckResult, IntegrationBase
+
+_SOURCE = "abuseipdb"
 
 
 class AbuseIPDBIntegration(IntegrationBase):
@@ -56,10 +59,22 @@ class AbuseIPDBIntegration(IntegrationBase):
     async def check_ip(self, ip: str, max_age_days: int = 90) -> dict:
         if not self._client:
             raise RuntimeError("Not connected")
-        async with self._client.get(
-            "/check", params={"ipAddress": ip, "maxAgeInDays": str(max_age_days)}
-        ) as resp:
-            return await resp.json()
+
+        async def _fetch() -> dict:
+            async with self._client.get(
+                "/check", params={"ipAddress": ip, "maxAgeInDays": str(max_age_days)}
+            ) as resp:
+                return await resp.json()
+
+        # max_age_days is part of the semantic lookup; fold it into the key value.
+        cache_value = f"{ip}|maxAgeInDays={max_age_days}"
+        return await _cache_module.get_default_cache().get_or_fetch(
+            source=_SOURCE,
+            obs_type="ip",
+            value=cache_value,
+            fetcher=_fetch,
+            ttl_seconds=_cache_module.default_ttl_for(_SOURCE),
+        )
 
     async def disconnect(self) -> None:
         if self._client:

--- a/src/opensoar/integrations/cache.py
+++ b/src/opensoar/integrations/cache.py
@@ -1,0 +1,333 @@
+"""TTL-based enrichment cache for integration adapters (issue #67).
+
+Keeps upstream enrichment API traffic down. Keyed by ``(source, type, value)``;
+TTL per source comes from :mod:`opensoar.config`. Integration adapters call
+:func:`cached_enrichment` (decorator) or :meth:`EnrichmentCache.get_or_fetch`
+(imperative) to wrap upstream calls. A small counter shim records
+hits/misses/stores — swap for Prometheus metrics once issue #62 ships.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from functools import wraps
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+CACHE_KEY_PREFIX = "opensoar:enrichment:"
+
+
+class CacheBackend(Protocol):
+    """Minimal async KV interface — Redis or in-memory fake both satisfy it."""
+
+    async def get(self, key: str) -> str | None: ...
+    async def set(self, key: str, value: str, ttl_seconds: int) -> None: ...
+    async def delete(self, key: str) -> None: ...
+    async def delete_prefix(self, prefix: str) -> int: ...
+
+
+class InMemoryCacheBackend:
+    """Deterministic in-memory backend for tests. Not thread-safe."""
+
+    def __init__(self) -> None:
+        # key -> (value, expires_at_monotonic)
+        self._store: dict[str, tuple[str, float]] = {}
+        self._clock_offset: float = 0.0
+
+    def _now(self) -> float:
+        return time.monotonic() + self._clock_offset
+
+    def _fast_forward(self, seconds: float) -> None:
+        """Test helper — advance the backend's internal clock."""
+        self._clock_offset += seconds
+
+    async def get(self, key: str) -> str | None:
+        entry = self._store.get(key)
+        if entry is None:
+            return None
+        value, expires_at = entry
+        if self._now() >= expires_at:
+            del self._store[key]
+            return None
+        return value
+
+    async def set(self, key: str, value: str, ttl_seconds: int) -> None:
+        self._store[key] = (value, self._now() + max(0, ttl_seconds))
+
+    async def delete(self, key: str) -> None:
+        self._store.pop(key, None)
+
+    async def delete_prefix(self, prefix: str) -> int:
+        matching = [k for k in self._store if k.startswith(prefix)]
+        for k in matching:
+            del self._store[k]
+        return len(matching)
+
+
+class RedisCacheBackend:
+    """Async Redis backend. Lazily connects on first use."""
+
+    def __init__(self, url: str):
+        self._url = url
+        self._client: Any | None = None
+        self._lock = asyncio.Lock()
+
+    async def _ensure_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        async with self._lock:
+            if self._client is None:
+                from redis import asyncio as redis_asyncio
+
+                self._client = redis_asyncio.from_url(
+                    self._url, encoding="utf-8", decode_responses=True
+                )
+        return self._client
+
+    async def get(self, key: str) -> str | None:
+        client = await self._ensure_client()
+        return await client.get(key)
+
+    async def set(self, key: str, value: str, ttl_seconds: int) -> None:
+        client = await self._ensure_client()
+        # redis-py: ex=<seconds> sets the TTL.
+        await client.set(key, value, ex=max(1, ttl_seconds))
+
+    async def delete(self, key: str) -> None:
+        client = await self._ensure_client()
+        await client.delete(key)
+
+    async def delete_prefix(self, prefix: str) -> int:
+        client = await self._ensure_client()
+        deleted = 0
+        async for key in client.scan_iter(match=f"{prefix}*"):
+            await client.delete(key)
+            deleted += 1
+        return deleted
+
+
+@dataclass
+class CacheMetrics:
+    """Lightweight counter shim — increments are also logged at INFO.
+
+    TODO(#62): replace with Prometheus counters when the metrics endpoint lands.
+    This class has a stable interface so the swap is a one-liner at
+    :func:`get_default_cache`.
+    """
+
+    hits: int = 0
+    misses: int = 0
+    stores: int = 0
+    invalidations: int = 0
+    by_source: dict[str, dict[str, int]] = field(default_factory=dict)
+
+    def _bump(self, kind: str, source: str) -> None:
+        bucket = self.by_source.setdefault(
+            source, {"hits": 0, "misses": 0, "stores": 0, "invalidations": 0}
+        )
+        bucket[kind] = bucket.get(kind, 0) + 1
+
+    def hit(self, source: str) -> None:
+        self.hits += 1
+        self._bump("hits", source)
+        logger.info("enrichment_cache.hit source=%s", source)
+
+    def miss(self, source: str) -> None:
+        self.misses += 1
+        self._bump("misses", source)
+        logger.info("enrichment_cache.miss source=%s", source)
+
+    def store(self, source: str) -> None:
+        self.stores += 1
+        self._bump("stores", source)
+        logger.info("enrichment_cache.store source=%s", source)
+
+    def invalidate(self, source: str, count: int = 1) -> None:
+        self.invalidations += count
+        self._bump("invalidations", source)
+        logger.info("enrichment_cache.invalidate source=%s count=%d", source, count)
+
+
+# ── Source → TTL lookup ─────────────────────────────────────────────
+
+
+def default_ttl_for(source: str) -> int:
+    """Return per-source TTL (seconds) from settings, else a sensible default."""
+    from opensoar.config import settings
+
+    table = {
+        "virustotal": getattr(settings, "enrichment_cache_ttl_virustotal", 24 * 3600),
+        "abuseipdb": getattr(settings, "enrichment_cache_ttl_abuseipdb", 12 * 3600),
+        "greynoise": getattr(settings, "enrichment_cache_ttl_greynoise", 6 * 3600),
+    }
+    return int(table.get(source, getattr(settings, "enrichment_cache_ttl_default", 3600)))
+
+
+# ── Cache facade ────────────────────────────────────────────────────
+
+
+class EnrichmentCache:
+    """Facade over any ``CacheBackend``. Handles key layout + JSON codec."""
+
+    def __init__(
+        self,
+        backend: CacheBackend,
+        metrics: CacheMetrics | None = None,
+    ) -> None:
+        self.backend = backend
+        self.metrics = metrics or CacheMetrics()
+
+    def build_key(self, source: str, obs_type: str, value: str) -> str:
+        # Hash the value so arbitrarily long / unicode observables still fit.
+        digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:32]
+        return f"{CACHE_KEY_PREFIX}{source}:{obs_type}:{digest}"
+
+    def source_prefix(self, source: str) -> str:
+        return f"{CACHE_KEY_PREFIX}{source}:"
+
+    async def get(
+        self, source: str, obs_type: str, value: str
+    ) -> Any | None:
+        raw = await self.backend.get(self.build_key(source, obs_type, value))
+        if raw is None:
+            return None
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            logger.warning(
+                "enrichment_cache.decode_failed source=%s type=%s", source, obs_type
+            )
+            return None
+
+    async def set(
+        self,
+        source: str,
+        obs_type: str,
+        value: str,
+        payload: Any,
+        ttl_seconds: int,
+    ) -> None:
+        key = self.build_key(source, obs_type, value)
+        try:
+            encoded = json.dumps(payload, default=str)
+        except (TypeError, ValueError):
+            logger.warning("enrichment_cache.encode_failed source=%s", source)
+            return
+        await self.backend.set(key, encoded, ttl_seconds=ttl_seconds)
+        self.metrics.store(source)
+
+    async def invalidate(self, source: str, obs_type: str, value: str) -> int:
+        await self.backend.delete(self.build_key(source, obs_type, value))
+        self.metrics.invalidate(source, 1)
+        return 1
+
+    async def invalidate_source(self, source: str) -> int:
+        count = await self.backend.delete_prefix(self.source_prefix(source))
+        self.metrics.invalidate(source, count)
+        return count
+
+    async def get_or_fetch(
+        self,
+        *,
+        source: str,
+        obs_type: str,
+        value: str,
+        fetcher: Callable[[], Awaitable[Any]],
+        ttl_seconds: int | None = None,
+    ) -> Any:
+        cached = await self.get(source, obs_type, value)
+        if cached is not None:
+            self.metrics.hit(source)
+            return cached
+
+        self.metrics.miss(source)
+        result = await fetcher()
+        ttl = ttl_seconds if ttl_seconds is not None else default_ttl_for(source)
+        await self.set(source, obs_type, value, result, ttl_seconds=ttl)
+        return result
+
+
+# ── Default singleton wiring ────────────────────────────────────────
+
+_default_cache: EnrichmentCache | None = None
+
+
+def get_default_cache() -> EnrichmentCache:
+    """Return a process-wide cache. Redis-backed in prod, in-memory otherwise."""
+    global _default_cache
+    if _default_cache is not None:
+        return _default_cache
+    try:
+        from opensoar.config import settings
+
+        backend: CacheBackend = RedisCacheBackend(settings.redis_url)
+    except Exception:  # pragma: no cover - defensive fallback
+        logger.exception(
+            "enrichment_cache.redis_unavailable falling back to in-memory"
+        )
+        backend = InMemoryCacheBackend()
+    _default_cache = EnrichmentCache(backend=backend)
+    return _default_cache
+
+
+def reset_default_cache() -> None:
+    """Reset the module-level singleton. Intended for tests."""
+    global _default_cache
+    _default_cache = None
+
+
+# ── Decorator helper ────────────────────────────────────────────────
+
+
+def cached_enrichment(
+    cache: EnrichmentCache | None = None,
+    *,
+    source: str,
+    obs_type: str,
+    ttl_seconds: int | None = None,
+    value_arg: str | None = None,
+) -> Callable[[Callable[..., Awaitable[Any]]], Callable[..., Awaitable[Any]]]:
+    """Wrap an async fetcher so it consults the enrichment cache.
+
+    The observable ``value`` is inferred from the first positional arg unless
+    ``value_arg`` names a kwarg. ``cache`` defaults to
+    :func:`get_default_cache` at call time so tests can monkey-patch it.
+    """
+
+    def decorator(
+        fn: Callable[..., Awaitable[Any]]
+    ) -> Callable[..., Awaitable[Any]]:
+        @wraps(fn)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            if value_arg is not None:
+                value = kwargs.get(value_arg)
+                if value is None and args:
+                    value = args[0]
+            elif args:
+                value = args[0]
+            else:
+                # No value to key on — skip cache.
+                return await fn(*args, **kwargs)
+
+            active_cache = cache if cache is not None else get_default_cache()
+
+            async def _call() -> Any:
+                return await fn(*args, **kwargs)
+
+            return await active_cache.get_or_fetch(
+                source=source,
+                obs_type=obs_type,
+                value=str(value),
+                fetcher=_call,
+                ttl_seconds=ttl_seconds,
+            )
+
+        return wrapper
+
+    return decorator

--- a/src/opensoar/integrations/virustotal/connector.py
+++ b/src/opensoar/integrations/virustotal/connector.py
@@ -5,7 +5,10 @@ from typing import Any
 import aiohttp
 
 from opensoar.core.decorators import action
+from opensoar.integrations import cache as _cache_module
 from opensoar.integrations.base import ActionDefinition, HealthCheckResult, IntegrationBase
+
+_SOURCE = "virustotal"
 
 
 class VirusTotalIntegration(IntegrationBase):
@@ -61,20 +64,50 @@ class VirusTotalIntegration(IntegrationBase):
     async def lookup_ip(self, ip: str) -> dict:
         if not self._client:
             raise RuntimeError("Not connected")
-        async with self._client.get(f"/ip_addresses/{ip}") as resp:
-            return await resp.json()
+
+        async def _fetch() -> dict:
+            async with self._client.get(f"/ip_addresses/{ip}") as resp:
+                return await resp.json()
+
+        return await _cache_module.get_default_cache().get_or_fetch(
+            source=_SOURCE,
+            obs_type="ip",
+            value=ip,
+            fetcher=_fetch,
+            ttl_seconds=_cache_module.default_ttl_for(_SOURCE),
+        )
 
     async def lookup_hash(self, file_hash: str) -> dict:
         if not self._client:
             raise RuntimeError("Not connected")
-        async with self._client.get(f"/files/{file_hash}") as resp:
-            return await resp.json()
+
+        async def _fetch() -> dict:
+            async with self._client.get(f"/files/{file_hash}") as resp:
+                return await resp.json()
+
+        return await _cache_module.get_default_cache().get_or_fetch(
+            source=_SOURCE,
+            obs_type="hash",
+            value=file_hash,
+            fetcher=_fetch,
+            ttl_seconds=_cache_module.default_ttl_for(_SOURCE),
+        )
 
     async def lookup_domain(self, domain: str) -> dict:
         if not self._client:
             raise RuntimeError("Not connected")
-        async with self._client.get(f"/domains/{domain}") as resp:
-            return await resp.json()
+
+        async def _fetch() -> dict:
+            async with self._client.get(f"/domains/{domain}") as resp:
+                return await resp.json()
+
+        return await _cache_module.get_default_cache().get_or_fetch(
+            source=_SOURCE,
+            obs_type="domain",
+            value=domain,
+            fetcher=_fetch,
+            ttl_seconds=_cache_module.default_ttl_for(_SOURCE),
+        )
 
     async def disconnect(self) -> None:
         if self._client:

--- a/tests/test_enrichment_cache.py
+++ b/tests/test_enrichment_cache.py
@@ -1,0 +1,361 @@
+"""Tests for the TTL-based enrichment cache (issue #67)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from fastapi import HTTPException
+
+from opensoar.integrations.cache import (
+    CACHE_KEY_PREFIX,
+    CacheMetrics,
+    EnrichmentCache,
+    InMemoryCacheBackend,
+    cached_enrichment,
+)
+from opensoar.plugins import register_tenant_access_validator
+
+
+class TestInMemoryCacheBackend:
+    async def test_set_then_get_returns_value(self):
+        backend = InMemoryCacheBackend()
+        await backend.set("k", '{"n": 1}', ttl_seconds=60)
+        assert await backend.get("k") == '{"n": 1}'
+
+    async def test_expired_value_returns_none(self):
+        backend = InMemoryCacheBackend()
+        # Use a zero/negative ttl to force immediate expiry.
+        await backend.set("k", '{"n": 1}', ttl_seconds=0)
+        # Fast-forward time inside the fake backend.
+        backend._fast_forward(1)
+        assert await backend.get("k") is None
+
+    async def test_delete_removes_value(self):
+        backend = InMemoryCacheBackend()
+        await backend.set("k", "v", ttl_seconds=60)
+        await backend.delete("k")
+        assert await backend.get("k") is None
+
+    async def test_delete_by_prefix(self):
+        backend = InMemoryCacheBackend()
+        await backend.set("a:x", "1", ttl_seconds=60)
+        await backend.set("a:y", "2", ttl_seconds=60)
+        await backend.set("b:z", "3", ttl_seconds=60)
+        count = await backend.delete_prefix("a:")
+        assert count == 2
+        assert await backend.get("a:x") is None
+        assert await backend.get("a:y") is None
+        assert await backend.get("b:z") == "3"
+
+
+class TestEnrichmentCacheCore:
+    async def test_cache_miss_calls_upstream_and_stores(self):
+        backend = InMemoryCacheBackend()
+        metrics = CacheMetrics()
+        cache = EnrichmentCache(backend=backend, metrics=metrics)
+
+        upstream = AsyncMock(return_value={"verdict": "clean"})
+        result = await cache.get_or_fetch(
+            source="virustotal",
+            obs_type="ip",
+            value="1.2.3.4",
+            fetcher=upstream,
+            ttl_seconds=60,
+        )
+        assert result == {"verdict": "clean"}
+        upstream.assert_awaited_once()
+        assert metrics.misses == 1
+        assert metrics.hits == 0
+        assert metrics.stores == 1
+
+    async def test_cache_hit_skips_upstream(self):
+        backend = InMemoryCacheBackend()
+        metrics = CacheMetrics()
+        cache = EnrichmentCache(backend=backend, metrics=metrics)
+
+        upstream = AsyncMock(return_value={"verdict": "clean"})
+        await cache.get_or_fetch(
+            source="virustotal",
+            obs_type="ip",
+            value="1.2.3.4",
+            fetcher=upstream,
+            ttl_seconds=60,
+        )
+
+        upstream2 = AsyncMock(return_value={"verdict": "should-not-be-used"})
+        result = await cache.get_or_fetch(
+            source="virustotal",
+            obs_type="ip",
+            value="1.2.3.4",
+            fetcher=upstream2,
+            ttl_seconds=60,
+        )
+        assert result == {"verdict": "clean"}
+        upstream2.assert_not_awaited()
+        assert metrics.hits == 1
+
+    async def test_ttl_expiry_refetches(self):
+        backend = InMemoryCacheBackend()
+        metrics = CacheMetrics()
+        cache = EnrichmentCache(backend=backend, metrics=metrics)
+
+        call_count = 0
+
+        async def fetcher():
+            nonlocal call_count
+            call_count += 1
+            return {"call": call_count}
+
+        first = await cache.get_or_fetch(
+            source="virustotal", obs_type="ip", value="1.2.3.4",
+            fetcher=fetcher, ttl_seconds=60,
+        )
+        assert first == {"call": 1}
+
+        # Expire the entry.
+        backend._fast_forward(120)
+
+        second = await cache.get_or_fetch(
+            source="virustotal", obs_type="ip", value="1.2.3.4",
+            fetcher=fetcher, ttl_seconds=60,
+        )
+        assert second == {"call": 2}
+        assert metrics.misses == 2
+        assert metrics.stores == 2
+
+    async def test_invalidate_clears_single_key(self):
+        backend = InMemoryCacheBackend()
+        cache = EnrichmentCache(backend=backend)
+
+        await cache.set("virustotal", "ip", "1.2.3.4", {"v": 1}, ttl_seconds=60)
+        assert await cache.get("virustotal", "ip", "1.2.3.4") == {"v": 1}
+
+        await cache.invalidate("virustotal", "ip", "1.2.3.4")
+        assert await cache.get("virustotal", "ip", "1.2.3.4") is None
+
+    async def test_invalidate_by_source_clears_all_matching(self):
+        backend = InMemoryCacheBackend()
+        cache = EnrichmentCache(backend=backend)
+
+        await cache.set("virustotal", "ip", "1.2.3.4", {"v": 1}, ttl_seconds=60)
+        await cache.set("virustotal", "domain", "evil.com", {"v": 2}, ttl_seconds=60)
+        await cache.set("abuseipdb", "ip", "1.2.3.4", {"v": 3}, ttl_seconds=60)
+
+        cleared = await cache.invalidate_source("virustotal")
+        assert cleared == 2
+        assert await cache.get("virustotal", "ip", "1.2.3.4") is None
+        assert await cache.get("virustotal", "domain", "evil.com") is None
+        assert await cache.get("abuseipdb", "ip", "1.2.3.4") == {"v": 3}
+
+    async def test_key_is_tuple_based(self):
+        backend = InMemoryCacheBackend()
+        cache = EnrichmentCache(backend=backend)
+        key = cache.build_key("virustotal", "ip", "1.2.3.4")
+        assert key.startswith(CACHE_KEY_PREFIX)
+        assert "virustotal" in key
+        assert "ip" in key
+        # Different values produce different keys (value is hashed for key safety).
+        other = cache.build_key("virustotal", "ip", "5.6.7.8")
+        assert key != other
+
+    async def test_cached_enrichment_decorator_wraps_fetcher(self):
+        backend = InMemoryCacheBackend()
+        cache = EnrichmentCache(backend=backend)
+
+        calls = 0
+
+        @cached_enrichment(cache, source="virustotal", obs_type="ip", ttl_seconds=60)
+        async def fetch(ip: str):
+            nonlocal calls
+            calls += 1
+            return {"ip": ip, "score": 0.5}
+
+        r1 = await fetch("1.2.3.4")
+        r2 = await fetch("1.2.3.4")
+        assert r1 == r2 == {"ip": "1.2.3.4", "score": 0.5}
+        assert calls == 1
+
+        r3 = await fetch("5.6.7.8")
+        assert calls == 2
+        assert r3 == {"ip": "5.6.7.8", "score": 0.5}
+
+
+class TestIntegrationAdaptersUseCache:
+    async def test_virustotal_lookup_ip_uses_cache(self, monkeypatch):
+        """VT's lookup_ip should write-through to cache and skip upstream on hit."""
+        from opensoar.integrations import cache as cache_module
+        from opensoar.integrations.virustotal.connector import VirusTotalIntegration
+
+        backend = InMemoryCacheBackend()
+        cache = EnrichmentCache(backend=backend)
+        monkeypatch.setattr(cache_module, "get_default_cache", lambda: cache)
+
+        integ = VirusTotalIntegration({"api_key": "test-key"})
+
+        # Replace the HTTP client with a mock that counts calls and returns a canned payload.
+        calls = {"n": 0}
+
+        class _MockResp:
+            def __init__(self, payload):
+                self._payload = payload
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *a):
+                return None
+            async def json(self):
+                return self._payload
+
+        class _MockClient:
+            def get(self, path):
+                calls["n"] += 1
+                return _MockResp({"data": {"id": path, "score": 1}})
+
+        integ._client = _MockClient()
+
+        first = await integ.lookup_ip("1.2.3.4")
+        second = await integ.lookup_ip("1.2.3.4")
+        assert first == second
+        assert calls["n"] == 1  # second call hit cache
+
+    async def test_abuseipdb_check_ip_uses_cache(self, monkeypatch):
+        from opensoar.integrations import cache as cache_module
+        from opensoar.integrations.abuseipdb.connector import AbuseIPDBIntegration
+
+        backend = InMemoryCacheBackend()
+        cache = EnrichmentCache(backend=backend)
+        monkeypatch.setattr(cache_module, "get_default_cache", lambda: cache)
+
+        integ = AbuseIPDBIntegration({"api_key": "abuse-key"})
+
+        calls = {"n": 0}
+
+        class _MockResp:
+            def __init__(self, payload):
+                self._payload = payload
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *a):
+                return None
+            async def json(self):
+                return self._payload
+
+        class _MockClient:
+            def get(self, path, params=None):
+                calls["n"] += 1
+                return _MockResp({"data": {"abuseConfidenceScore": 12}})
+
+        integ._client = _MockClient()
+
+        first = await integ.check_ip("1.2.3.4")
+        second = await integ.check_ip("1.2.3.4")
+        assert first == second
+        assert calls["n"] == 1
+
+
+class TestInvalidationEndpoint:
+    async def test_delete_enrichment_by_source_clears_cache_and_record(
+        self, client, registered_analyst, monkeypatch
+    ):
+        from opensoar.integrations import cache as cache_module
+
+        backend = InMemoryCacheBackend()
+        cache = EnrichmentCache(backend=backend)
+        monkeypatch.setattr(cache_module, "get_default_cache", lambda: cache)
+
+        # Create observable, seed enrichment + cache.
+        create = await client.post(
+            "/api/v1/observables",
+            json={"type": "ip", "value": "203.0.113.55", "source": "cache-test"},
+            headers=registered_analyst["headers"],
+        )
+        obs_id = create.json()["id"]
+
+        await client.post(
+            f"/api/v1/observables/{obs_id}/enrichments",
+            json={
+                "source": "virustotal",
+                "data": {"malicious": 2},
+                "malicious": False,
+                "score": 0.3,
+            },
+            headers=registered_analyst["headers"],
+        )
+        await cache.set("virustotal", "ip", "203.0.113.55", {"cached": True}, ttl_seconds=60)
+        assert await cache.get("virustotal", "ip", "203.0.113.55") == {"cached": True}
+
+        resp = await client.delete(
+            f"/api/v1/observables/{obs_id}/enrichments/virustotal",
+            headers=registered_analyst["headers"],
+        )
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["source"] == "virustotal"
+        assert payload["cache_cleared"] >= 1
+
+        # Cache entry should now be gone.
+        assert await cache.get("virustotal", "ip", "203.0.113.55") is None
+
+        # Observable should no longer have a VT enrichment entry.
+        detail = await client.get(
+            f"/api/v1/observables/{obs_id}", headers=registered_analyst["headers"]
+        )
+        enrichments = detail.json()["enrichments"] or []
+        assert all(e.get("source") != "virustotal" for e in enrichments)
+
+    async def test_delete_enrichment_requires_auth(self, client, registered_analyst):
+        create = await client.post(
+            "/api/v1/observables",
+            json={"type": "ip", "value": "203.0.113.60", "source": "auth-test"},
+            headers=registered_analyst["headers"],
+        )
+        obs_id = create.json()["id"]
+
+        resp = await client.delete(
+            f"/api/v1/observables/{obs_id}/enrichments/virustotal"
+        )
+        assert resp.status_code == 401
+
+    async def test_delete_enrichment_missing_observable_returns_404(
+        self, client, registered_analyst
+    ):
+        import uuid as _uuid
+        resp = await client.delete(
+            f"/api/v1/observables/{_uuid.uuid4()}/enrichments/virustotal",
+            headers=registered_analyst["headers"],
+        )
+        assert resp.status_code == 404
+
+    async def test_delete_enrichment_respects_tenant_scope(
+        self, client, registered_analyst, monkeypatch
+    ):
+        """Tenant validator must be consulted before invalidation proceeds."""
+        from opensoar.integrations import cache as cache_module
+        from opensoar.main import app
+
+        backend = InMemoryCacheBackend()
+        cache = EnrichmentCache(backend=backend)
+        monkeypatch.setattr(cache_module, "get_default_cache", lambda: cache)
+
+        create = await client.post(
+            "/api/v1/observables",
+            json={"type": "ip", "value": "198.51.100.99", "source": "tenant-test"},
+            headers=registered_analyst["headers"],
+        )
+        obs_id = create.json()["id"]
+
+        async def validator(**kwargs):
+            resource = kwargs.get("resource")
+            if resource is not None and getattr(resource, "value", None) == "198.51.100.99":
+                raise HTTPException(status_code=403, detail="Tenant access denied")
+
+        original = list(app.state.tenant_access_validators)
+        app.state.tenant_access_validators = []
+        register_tenant_access_validator(app, validator)
+        try:
+            resp = await client.delete(
+                f"/api/v1/observables/{obs_id}/enrichments/virustotal",
+                headers=registered_analyst["headers"],
+            )
+        finally:
+            app.state.tenant_access_validators = original
+
+        assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- Redis-backed enrichment cache keyed by `(source, type, value)` with per-source TTLs (VirusTotal 24h, AbuseIPDB 12h, GreyNoise 6h by default, all configurable via settings).
- VirusTotal and AbuseIPDB connectors read-through + write-through; any enrichment code path can reuse `EnrichmentCache.get_or_fetch` or the `@cached_enrichment` decorator without depending on #66.
- `DELETE /observables/{id}/enrichments/{source}` — auth-required, `OBSERVABLES_MANAGE`, tenant-scoped via the existing plugin validators. Clears both the cache entry and any stored enrichment records for that source.
- Lightweight `CacheMetrics` counter shim logs hits/misses/stores at INFO with a TODO hook for swapping to Prometheus once #62 merges.

## Default TTL table
| Source     | TTL  | Setting                             |
|------------|------|-------------------------------------|
| VirusTotal | 24h  | `ENRICHMENT_CACHE_TTL_VIRUSTOTAL`   |
| AbuseIPDB  | 12h  | `ENRICHMENT_CACHE_TTL_ABUSEIPDB`    |
| GreyNoise  | 6h   | `ENRICHMENT_CACHE_TTL_GREYNOISE`    |
| fallback   | 1h   | `ENRICHMENT_CACHE_TTL_DEFAULT`      |

## Test plan
- [x] Cache miss calls upstream + stores
- [x] Cache hit skips upstream
- [x] TTL expiry triggers refetch
- [x] Invalidation endpoint clears cache + record
- [x] Invalidation respects tenant scope (returns 403 when validator denies)
- [x] Invalidation requires auth (401 without bearer)
- [x] VirusTotal / AbuseIPDB connectors round-trip through cache
- [x] Full pytest suite (287 passed)
- [x] `ruff check src/ tests/` clean

Closes #67