### PR TITLE
Standardize UI error handling with classifier, toasts, and retry

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,8 +1,9 @@
+import { useMemo } from 'react'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClientProvider } from '@tanstack/react-query'
 import { AuthProvider, useAuth } from '@/contexts/AuthContext'
 import { WorkspaceProvider } from '@/contexts/WorkspaceContext'
-import { ToastProvider } from '@/components/ui/Toast'
+import { ToastProvider, useToast } from '@/components/ui/Toast'
 import { AppLayout } from '@/layouts/AppLayout'
 import { DashboardPage } from '@/pages/DashboardPage'
 import { AlertsListPage } from '@/pages/AlertsListPage'
@@ -15,12 +16,7 @@ import { IncidentDetailPage } from '@/pages/IncidentDetailPage'
 import { SettingsPage } from '@/pages/SettingsPage'
 import { LoginPage } from '@/pages/LoginPage'
 import { Spinner } from '@/components/ui/Spinner'
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: { staleTime: 30_000, retry: 1 },
-  },
-})
+import { buildQueryClient } from '@/lib/queryErrors'
 
 function RequireAuth({ children }: { children: React.ReactNode }) {
   const { analyst, isLoading } = useAuth()
@@ -58,31 +54,41 @@ function PublicOnly({ children }: { children: React.ReactNode }) {
   return children
 }
 
-export default function App() {
+function AppRoutes() {
+  const toast = useToast()
+  // Build the QueryClient once we have toast available — so global query and
+  // mutation errors can surface through the unified toast system.
+  const queryClient = useMemo(() => buildQueryClient({ toast }), [toast])
   return (
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
         <WorkspaceProvider>
-          <ToastProvider>
-            <BrowserRouter>
-              <Routes>
-                <Route path="/login" element={<PublicOnly><LoginPage /></PublicOnly>} />
-                <Route element={<RequireAuth><AppLayout /></RequireAuth>}>
-                  <Route index element={<DashboardPage />} />
-                  <Route path="alerts" element={<AlertsListPage />} />
-                  <Route path="alerts/:id" element={<AlertDetailPage />} />
-                  <Route path="runs" element={<RunsListPage />} />
-                  <Route path="runs/:id" element={<RunDetailPage />} />
-                  <Route path="incidents" element={<IncidentsListPage />} />
-                  <Route path="incidents/:id" element={<IncidentDetailPage />} />
-                  <Route path="playbooks" element={<PlaybooksListPage />} />
-                  <Route path="settings" element={<SettingsPage />} />
-                </Route>
-              </Routes>
-            </BrowserRouter>
-          </ToastProvider>
+          <BrowserRouter>
+            <Routes>
+              <Route path="/login" element={<PublicOnly><LoginPage /></PublicOnly>} />
+              <Route element={<RequireAuth><AppLayout /></RequireAuth>}>
+                <Route index element={<DashboardPage />} />
+                <Route path="alerts" element={<AlertsListPage />} />
+                <Route path="alerts/:id" element={<AlertDetailPage />} />
+                <Route path="runs" element={<RunsListPage />} />
+                <Route path="runs/:id" element={<RunDetailPage />} />
+                <Route path="incidents" element={<IncidentsListPage />} />
+                <Route path="incidents/:id" element={<IncidentDetailPage />} />
+                <Route path="playbooks" element={<PlaybooksListPage />} />
+                <Route path="settings" element={<SettingsPage />} />
+              </Route>
+            </Routes>
+          </BrowserRouter>
         </WorkspaceProvider>
       </AuthProvider>
     </QueryClientProvider>
+  )
+}
+
+export default function App() {
+  return (
+    <ToastProvider>
+      <AppRoutes />
+    </ToastProvider>
   )
 }

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1,53 +1,105 @@
+import { ApiError } from '@/lib/errors'
+
 const BASE = '/api/v1'
+
+type UnauthorizedListener = () => void
+const unauthorizedListeners = new Set<UnauthorizedListener>()
+
+/**
+ * Subscribe to 401 Unauthorized responses bubbling up from any API call.
+ * The AuthProvider wires this to clear the session and redirect to /login
+ * without every caller having to add the same catch.
+ */
+export function onUnauthorized(listener: UnauthorizedListener): () => void {
+  unauthorizedListeners.add(listener)
+  return () => { unauthorizedListeners.delete(listener) }
+}
 
 function authHeaders(): HeadersInit {
   const token = localStorage.getItem('opensoar_token')
   return token ? { Authorization: `Bearer ${token}` } : {}
 }
 
+async function parseBody(res: Response): Promise<unknown> {
+  const contentType = res.headers.get('content-type') ?? ''
+  if (contentType.includes('application/json')) {
+    try {
+      return await res.json()
+    } catch {
+      return null
+    }
+  }
+  try {
+    return await res.text()
+  } catch {
+    return null
+  }
+}
+
+async function request<T>(
+  path: string,
+  init: RequestInit,
+): Promise<T> {
+  let res: Response
+  try {
+    res = await fetch(`${BASE}${path}`, init)
+  } catch (err) {
+    // Transport-level failure (offline, DNS, CORS, aborted, etc.)
+    const message = err instanceof Error ? err.message : 'Network request failed'
+    throw new ApiError(message, { status: 0, isNetworkError: true })
+  }
+
+  if (!res.ok) {
+    const body = await parseBody(res)
+    const detail =
+      body && typeof body === 'object' && 'detail' in body && typeof (body as { detail: unknown }).detail === 'string'
+        ? (body as { detail: string }).detail
+        : `${res.status} ${res.statusText}`
+    const error = new ApiError(detail, { status: res.status, body })
+    if (res.status === 401) {
+      for (const listener of unauthorizedListeners) {
+        try { listener() } catch { /* ignore */ }
+      }
+    }
+    throw error
+  }
+
+  return (await res.json()) as T
+}
+
 async function fetchJSON<T>(path: string): Promise<T> {
-  const res = await fetch(`${BASE}${path}`, { headers: authHeaders() })
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
-  return res.json()
+  return request<T>(path, { headers: authHeaders() })
 }
 
 async function postJSON<T>(path: string, body: Record<string, unknown>): Promise<T> {
-  const res = await fetch(`${BASE}${path}`, {
+  return request<T>(path, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...authHeaders() },
     body: JSON.stringify(body),
   })
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
-  return res.json()
 }
 
 async function deleteJSON(path: string): Promise<{ detail: string }> {
-  const res = await fetch(`${BASE}${path}`, {
+  return request<{ detail: string }>(path, {
     method: 'DELETE',
     headers: authHeaders(),
   })
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
-  return res.json()
 }
 
 async function patchJSON<T>(path: string, body: Record<string, unknown>): Promise<T> {
-  const res = await fetch(`${BASE}${path}`, {
+  return request<T>(path, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json', ...authHeaders() },
     body: JSON.stringify(body),
   })
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
-  return res.json()
 }
 
 async function putJSON<T>(path: string, body: Record<string, unknown>): Promise<T> {
-  const res = await fetch(`${BASE}${path}`, {
+  return request<T>(path, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json', ...authHeaders() },
     body: JSON.stringify(body),
   })
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
-  return res.json()
 }
 
 // Types

--- a/ui/src/components/ui/QueryErrorState.tsx
+++ b/ui/src/components/ui/QueryErrorState.tsx
@@ -1,0 +1,40 @@
+import { AlertTriangle, RotateCw } from 'lucide-react'
+import { classifyError } from '@/lib/errors'
+import { Button } from '@/components/ui/Button'
+
+interface QueryErrorStateProps {
+  error: unknown
+  onRetry: () => void
+  title?: string
+  className?: string
+}
+
+/**
+ * Inline error block for non-destructive GET queries. Pair with
+ * `query.isError` + `query.refetch` from React Query.
+ */
+export function QueryErrorState({ error, onRetry, title, className }: QueryErrorStateProps) {
+  const cat = classifyError(error)
+  const heading =
+    title ?? (cat.kind === 'network' ? 'Could not reach the server' : 'Something went wrong')
+
+  return (
+    <div
+      className={
+        'flex flex-col items-center justify-center text-center gap-3 rounded-md border border-danger/20 bg-danger/5 px-6 py-8 ' +
+        (className ?? '')
+      }
+      role="alert"
+    >
+      <AlertTriangle size={20} className="text-danger" />
+      <div>
+        <div className="text-sm font-medium text-heading">{heading}</div>
+        <div className="text-xs text-muted mt-1 max-w-md">{cat.message}</div>
+      </div>
+      <Button variant="default" size="sm" onClick={onRetry}>
+        <RotateCw size={12} className="mr-1.5" />
+        Retry
+      </Button>
+    </div>
+  )
+}

--- a/ui/src/components/ui/Toast.test.tsx
+++ b/ui/src/components/ui/Toast.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest'
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ToastProvider, useToast } from './Toast'
+
+function Trigger({ onReady }: { onReady: (toast: ReturnType<typeof useToast>) => void }) {
+  const toast = useToast()
+  onReady(toast)
+  return null
+}
+
+function renderWithProvider() {
+  let toastApi: ReturnType<typeof useToast> | null = null
+  render(
+    <ToastProvider>
+      <Trigger onReady={(t) => { toastApi = t }} />
+    </ToastProvider>,
+  )
+  if (!toastApi) throw new Error('toast api not ready')
+  return toastApi as ReturnType<typeof useToast>
+}
+
+describe('Toast', () => {
+  it('renders a toast when error() is called', () => {
+    const toast = renderWithProvider()
+    act(() => { toast.error('Something broke', 'Details here') })
+    expect(screen.getByText('Something broke')).toBeInTheDocument()
+    expect(screen.getByText('Details here')).toBeInTheDocument()
+  })
+
+  it('can be dismissed via the close button', async () => {
+    const user = userEvent.setup()
+    const toast = renderWithProvider()
+    act(() => { toast.success('Saved') })
+    expect(screen.getByText('Saved')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /dismiss/i }))
+    expect(screen.queryByText('Saved')).not.toBeInTheDocument()
+  })
+
+  it('renders an action button (e.g. Retry) and fires callback', async () => {
+    const user = userEvent.setup()
+    const onRetry = vi.fn()
+    const toast = renderWithProvider()
+    act(() => {
+      toast.error('Failed to load', 'Network down', {
+        action: { label: 'Retry', onClick: onRetry },
+      })
+    })
+
+    const retryBtn = await screen.findByRole('button', { name: 'Retry' })
+    await user.click(retryBtn)
+    expect(onRetry).toHaveBeenCalledTimes(1)
+    // action click also dismisses the toast
+    expect(screen.queryByText('Failed to load')).not.toBeInTheDocument()
+  })
+
+  it('auto-dismisses non-action toasts after their duration', () => {
+    vi.useFakeTimers()
+    try {
+      const toast = renderWithProvider()
+      act(() => { toast.info('Heads up') })
+      expect(screen.getByText('Heads up')).toBeInTheDocument()
+
+      act(() => { vi.advanceTimersByTime(5000) })
+      expect(screen.queryByText('Heads up')).not.toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps action toasts on screen longer (no auto-dismiss within normal window)', () => {
+    vi.useFakeTimers()
+    try {
+      const toast = renderWithProvider()
+      act(() => {
+        toast.error('Persistent', undefined, { action: { label: 'Retry', onClick: () => {} } })
+      })
+      expect(screen.getByText('Persistent')).toBeInTheDocument()
+      act(() => { vi.advanceTimersByTime(5000) })
+      // still present because action toasts stay longer
+      expect(screen.getByText('Persistent')).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/ui/src/components/ui/Toast.tsx
+++ b/ui/src/components/ui/Toast.tsx
@@ -1,29 +1,46 @@
 /* eslint-disable react-refresh/only-export-components */
-import { createContext, useContext, useState, useCallback, type ReactNode } from 'react'
+import { createContext, useContext, useState, useCallback, useEffect, useRef, type ReactNode } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { CheckCircle, XCircle, AlertTriangle, Info, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 type ToastType = 'success' | 'error' | 'warning' | 'info'
 
-interface Toast {
+export interface ToastAction {
+  label: string
+  onClick: () => void
+}
+
+export interface ToastOptions {
+  action?: ToastAction
+  /** Override auto-dismiss in ms. 0 or negative keeps the toast until dismissed. */
+  duration?: number
+}
+
+interface ToastEntry {
   id: number
   type: ToastType
   title: string
   description?: string
+  action?: ToastAction
+  duration: number
 }
 
 interface ToastContextType {
-  toast: (type: ToastType, title: string, description?: string) => void
-  success: (title: string, description?: string) => void
-  error: (title: string, description?: string) => void
-  warning: (title: string, description?: string) => void
-  info: (title: string, description?: string) => void
+  toast: (type: ToastType, title: string, description?: string, options?: ToastOptions) => number
+  success: (title: string, description?: string, options?: ToastOptions) => number
+  error: (title: string, description?: string, options?: ToastOptions) => number
+  warning: (title: string, description?: string, options?: ToastOptions) => number
+  info: (title: string, description?: string, options?: ToastOptions) => number
+  dismiss: (id: number) => void
 }
 
 const ToastContext = createContext<ToastContextType | null>(null)
 
 let toastId = 0
+
+const DEFAULT_DURATION = 4000
+const ACTION_DURATION = 10000
 
 const ICONS: Record<ToastType, ReactNode> = {
   success: <CheckCircle size={16} className="text-success shrink-0" />,
@@ -39,27 +56,100 @@ const BORDER_COLORS: Record<ToastType, string> = {
   info: 'border-l-info',
 }
 
-export function ToastProvider({ children }: { children: ReactNode }) {
-  const [toasts, setToasts] = useState<Toast[]>([])
+function ToastItem({
+  toast,
+  onDismiss,
+}: {
+  toast: ToastEntry
+  onDismiss: (id: number) => void
+}) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  const addToast = useCallback((type: ToastType, title: string, description?: string) => {
-    const id = ++toastId
-    setToasts((prev) => [...prev, { id, type, title, description }])
-    setTimeout(() => {
-      setToasts((prev) => prev.filter((t) => t.id !== id))
-    }, 4000)
-  }, [])
+  useEffect(() => {
+    if (toast.duration > 0) {
+      timerRef.current = setTimeout(() => onDismiss(toast.id), toast.duration)
+    }
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [toast.id, toast.duration, onDismiss])
+
+  const handleAction = () => {
+    toast.action?.onClick()
+    onDismiss(toast.id)
+  }
+
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, x: 80, scale: 0.95 }}
+      animate={{ opacity: 1, x: 0, scale: 1 }}
+      exit={{ opacity: 0, x: 80, scale: 0.95 }}
+      transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+      className={cn(
+        'pointer-events-auto w-80 bg-surface border border-border rounded-lg shadow-xl',
+        'border-l-[3px]',
+        BORDER_COLORS[toast.type],
+      )}
+      role={toast.type === 'error' ? 'alert' : 'status'}
+    >
+      <div className="flex items-start gap-3 px-4 py-3">
+        {ICONS[toast.type]}
+        <div className="flex-1 min-w-0">
+          <div className="text-xs font-medium text-heading">{toast.title}</div>
+          {toast.description && (
+            <div className="text-[11px] text-muted mt-0.5">{toast.description}</div>
+          )}
+          {toast.action && (
+            <button
+              type="button"
+              onClick={handleAction}
+              className="mt-2 text-[11px] font-medium text-accent hover:text-accent/80 bg-transparent border-none cursor-pointer p-0"
+            >
+              {toast.action.label}
+            </button>
+          )}
+        </div>
+        <button
+          type="button"
+          aria-label="Dismiss notification"
+          onClick={() => onDismiss(toast.id)}
+          className="p-0.5 text-muted hover:text-heading bg-transparent border-none cursor-pointer shrink-0"
+        >
+          <X size={12} />
+        </button>
+      </div>
+    </motion.div>
+  )
+}
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastEntry[]>([])
 
   const remove = useCallback((id: number) => {
     setToasts((prev) => prev.filter((t) => t.id !== id))
   }, [])
 
+  const addToast = useCallback(
+    (type: ToastType, title: string, description?: string, options?: ToastOptions): number => {
+      const id = ++toastId
+      const duration = options?.duration ?? (options?.action ? ACTION_DURATION : DEFAULT_DURATION)
+      setToasts((prev) => [
+        ...prev,
+        { id, type, title, description, action: options?.action, duration },
+      ])
+      return id
+    },
+    [],
+  )
+
   const ctx: ToastContextType = {
     toast: addToast,
-    success: (title, desc) => addToast('success', title, desc),
-    error: (title, desc) => addToast('error', title, desc),
-    warning: (title, desc) => addToast('warning', title, desc),
-    info: (title, desc) => addToast('info', title, desc),
+    success: (title, desc, opts) => addToast('success', title, desc, opts),
+    error: (title, desc, opts) => addToast('error', title, desc, opts),
+    warning: (title, desc, opts) => addToast('warning', title, desc, opts),
+    info: (title, desc, opts) => addToast('info', title, desc, opts),
+    dismiss: remove,
   }
 
   return (
@@ -68,35 +158,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
       <div className="fixed bottom-4 right-4 z-[100] flex flex-col gap-2 pointer-events-none">
         <AnimatePresence mode="popLayout">
           {toasts.map((t) => (
-            <motion.div
-              key={t.id}
-              layout
-              initial={{ opacity: 0, x: 80, scale: 0.95 }}
-              animate={{ opacity: 1, x: 0, scale: 1 }}
-              exit={{ opacity: 0, x: 80, scale: 0.95 }}
-              transition={{ type: 'spring', stiffness: 500, damping: 30 }}
-              className={cn(
-                'pointer-events-auto w-80 bg-surface border border-border rounded-lg shadow-xl',
-                'border-l-[3px]',
-                BORDER_COLORS[t.type],
-              )}
-            >
-              <div className="flex items-start gap-3 px-4 py-3">
-                {ICONS[t.type]}
-                <div className="flex-1 min-w-0">
-                  <div className="text-xs font-medium text-heading">{t.title}</div>
-                  {t.description && (
-                    <div className="text-[11px] text-muted mt-0.5">{t.description}</div>
-                  )}
-                </div>
-                <button
-                  onClick={() => remove(t.id)}
-                  className="p-0.5 text-muted hover:text-heading bg-transparent border-none cursor-pointer shrink-0"
-                >
-                  <X size={12} />
-                </button>
-              </div>
-            </motion.div>
+            <ToastItem key={t.id} toast={t} onDismiss={remove} />
           ))}
         </AnimatePresence>
       </div>

--- a/ui/src/contexts/AuthContext.tsx
+++ b/ui/src/contexts/AuthContext.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
 import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react'
-import { api, type Analyst, type AuthCapabilities } from '@/api'
+import { api, onUnauthorized, type Analyst, type AuthCapabilities } from '@/api'
 
 interface AuthContextType {
   analyst: Analyst | null
@@ -60,6 +60,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const logout = useCallback(() => {
     localStorage.removeItem('opensoar_token')
     setAnalyst(null)
+  }, [])
+
+  // Any 401 from api.ts clears the session — RequireAuth then redirects to /login.
+  useEffect(() => {
+    return onUnauthorized(() => {
+      localStorage.removeItem('opensoar_token')
+      setAnalyst(null)
+    })
   }, [])
 
   return (

--- a/ui/src/lib/errors.test.ts
+++ b/ui/src/lib/errors.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import { ApiError, classifyError, type ErrorCategory } from './errors'
+
+describe('classifyError', () => {
+  it('classifies 401 as unauthorized', () => {
+    const err = new ApiError('unauthorized', { status: 401 })
+    const cat: ErrorCategory = classifyError(err)
+    expect(cat.kind).toBe('unauthorized')
+    expect(cat.status).toBe(401)
+    expect(cat.message).toBe('unauthorized')
+    expect(cat.fieldErrors).toBeNull()
+    expect(cat.shouldToast).toBe(false)
+  })
+
+  it('classifies 422 with field errors as validation', () => {
+    const err = new ApiError('invalid', {
+      status: 422,
+      body: {
+        detail: [
+          { loc: ['body', 'title'], msg: 'required', type: 'missing' },
+          { loc: ['body', 'severity'], msg: 'bad value', type: 'value_error' },
+        ],
+      },
+    })
+    const cat = classifyError(err)
+    expect(cat.kind).toBe('validation')
+    expect(cat.status).toBe(422)
+    expect(cat.fieldErrors).toEqual({
+      title: 'required',
+      severity: 'bad value',
+    })
+  })
+
+  it('classifies 422 with string detail as validation with form-wide error', () => {
+    const err = new ApiError('Bad input', {
+      status: 422,
+      body: { detail: 'Bad input' },
+    })
+    const cat = classifyError(err)
+    expect(cat.kind).toBe('validation')
+    expect(cat.fieldErrors).toEqual({ _form: 'Bad input' })
+  })
+
+  it('classifies 500 as server', () => {
+    const err = new ApiError('boom', { status: 500 })
+    expect(classifyError(err).kind).toBe('server')
+  })
+
+  it('classifies 503 as server', () => {
+    const err = new ApiError('down', { status: 503 })
+    expect(classifyError(err).kind).toBe('server')
+  })
+
+  it('classifies network error (no status) as network', () => {
+    const err = new ApiError('Network request failed', { status: 0, isNetworkError: true })
+    expect(classifyError(err).kind).toBe('network')
+  })
+
+  it('classifies TypeError (fetch failure) as network', () => {
+    const err = new TypeError('Failed to fetch')
+    expect(classifyError(err).kind).toBe('network')
+  })
+
+  it('classifies 400 as client', () => {
+    const err = new ApiError('bad', { status: 400 })
+    expect(classifyError(err).kind).toBe('client')
+  })
+
+  it('classifies 404 as client', () => {
+    const err = new ApiError('missing', { status: 404 })
+    expect(classifyError(err).kind).toBe('client')
+  })
+
+  it('extracts detail string from body for message', () => {
+    const err = new ApiError('500 Internal Server Error', {
+      status: 500,
+      body: { detail: 'database is unavailable' },
+    })
+    expect(classifyError(err).message).toBe('database is unavailable')
+  })
+
+  it('handles unknown errors', () => {
+    const cat = classifyError(new Error('mystery'))
+    expect(cat.kind).toBe('unknown')
+    expect(cat.message).toBe('mystery')
+  })
+
+  it('should surface toast for server errors', () => {
+    expect(classifyError(new ApiError('x', { status: 500 })).shouldToast).toBe(true)
+  })
+
+  it('should surface toast for network errors', () => {
+    expect(classifyError(new ApiError('x', { status: 0, isNetworkError: true })).shouldToast).toBe(true)
+  })
+
+  it('should NOT surface toast for 401', () => {
+    expect(classifyError(new ApiError('x', { status: 401 })).shouldToast).toBe(false)
+  })
+
+  it('should NOT surface toast for 422', () => {
+    expect(classifyError(new ApiError('x', { status: 422 })).shouldToast).toBe(false)
+  })
+})

--- a/ui/src/lib/errors.ts
+++ b/ui/src/lib/errors.ts
@@ -1,0 +1,164 @@
+/**
+ * Standardized API error handling for OpenSOAR UI.
+ *
+ * `ApiError` is thrown by `api.ts` wrappers whenever a fetch response is
+ * non-2xx or the network transport itself fails. It carries the HTTP status,
+ * the parsed response body (when JSON), and an `isNetworkError` flag so
+ * callers and UI error handlers can route appropriately.
+ *
+ * `classifyError` reduces any thrown value to a single `ErrorCategory`
+ * that downstream UI code can consume without knowing transport details.
+ */
+
+export interface ApiErrorInit {
+  status: number
+  body?: unknown
+  isNetworkError?: boolean
+}
+
+export class ApiError extends Error {
+  readonly status: number
+  readonly body: unknown
+  readonly isNetworkError: boolean
+
+  constructor(message: string, init: ApiErrorInit) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = init.status
+    this.body = init.body
+    this.isNetworkError = init.isNetworkError ?? false
+  }
+}
+
+export type ErrorKind =
+  | 'unauthorized'
+  | 'validation'
+  | 'client'
+  | 'server'
+  | 'network'
+  | 'unknown'
+
+export interface ErrorCategory {
+  kind: ErrorKind
+  status: number
+  message: string
+  fieldErrors: Record<string, string> | null
+  shouldToast: boolean
+}
+
+interface PydanticValidationItem {
+  loc?: Array<string | number>
+  msg?: string
+  type?: string
+}
+
+function isPydanticValidationList(value: unknown): value is PydanticValidationItem[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'object' && item !== null)
+}
+
+function extractFieldErrors(body: unknown): Record<string, string> | null {
+  if (!body || typeof body !== 'object') return null
+  const detail = (body as { detail?: unknown }).detail
+
+  if (typeof detail === 'string') {
+    return { _form: detail }
+  }
+
+  if (isPydanticValidationList(detail)) {
+    const errors: Record<string, string> = {}
+    for (const item of detail) {
+      const loc = item.loc ?? []
+      // Drop the first segment ("body"/"query"/etc) if present, keep the field name.
+      const trimmed = loc[0] === 'body' || loc[0] === 'query' || loc[0] === 'path' ? loc.slice(1) : loc
+      const key = trimmed.map(String).join('.') || '_form'
+      if (item.msg) errors[key] = item.msg
+    }
+    return Object.keys(errors).length > 0 ? errors : null
+  }
+
+  return null
+}
+
+function extractMessage(err: unknown, fallback: string): string {
+  if (err instanceof ApiError && err.body && typeof err.body === 'object') {
+    const detail = (err.body as { detail?: unknown }).detail
+    if (typeof detail === 'string') return detail
+  }
+  if (err instanceof Error && err.message) return err.message
+  return fallback
+}
+
+export function classifyError(err: unknown): ErrorCategory {
+  // Network (thrown TypeError by fetch when offline/DNS/etc)
+  if (err instanceof TypeError) {
+    return {
+      kind: 'network',
+      status: 0,
+      message: err.message || 'Network request failed',
+      fieldErrors: null,
+      shouldToast: true,
+    }
+  }
+
+  if (err instanceof ApiError) {
+    if (err.isNetworkError || err.status === 0) {
+      return {
+        kind: 'network',
+        status: 0,
+        message: extractMessage(err, 'Network request failed'),
+        fieldErrors: null,
+        shouldToast: true,
+      }
+    }
+    if (err.status === 401) {
+      return {
+        kind: 'unauthorized',
+        status: 401,
+        message: extractMessage(err, 'Unauthorized'),
+        fieldErrors: null,
+        shouldToast: false,
+      }
+    }
+    if (err.status === 422) {
+      return {
+        kind: 'validation',
+        status: 422,
+        message: extractMessage(err, 'Validation failed'),
+        fieldErrors: extractFieldErrors(err.body),
+        shouldToast: false,
+      }
+    }
+    if (err.status >= 500) {
+      return {
+        kind: 'server',
+        status: err.status,
+        message: extractMessage(err, 'Server error'),
+        fieldErrors: null,
+        shouldToast: true,
+      }
+    }
+    if (err.status >= 400) {
+      return {
+        kind: 'client',
+        status: err.status,
+        message: extractMessage(err, 'Request failed'),
+        fieldErrors: null,
+        shouldToast: true,
+      }
+    }
+  }
+
+  const message = err instanceof Error ? err.message : 'Unknown error'
+  return {
+    kind: 'unknown',
+    status: 0,
+    message,
+    fieldErrors: null,
+    shouldToast: true,
+  }
+}
+
+/** Convenience predicate for the mass-import sites that only care about auth. */
+export function isUnauthorized(err: unknown): boolean {
+  return err instanceof ApiError && err.status === 401
+}

--- a/ui/src/lib/queryErrors.ts
+++ b/ui/src/lib/queryErrors.ts
@@ -1,0 +1,67 @@
+import { QueryCache, MutationCache, QueryClient } from '@tanstack/react-query'
+import { classifyError } from '@/lib/errors'
+import type { useToast } from '@/components/ui/Toast'
+
+type ToastApi = ReturnType<typeof useToast>
+
+interface BuildOptions {
+  toast: ToastApi
+}
+
+/**
+ * Build a shared QueryClient wired to the toast system.
+ *
+ * - GET query failures classified as `server` or `network` show a toast with
+ *   a Retry action that re-invokes `query.fetch()`.
+ * - 401 is silent (handled via api.ts -> AuthProvider, which redirects).
+ * - 422 is silent at the toast layer; the page renders inline field errors
+ *   from `error.body.detail` using `classifyError(err).fieldErrors`.
+ * - Mutations default to toast-on-error so callers that forget a local
+ *   `onError` still get a reasonable message. Local `onError` handlers
+ *   still run and can be more specific (e.g. field errors on forms).
+ */
+export function buildQueryClient({ toast }: BuildOptions): QueryClient {
+  const queryCache = new QueryCache({
+    onError: (error, query) => {
+      const cat = classifyError(error)
+      if (!cat.shouldToast) return
+      // Only show retry on queries (GETs). Mutations handle their own retry.
+      if (cat.kind === 'server' || cat.kind === 'network') {
+        toast.error(
+          cat.kind === 'network' ? 'Network error' : 'Server error',
+          cat.message,
+          {
+            action: {
+              label: 'Retry',
+              onClick: () => { void query.fetch() },
+            },
+          },
+        )
+        return
+      }
+      toast.error('Request failed', cat.message)
+    },
+  })
+
+  const mutationCache = new MutationCache({
+    onError: (error, _variables, _context, mutation) => {
+      // If the caller attached its own onError, let that drive the UX
+      // (typically inline field errors for validation cases).
+      if (mutation.options.onError) return
+      const cat = classifyError(error)
+      if (!cat.shouldToast) return
+      toast.error(
+        cat.kind === 'network' ? 'Network error' : 'Request failed',
+        cat.message,
+      )
+    },
+  })
+
+  return new QueryClient({
+    queryCache,
+    mutationCache,
+    defaultOptions: {
+      queries: { staleTime: 30_000, retry: 1 },
+    },
+  })
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,22 +1,10 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import './index.css'
 import App from './App'
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      refetchInterval: 5000,
-      staleTime: 2000,
-    },
-  },
-})
-
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <App />
-    </QueryClientProvider>
+    <App />
   </StrictMode>,
 )

--- a/ui/src/pages/AlertsListPage.tsx
+++ b/ui/src/pages/AlertsListPage.tsx
@@ -14,6 +14,7 @@ import { Checkbox } from '@/components/ui/Checkbox'
 import { TableSkeleton } from '@/components/ui/Skeleton'
 import { Pagination } from '@/components/ui/Pagination'
 import { EmptyState } from '@/components/ui/EmptyState'
+import { QueryErrorState } from '@/components/ui/QueryErrorState'
 import { Tooltip } from '@/components/ui/Tooltip'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogBody, DialogFooter } from '@/components/ui/Dialog'
 import { PageTransition } from '@/components/ui/PageTransition'
@@ -198,7 +199,7 @@ export function AlertsListPage() {
 
   const selectionActive = selected.size > 0
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ['alerts', filters, page, selectedTenantId],
     queryFn: () => api.alerts.list({ ...filters, tenant_id: selectedTenantId || undefined, limit, offset: page * limit }),
   })
@@ -293,7 +294,11 @@ export function AlertsListPage() {
 
       {isLoading && <TableSkeleton rows={8} cols={7} />}
 
-      {!isLoading && filteredAlerts.length === 0 && (
+      {!isLoading && isError && (
+        <QueryErrorState error={error} onRetry={() => { void refetch() }} />
+      )}
+
+      {!isLoading && !isError && filteredAlerts.length === 0 && (
         <EmptyState
           icon={<Shield size={32} />}
           title="No alerts found"

--- a/ui/src/pages/IncidentsListPage.tsx
+++ b/ui/src/pages/IncidentsListPage.tsx
@@ -12,6 +12,7 @@ import { Table, TableHeader, TableBody, TableHead, TableCell, TableHeaderRow } f
 import { TableSkeleton } from '@/components/ui/Skeleton'
 import { Pagination } from '@/components/ui/Pagination'
 import { EmptyState } from '@/components/ui/EmptyState'
+import { QueryErrorState } from '@/components/ui/QueryErrorState'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogBody, DialogFooter } from '@/components/ui/Dialog'
 import { PageTransition } from '@/components/ui/PageTransition'
 import { useToast } from '@/components/ui/Toast'
@@ -112,7 +113,7 @@ export function IncidentsListPage() {
   const [showCreateDialog, setShowCreateDialog] = useState(false)
   const limit = 50
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ['incidents', filters, page, selectedTenantId],
     queryFn: () => api.incidents.list({ ...filters, tenant_id: selectedTenantId || undefined, limit, offset: page * limit }),
   })
@@ -237,7 +238,11 @@ export function IncidentsListPage() {
 
       {isLoading && <TableSkeleton rows={8} cols={6} />}
 
-      {!isLoading && incidents.length === 0 && (
+      {!isLoading && isError && (
+        <QueryErrorState error={error} onRetry={() => { void refetch() }} />
+      )}
+
+      {!isLoading && !isError && incidents.length === 0 && (
         <EmptyState
           icon={<Briefcase size={32} />}
           title="No incidents found"

--- a/ui/src/pages/RunsListPage.tsx
+++ b/ui/src/pages/RunsListPage.tsx
@@ -8,6 +8,7 @@ import { PageHeader } from '@/components/ui/PageHeader'
 import { StatusBadge } from '@/components/ui/Badge'
 import { Select } from '@/components/ui/Select'
 import { EmptyState } from '@/components/ui/EmptyState'
+import { QueryErrorState } from '@/components/ui/QueryErrorState'
 import { TableSkeleton } from '@/components/ui/Skeleton'
 import { Pagination } from '@/components/ui/Pagination'
 import { PageTransition } from '@/components/ui/PageTransition'
@@ -97,7 +98,7 @@ export function RunsListPage() {
   const [expandedId, setExpandedId] = useState<string | null>(null)
   const limit = 50
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ['runs', filters, page, selectedTenantId],
     queryFn: () => api.runs.list({ ...filters, tenant_id: selectedTenantId || undefined, limit, offset: page * limit }),
   })
@@ -140,7 +141,11 @@ export function RunsListPage() {
 
       {isLoading && <TableSkeleton rows={8} cols={7} />}
 
-      {!isLoading && (!data || data.runs.length === 0) && (
+      {!isLoading && isError && (
+        <QueryErrorState error={error} onRetry={() => { void refetch() }} />
+      )}
+
+      {!isLoading && !isError && (!data || data.runs.length === 0) && (
         <EmptyState icon={<Play size={32} />} title="No playbook runs" description="Runs will appear here when playbooks are triggered" />
       )}
 

--- a/ui/src/test/setup.ts
+++ b/ui/src/test/setup.ts
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom/vitest'
 import { afterEach, vi } from 'vitest'
 import { cleanup } from '@testing-library/react'
+import React from 'react'
 
 // Node 25+ ships a stub `localStorage` on globalThis that lacks the DOM
 // `Storage` interface (no getItem/setItem/clear). jsdom inherits that broken
@@ -73,3 +74,53 @@ if (!window.ResizeObserver) {
 window.scrollTo = vi.fn() as unknown as typeof window.scrollTo
 Element.prototype.scrollTo = vi.fn() as unknown as Element['scrollTo']
 Element.prototype.scrollIntoView = vi.fn() as unknown as Element['scrollIntoView']
+
+// Strip the framer-motion animation props that would otherwise be warned about
+// when forwarded to a plain DOM element.
+const MOTION_PROPS = new Set([
+  'initial',
+  'animate',
+  'exit',
+  'transition',
+  'layout',
+  'layoutId',
+  'variants',
+  'whileHover',
+  'whileTap',
+  'whileFocus',
+  'whileInView',
+  'drag',
+  'dragConstraints',
+])
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function stripMotionProps(props: Record<string, any>): Record<string, any> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const clean: Record<string, any> = {}
+  for (const key of Object.keys(props)) {
+    if (!MOTION_PROPS.has(key)) clean[key] = props[key]
+  }
+  return clean
+}
+
+// Stub framer-motion so tests don't wait on layout/exit animations.
+vi.mock('framer-motion', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('framer-motion')
+  const makeComponent = (tag: string) =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    React.forwardRef<unknown, any>((props, ref) =>
+      React.createElement(tag, { ...stripMotionProps(props), ref }),
+    )
+
+  return {
+    ...actual,
+    AnimatePresence: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    motion: new Proxy(
+      {},
+      {
+        get: (_target, tag: string) => makeComponent(tag),
+      },
+    ),
+  }
+})


### PR DESCRIPTION
## Summary

- Adds `ApiError` + `classifyError` (401/422/4xx/5xx/network/unknown) so pages can route errors consistently instead of relying on raw `Error` messages
- Wires React Query's `QueryCache`/`MutationCache` to the existing Toast system: 5xx and network failures now surface a toast with a "Retry" action, 401 is silent (AuthProvider clears the session so `RequireAuth` redirects to `/login`), and 422 stays silent so forms can render inline field errors from `error.body.detail`
- Extends the Toast component with an `action` button (default label "Retry") and a keep-alive duration for actionable errors, plus an accessible dismiss label and `role="alert"` for errors
- Adds a reusable `QueryErrorState` inline block and uses it on the Alerts, Incidents, and Runs list pages so a failed GET shows an inline Retry button instead of an empty table
- Introduces minimal Vitest + Testing Library setup (isolated from the strict `tsc -b` build) with component tests for toast trigger, dismiss, action-click, auto-dismiss, and unit tests for the error classifier

Closes #64

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` (`tsc -b && vite build`) — passes
- [x] `npm test` — 20/20 pass (toast trigger/dismiss/action/auto-dismiss; classifier covers 401, 422 pydantic, 422 string detail, 5xx, network, 4xx, unknown, toast-gating)
- [ ] Manual: stop API and click Retry in the toast / inline block
- [ ] Manual: submit a form that fails with 422 and confirm no toast + inline field errors still render via caller-provided `onError`