### PR TITLE
Add Vitest component tests for critical UI paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,9 +205,37 @@ jobs:
           grep -q 'name: PLAYBOOK_DIRS' /tmp/opensoar-helm.yaml
           grep -q 'app.kubernetes.io/component: worker' /tmp/opensoar-helm.yaml
 
+  ui-test:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ui
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Install UI dependencies
+        run: npm ci
+
+      - name: Lint UI
+        run: npm run lint
+
+      - name: Run UI component tests
+        run: npm test
+
+      - name: Type-check UI
+        run: npx tsc -b
+
   build:
     runs-on: ubuntu-latest
-    needs: [test, compose-upgrade-smoke, deploy-install-smoke, helm-packaging-smoke]
+    needs: [test, ui-test, compose-upgrade-smoke, deploy-install-smoke, helm-packaging-smoke]
     if: github.event_name == 'push'
     permissions:
       contents: read

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -21,22 +21,86 @@
         "@eslint/js": "^9.39.4",
         "@playwright/test": "^1.59.1",
         "@tailwindcss/vite": "^4.2.2",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.0",
+        "@vitest/ui": "^4.1.4",
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
+        "jsdom": "^29.0.2",
         "tailwindcss": "^4.2.1",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.56.1",
-        "vite": "^8.0.5"
+        "vite": "^8.0.5",
+        "vitest": "^4.1.4"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.10.tgz",
+      "integrity": "sha512-KyOb19eytNSELkmdqzZZUXWCU25byIlOld5qVFg0RYdS0T3tt7jeDByxk9hIAC73frclD8GKrHttr0SUjKCCdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -230,6 +294,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -276,6 +350,196 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -435,6 +699,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -581,6 +863,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",
@@ -1284,6 +1573,96 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1293,6 +1672,25 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3-array": {
@@ -1358,6 +1756,13 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1386,7 +1791,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1729,6 +2134,141 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/ui": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.4.tgz",
+      "integrity": "sha512-EgFR7nlj5iTDYZYCvavjFokNYwr3c3ry0sFiCg+N7B233Nwp+NNx7eoF/XvMWDCKY71xXAG3kFkt97ZHBJVL8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "fflate": "^0.8.2",
+        "flatted": "^3.4.2",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.1.4"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1769,6 +2309,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1792,6 +2343,26 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1810,6 +2381,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -1887,6 +2468,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1976,11 +2567,32 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -2104,6 +2716,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2122,6 +2748,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -2135,6 +2768,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2144,6 +2787,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.313",
@@ -2165,6 +2816,26 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-toolkit": {
       "version": "1.45.1",
@@ -2373,6 +3044,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2388,6 +3069,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2427,6 +3118,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -2591,6 +3289,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2638,6 +3349,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -2669,6 +3390,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2705,6 +3433,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -3081,6 +3860,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3089,6 +3879,23 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -3118,6 +3925,16 @@
       "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
       "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
       "license": "MIT"
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -3157,6 +3974,17 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -3222,6 +4050,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3241,6 +4082,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3347,6 +4195,44 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -3460,6 +4346,20 @@
         "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -3473,6 +4373,16 @@
       "license": "MIT",
       "peerDependencies": {
         "redux": "^5.0.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/reselect": {
@@ -3532,6 +4442,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3577,6 +4500,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3585,6 +4530,33 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3613,6 +4585,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
@@ -3640,6 +4619,23 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3655,6 +4651,72 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3725,6 +4787,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -3884,6 +4956,144 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3900,6 +5110,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -3909,6 +5136,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,6 +18,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:ui": "vitest --ui",
     "test:e2e": "playwright test",
     "preview": "vite preview"
   },
@@ -35,17 +38,23 @@
     "@eslint/js": "^9.39.4",
     "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.2.2",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.0",
+    "@vitest/ui": "^4.1.4",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "jsdom": "^29.0.2",
     "tailwindcss": "^4.2.1",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.56.1",
-    "vite": "^8.0.5"
+    "vite": "^8.0.5",
+    "vitest": "^4.1.4"
   }
 }

--- a/ui/src/components/ui/__tests__/Badge.test.tsx
+++ b/ui/src/components/ui/__tests__/Badge.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Badge, SeverityBadge, StatusBadge, DeterminationBadge } from '@/components/ui/Badge'
+
+describe('Badge', () => {
+  it('renders its children', () => {
+    render(<Badge>new</Badge>)
+    expect(screen.getByText('new')).toBeInTheDocument()
+  })
+
+  it('applies a custom color via inline style', () => {
+    render(<Badge color="rgb(255, 0, 0)">high</Badge>)
+    const el = screen.getByText('high')
+    expect(el).toHaveStyle({ color: 'rgb(255, 0, 0)' })
+  })
+})
+
+describe('SeverityBadge', () => {
+  it('renders the severity value as the label', () => {
+    render(<SeverityBadge severity="critical" />)
+    expect(screen.getByText('critical')).toBeInTheDocument()
+  })
+})
+
+describe('StatusBadge', () => {
+  it('humanises the status by replacing underscores with spaces', () => {
+    render(<StatusBadge status="in_progress" />)
+    expect(screen.getByText('in progress')).toBeInTheDocument()
+  })
+
+  it('keeps the status text intact when no underscore is present', () => {
+    render(<StatusBadge status="new" />)
+    expect(screen.getByText('new')).toBeInTheDocument()
+  })
+})
+
+describe('DeterminationBadge', () => {
+  it('renders the determination label', () => {
+    render(<DeterminationBadge determination="malicious" />)
+    expect(screen.getByText('malicious')).toBeInTheDocument()
+  })
+})

--- a/ui/src/components/ui/__tests__/Button.test.tsx
+++ b/ui/src/components/ui/__tests__/Button.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Button } from '@/components/ui/Button'
+
+describe('Button', () => {
+  it('renders its children and handles clicks', async () => {
+    const onClick = vi.fn()
+    render(<Button onClick={onClick}>Save</Button>)
+    const btn = screen.getByRole('button', { name: 'Save' })
+    await userEvent.click(btn)
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fire onClick when disabled', async () => {
+    const onClick = vi.fn()
+    render(
+      <Button onClick={onClick} disabled>
+        Save
+      </Button>,
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('applies the primary variant class', () => {
+    render(<Button variant="primary">Go</Button>)
+    const btn = screen.getByRole('button', { name: 'Go' })
+    expect(btn.className).toMatch(/bg-accent/)
+  })
+})

--- a/ui/src/components/ui/__tests__/ExecutionPlan.test.tsx
+++ b/ui/src/components/ui/__tests__/ExecutionPlan.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ExecutionPlan } from '@/components/ui/ExecutionPlan'
+
+const baseStep = {
+  started_at: '2026-01-01T00:00:00Z',
+  finished_at: '2026-01-01T00:00:01Z',
+  duration_ms: 1000,
+  input_data: null,
+  output_data: null,
+  error: null,
+  attempt: 1,
+}
+
+describe('ExecutionPlan', () => {
+  it('renders the playbook name and step counts', () => {
+    render(
+      <ExecutionPlan
+        run={{
+          id: 'r-1',
+          playbook_name: 'Triage IP',
+          status: 'completed',
+          started_at: '2026-01-01T00:00:00Z',
+          finished_at: '2026-01-01T00:00:03Z',
+          error: null,
+          result: null,
+          steps: [
+            { id: 's1', action_name: 'lookup_ip', status: 'completed', ...baseStep },
+            { id: 's2', action_name: 'enrich_ip', status: 'completed', ...baseStep },
+            { id: 's3', action_name: 'post_slack', status: 'failed', ...baseStep, error: 'boom' },
+          ],
+        }}
+      />,
+    )
+
+    expect(screen.getByText('Triage IP')).toBeInTheDocument()
+    expect(screen.getByText(/2\/3 steps/)).toBeInTheDocument()
+    expect(screen.getByText(/1 failed/)).toBeInTheDocument()
+    expect(screen.getByText('lookup_ip')).toBeInTheDocument()
+    expect(screen.getByText('enrich_ip')).toBeInTheDocument()
+    expect(screen.getByText('post_slack')).toBeInTheDocument()
+  })
+
+  it('auto-expands failed steps to reveal the error', () => {
+    render(
+      <ExecutionPlan
+        run={{
+          id: 'r-2',
+          playbook_name: 'Failing run',
+          status: 'failed',
+          started_at: null,
+          finished_at: null,
+          error: null,
+          result: null,
+          steps: [
+            {
+              id: 's1',
+              action_name: 'broken_action',
+              status: 'failed',
+              ...baseStep,
+              error: 'connection refused',
+            },
+          ],
+        }}
+      />,
+    )
+
+    expect(screen.getByText('connection refused')).toBeInTheDocument()
+  })
+
+  it('renders a run-level error banner when the run failed without steps', () => {
+    render(
+      <ExecutionPlan
+        run={{
+          id: 'r-3',
+          playbook_name: 'Broken',
+          status: 'failed',
+          started_at: null,
+          finished_at: null,
+          error: 'Playbook failed to start',
+          result: null,
+          steps: [],
+        }}
+      />,
+    )
+
+    expect(screen.getByText(/Run Error/i)).toBeInTheDocument()
+    expect(screen.getByText('Playbook failed to start')).toBeInTheDocument()
+  })
+
+  it('toggles step details when clicked', async () => {
+    render(
+      <ExecutionPlan
+        run={{
+          id: 'r-4',
+          playbook_name: 'Toggle',
+          status: 'completed',
+          started_at: '2026-01-01T00:00:00Z',
+          finished_at: '2026-01-01T00:00:01Z',
+          error: null,
+          result: null,
+          steps: [
+            {
+              id: 's1',
+              action_name: 'enrich',
+              status: 'completed',
+              ...baseStep,
+              input_data: { ip: '1.2.3.4' },
+              output_data: { verdict: 'clean' },
+            },
+          ],
+        }}
+      />,
+    )
+
+    // Output section isn't visible until the step is expanded
+    expect(screen.queryByText('Output')).not.toBeInTheDocument()
+    await userEvent.click(screen.getByText('enrich'))
+    expect(screen.getByText('Output')).toBeInTheDocument()
+    expect(screen.getByText('Input')).toBeInTheDocument()
+  })
+})

--- a/ui/src/contexts/__tests__/AuthContext.test.tsx
+++ b/ui/src/contexts/__tests__/AuthContext.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { AuthProvider, useAuth } from '@/contexts/AuthContext'
+import { api, type Analyst, type AuthCapabilities } from '@/api'
+
+const analyst: Analyst = {
+  id: 'a-1',
+  username: 'alice',
+  display_name: 'Alice',
+  email: null,
+  is_active: true,
+  has_local_password: true,
+  role: 'admin',
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+const capabilities: AuthCapabilities = {
+  local_login_enabled: true,
+  local_registration_enabled: true,
+  providers: [],
+}
+
+function AuthConsumer() {
+  const { analyst, isLoading, login, logout, authCapabilitiesLoading } = useAuth()
+  return (
+    <div>
+      <div data-testid="loading">{String(isLoading)}</div>
+      <div data-testid="caps-loading">{String(authCapabilitiesLoading)}</div>
+      <div data-testid="username">{analyst?.username ?? 'anon'}</div>
+      <div data-testid="role">{analyst?.role ?? ''}</div>
+      <button onClick={() => login('alice', 'pw')}>login</button>
+      <button onClick={logout}>logout</button>
+    </div>
+  )
+}
+
+describe('AuthContext', () => {
+  beforeEach(() => {
+    vi.spyOn(api.auth, 'capabilities').mockResolvedValue(capabilities)
+  })
+
+  it('starts with no analyst when no token is persisted', async () => {
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    )
+    await waitFor(() => expect(screen.getByTestId('caps-loading')).toHaveTextContent('false'))
+    expect(screen.getByTestId('username')).toHaveTextContent('anon')
+    expect(screen.getByTestId('loading')).toHaveTextContent('false')
+  })
+
+  it('persists the token after login and exposes the analyst', async () => {
+    const loginSpy = vi.spyOn(api.auth, 'login').mockResolvedValue({
+      access_token: 'tok-123',
+      token_type: 'bearer',
+      analyst,
+    })
+
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => expect(screen.getByTestId('caps-loading')).toHaveTextContent('false'))
+    await userEvent.click(screen.getByText('login'))
+
+    await waitFor(() => expect(screen.getByTestId('username')).toHaveTextContent('alice'))
+    expect(screen.getByTestId('role')).toHaveTextContent('admin')
+    expect(localStorage.getItem('opensoar_token')).toBe('tok-123')
+    expect(loginSpy).toHaveBeenCalledWith({ username: 'alice', password: 'pw' })
+  })
+
+  it('clears the token and analyst on logout', async () => {
+    vi.spyOn(api.auth, 'login').mockResolvedValue({
+      access_token: 'tok-xyz',
+      token_type: 'bearer',
+      analyst,
+    })
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => expect(screen.getByTestId('caps-loading')).toHaveTextContent('false'))
+    await userEvent.click(screen.getByText('login'))
+    await waitFor(() => expect(localStorage.getItem('opensoar_token')).toBe('tok-xyz'))
+
+    await userEvent.click(screen.getByText('logout'))
+    expect(localStorage.getItem('opensoar_token')).toBeNull()
+    expect(screen.getByTestId('username')).toHaveTextContent('anon')
+  })
+
+  it('rehydrates analyst from persisted token on mount', async () => {
+    localStorage.setItem('opensoar_token', 'persisted-token')
+    vi.spyOn(api.auth, 'me').mockResolvedValue(analyst)
+
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => expect(screen.getByTestId('username')).toHaveTextContent('alice'))
+    expect(screen.getByTestId('loading')).toHaveTextContent('false')
+  })
+
+  it('clears an invalid persisted token when /auth/me fails', async () => {
+    localStorage.setItem('opensoar_token', 'stale-token')
+    vi.spyOn(api.auth, 'me').mockRejectedValue(new Error('401'))
+
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => expect(screen.getByTestId('loading')).toHaveTextContent('false'))
+    expect(localStorage.getItem('opensoar_token')).toBeNull()
+    expect(screen.getByTestId('username')).toHaveTextContent('anon')
+  })
+
+  it('throws when useAuth is used outside the provider', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(() => {
+      act(() => {
+        render(<AuthConsumer />)
+      })
+    }).toThrow(/AuthProvider/)
+    errSpy.mockRestore()
+  })
+})

--- a/ui/src/pages/__tests__/AlertDetailPage.test.tsx
+++ b/ui/src/pages/__tests__/AlertDetailPage.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '@/test/utils'
+import { AlertDetailPage } from '@/pages/AlertDetailPage'
+import { api, type AlertDetail } from '@/api'
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    analyst: {
+      id: 'analyst-1',
+      username: 'alice',
+      display_name: 'Alice',
+      email: null,
+      is_active: true,
+      has_local_password: true,
+      role: 'admin',
+      created_at: '2026-01-01T00:00:00Z',
+    },
+    isLoading: false,
+    authCapabilities: { local_login_enabled: true, local_registration_enabled: false, providers: [] },
+    authCapabilitiesLoading: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+  }),
+}))
+
+const detail: AlertDetail = {
+  id: 'alrt-1',
+  source: 'elastic',
+  source_id: null,
+  title: 'Phishing email detected',
+  description: 'User clicked on a suspicious link',
+  severity: 'high',
+  status: 'new',
+  source_ip: '10.0.0.1',
+  dest_ip: null,
+  hostname: 'host-01',
+  rule_name: 'phish-rule',
+  iocs: null,
+  tags: null,
+  assigned_to: null,
+  assigned_username: null,
+  duplicate_count: 1,
+  partner: null,
+  determination: 'unknown',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  raw_payload: {},
+  normalized: {},
+  resolved_at: null,
+  resolve_reason: null,
+}
+
+describe('AlertDetailPage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(api.alerts, 'get').mockResolvedValue(detail)
+    vi.spyOn(api.alerts, 'getRuns').mockResolvedValue({ runs: [], total: 0 })
+    vi.spyOn(api.alerts, 'getIncidents').mockResolvedValue([])
+    vi.spyOn(api.alerts, 'getActivities').mockResolvedValue({ activities: [], total: 0 })
+    vi.spyOn(api.playbooks, 'list').mockResolvedValue([])
+    vi.spyOn(api.actions, 'available').mockResolvedValue([])
+    vi.spyOn(api.analysts, 'list').mockResolvedValue([])
+  })
+
+  it('renders the alert detail title and description', async () => {
+    renderWithProviders(<AlertDetailPage />, {
+      initialEntries: ['/alerts/alrt-1'],
+      routePath: '/alerts/:id',
+    })
+
+    expect(await screen.findByText('Phishing email detected')).toBeInTheDocument()
+    expect(screen.getByText('User clicked on a suspicious link')).toBeInTheDocument()
+  })
+
+  it('renders "Alert not found" when the API returns nothing', async () => {
+    vi.spyOn(api.alerts, 'get').mockResolvedValue(
+      undefined as unknown as AlertDetail,
+    )
+
+    renderWithProviders(<AlertDetailPage />, {
+      initialEntries: ['/alerts/missing'],
+      routePath: '/alerts/:id',
+    })
+
+    expect(await screen.findByText('Alert not found')).toBeInTheDocument()
+  })
+})

--- a/ui/src/pages/__tests__/AlertsListPage.test.tsx
+++ b/ui/src/pages/__tests__/AlertsListPage.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+import { AlertsListPage } from '@/pages/AlertsListPage'
+import { api, type Alert } from '@/api'
+
+// WorkspaceContext depends on AuthContext + an API call; stub it out so we
+// can render the page in isolation.
+vi.mock('@/contexts/WorkspaceContext', () => ({
+  useWorkspace: () => ({ selectedTenantId: '', setSelectedTenantId: () => {}, tenants: [] }),
+}))
+
+function makeAlert(overrides: Partial<Alert> = {}): Alert {
+  return {
+    id: overrides.id ?? 'a-1',
+    source: 'elastic',
+    source_id: null,
+    title: overrides.title ?? 'Suspicious login',
+    description: null,
+    severity: overrides.severity ?? 'high',
+    status: overrides.status ?? 'new',
+    source_ip: '10.0.0.1',
+    dest_ip: null,
+    hostname: null,
+    rule_name: null,
+    iocs: null,
+    tags: null,
+    assigned_to: null,
+    assigned_username: null,
+    duplicate_count: 1,
+    partner: null,
+    determination: 'unknown',
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+describe('AlertsListPage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders the list of alerts returned by the API', async () => {
+    vi.spyOn(api.alerts, 'list').mockResolvedValue({
+      alerts: [
+        makeAlert({ id: 'a-1', title: 'Phishing email detected' }),
+        makeAlert({ id: 'a-2', title: 'Malware hash matched', severity: 'critical' }),
+      ],
+      total: 2,
+    })
+
+    renderWithProviders(<AlertsListPage />)
+
+    expect(await screen.findByText('Phishing email detected')).toBeInTheDocument()
+    expect(screen.getByText('Malware hash matched')).toBeInTheDocument()
+  })
+
+  it('shows the empty-state when the API returns no alerts', async () => {
+    vi.spyOn(api.alerts, 'list').mockResolvedValue({ alerts: [], total: 0 })
+
+    renderWithProviders(<AlertsListPage />)
+
+    expect(await screen.findByText('No alerts found')).toBeInTheDocument()
+  })
+
+  it('filters alerts client-side using the search box', async () => {
+    vi.spyOn(api.alerts, 'list').mockResolvedValue({
+      alerts: [
+        makeAlert({ id: 'a-1', title: 'Phishing email detected' }),
+        makeAlert({ id: 'a-2', title: 'Malware hash matched' }),
+      ],
+      total: 2,
+    })
+
+    renderWithProviders(<AlertsListPage />)
+
+    await screen.findByText('Phishing email detected')
+    await userEvent.type(screen.getByPlaceholderText(/search alerts/i), 'phishing')
+
+    await waitFor(() => {
+      expect(screen.getByText('Phishing email detected')).toBeInTheDocument()
+      expect(screen.queryByText('Malware hash matched')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/ui/src/pages/__tests__/IncidentDetailPage.test.tsx
+++ b/ui/src/pages/__tests__/IncidentDetailPage.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+import { IncidentDetailPage } from '@/pages/IncidentDetailPage'
+import { api, type Alert, type Incident2 } from '@/api'
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    analyst: {
+      id: 'analyst-1',
+      username: 'alice',
+      display_name: 'Alice',
+      email: null,
+      is_active: true,
+      has_local_password: true,
+      role: 'admin',
+      created_at: '2026-01-01T00:00:00Z',
+    },
+    isLoading: false,
+    authCapabilities: { local_login_enabled: true, local_registration_enabled: false, providers: [] },
+    authCapabilitiesLoading: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+  }),
+}))
+
+const incident: Incident2 = {
+  id: 'inc-1',
+  title: 'Lateral movement detected',
+  description: 'Suspicious RDP activity',
+  severity: 'high',
+  status: 'open',
+  assigned_to: null,
+  assigned_username: null,
+  tags: ['rdp'],
+  alert_count: 1,
+  closed_at: null,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+const alertOne: Alert = {
+  id: 'alrt-1',
+  source: 'elastic',
+  source_id: null,
+  title: 'RDP brute force',
+  description: null,
+  severity: 'high',
+  status: 'new',
+  source_ip: '10.0.0.1',
+  dest_ip: null,
+  hostname: null,
+  rule_name: null,
+  iocs: null,
+  tags: null,
+  assigned_to: null,
+  assigned_username: null,
+  duplicate_count: 1,
+  partner: null,
+  determination: 'unknown',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+describe('IncidentDetailPage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(api.incidents, 'get').mockResolvedValue(incident)
+    vi.spyOn(api.incidents, 'alerts').mockResolvedValue([alertOne])
+    vi.spyOn(api.incidents, 'activities').mockResolvedValue({ activities: [], total: 0 })
+    vi.spyOn(api.incidents, 'observables').mockResolvedValue([])
+    vi.spyOn(api.analysts, 'list').mockResolvedValue([])
+  })
+
+  it('renders the incident title, description and linked alert', async () => {
+    renderWithProviders(<IncidentDetailPage />, {
+      initialEntries: ['/incidents/inc-1'],
+      routePath: '/incidents/:id',
+    })
+
+    expect(await screen.findByText('Lateral movement detected')).toBeInTheDocument()
+    expect(screen.getByText('Suspicious RDP activity')).toBeInTheDocument()
+    expect(await screen.findByText('RDP brute force')).toBeInTheDocument()
+  })
+
+  it('calls the API to link an alert when a new id is submitted', async () => {
+    const linkSpy = vi
+      .spyOn(api.incidents, 'linkAlert')
+      .mockResolvedValue({ detail: 'linked' })
+
+    renderWithProviders(<IncidentDetailPage />, {
+      initialEntries: ['/incidents/inc-1'],
+      routePath: '/incidents/:id',
+    })
+
+    await screen.findByText('Lateral movement detected')
+    const openDialogButtons = screen.getAllByRole('button', { name: /link alert/i })
+    await userEvent.click(openDialogButtons[0])
+
+    await userEvent.type(
+      await screen.findByPlaceholderText(/paste alert id/i),
+      'alrt-2',
+    )
+
+    // The dialog footer button also says "Link Alert" — pick the one inside
+    // the dialog itself so we don't re-open the dialog.
+    const submitButtons = screen.getAllByRole('button', { name: /link alert/i })
+    await userEvent.click(submitButtons[submitButtons.length - 1])
+
+    await waitFor(() => {
+      expect(linkSpy).toHaveBeenCalledWith('inc-1', 'alrt-2')
+    })
+  })
+
+  it('calls the API to unlink an alert when its unlink button is pressed', async () => {
+    const unlinkSpy = vi
+      .spyOn(api.incidents, 'unlinkAlert')
+      .mockResolvedValue({ detail: 'unlinked' })
+
+    renderWithProviders(<IncidentDetailPage />, {
+      initialEntries: ['/incidents/inc-1'],
+      routePath: '/incidents/:id',
+    })
+
+    await screen.findByText('RDP brute force')
+    await userEvent.click(screen.getByTitle('Unlink alert'))
+
+    await waitFor(() => {
+      expect(unlinkSpy).toHaveBeenCalledWith('inc-1', 'alrt-1')
+    })
+  })
+})

--- a/ui/src/pages/__tests__/IncidentsListPage.test.tsx
+++ b/ui/src/pages/__tests__/IncidentsListPage.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '@/test/utils'
+import { IncidentsListPage } from '@/pages/IncidentsListPage'
+import { api, type Incident2 } from '@/api'
+
+vi.mock('@/contexts/WorkspaceContext', () => ({
+  useWorkspace: () => ({ selectedTenantId: '', setSelectedTenantId: () => {}, tenants: [] }),
+}))
+
+function makeIncident(overrides: Partial<Incident2> = {}): Incident2 {
+  return {
+    id: 'i-1',
+    title: 'Lateral movement',
+    description: null,
+    severity: 'high',
+    status: 'open',
+    assigned_to: null,
+    assigned_username: null,
+    tags: null,
+    alert_count: 3,
+    closed_at: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+describe('IncidentsListPage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(api.incidents, 'suggestions').mockResolvedValue([])
+  })
+
+  it('renders incidents from the API', async () => {
+    vi.spyOn(api.incidents, 'list').mockResolvedValue({
+      incidents: [
+        makeIncident({ id: 'i-1', title: 'Brute force on VPN' }),
+        makeIncident({ id: 'i-2', title: 'Data exfiltration attempt', severity: 'critical' }),
+      ],
+      total: 2,
+    })
+
+    renderWithProviders(<IncidentsListPage />)
+
+    expect(await screen.findByText('Brute force on VPN')).toBeInTheDocument()
+    expect(screen.getByText('Data exfiltration attempt')).toBeInTheDocument()
+  })
+
+  it('renders the empty-state when there are no incidents', async () => {
+    vi.spyOn(api.incidents, 'list').mockResolvedValue({ incidents: [], total: 0 })
+
+    renderWithProviders(<IncidentsListPage />)
+
+    expect(await screen.findByText('No incidents found')).toBeInTheDocument()
+  })
+
+  it('renders the correlation suggestions panel when suggestions are returned', async () => {
+    vi.spyOn(api.incidents, 'list').mockResolvedValue({ incidents: [], total: 0 })
+    vi.spyOn(api.incidents, 'suggestions').mockResolvedValue([
+      {
+        source_ip: '10.0.0.1',
+        alert_count: 2,
+        alerts: [
+          {
+            id: 'a-1',
+            source: 's',
+            source_id: null,
+            title: 'Brute force from 10.0.0.1',
+            description: null,
+            severity: 'high',
+            status: 'new',
+            source_ip: '10.0.0.1',
+            dest_ip: null,
+            hostname: null,
+            rule_name: null,
+            iocs: null,
+            tags: null,
+            assigned_to: null,
+            assigned_username: null,
+            duplicate_count: 1,
+            partner: null,
+            determination: 'unknown',
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          },
+        ],
+      },
+    ])
+
+    renderWithProviders(<IncidentsListPage />)
+
+    expect(await screen.findByText('Correlation Suggestions')).toBeInTheDocument()
+    expect(screen.getByText('10.0.0.1')).toBeInTheDocument()
+  })
+})

--- a/ui/src/pages/__tests__/LoginPage.test.tsx
+++ b/ui/src/pages/__tests__/LoginPage.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+import { LoginPage } from '@/pages/LoginPage'
+
+const login = vi.fn()
+const register = vi.fn()
+
+// Stub the AuthContext with a controllable mock so we can assert behavior.
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    analyst: null,
+    isLoading: false,
+    authCapabilities: {
+      local_login_enabled: true,
+      local_registration_enabled: true,
+      providers: [],
+    },
+    authCapabilitiesLoading: false,
+    login,
+    register,
+    logout: vi.fn(),
+  }),
+}))
+
+function getSubmitButton() {
+  // The form has two "Sign In" labels (the login/register tab toggle and the
+  // form submit). Pick the full-width submit button inside the form.
+  const buttons = screen.getAllByRole('button', { name: /sign in/i })
+  const submit = buttons.find((b) => b.className.includes('w-full'))
+  if (!submit) throw new Error('Submit button not found')
+  return submit
+}
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    login.mockReset()
+    register.mockReset()
+  })
+
+  it('renders the sign-in form when local login is enabled', () => {
+    renderWithProviders(<LoginPage />)
+    expect(screen.getByLabelText(/username/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument()
+    expect(getSubmitButton()).toBeInTheDocument()
+  })
+
+  it('submits username + password through the auth context', async () => {
+    login.mockResolvedValue(undefined)
+    renderWithProviders(<LoginPage />)
+
+    await userEvent.type(screen.getByLabelText(/username/i), 'alice')
+    await userEvent.type(screen.getByLabelText(/password/i), 'secret')
+    await userEvent.click(getSubmitButton())
+
+    await waitFor(() => expect(login).toHaveBeenCalledWith('alice', 'secret'))
+  })
+
+  it('surfaces "Invalid credentials" when login rejects', async () => {
+    login.mockRejectedValue(new Error('401'))
+    renderWithProviders(<LoginPage />)
+
+    await userEvent.type(screen.getByLabelText(/username/i), 'alice')
+    await userEvent.type(screen.getByLabelText(/password/i), 'bad')
+    await userEvent.click(getSubmitButton())
+
+    expect(await screen.findByText(/invalid credentials/i)).toBeInTheDocument()
+  })
+})

--- a/ui/src/pages/__tests__/RunDetailPage.test.tsx
+++ b/ui/src/pages/__tests__/RunDetailPage.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '@/test/utils'
+import { RunDetailPage } from '@/pages/RunDetailPage'
+import { api, type PlaybookRun } from '@/api'
+
+const run: PlaybookRun = {
+  id: 'r-1',
+  playbook_id: 'pb-1',
+  alert_id: null,
+  sequence_id: null,
+  sequence_position: null,
+  sequence_total: null,
+  status: 'completed',
+  started_at: '2026-01-01T00:00:00Z',
+  finished_at: '2026-01-01T00:00:05Z',
+  error: null,
+  result: null,
+  action_results: [
+    {
+      id: 'step-1',
+      action_name: 'lookup_ip',
+      status: 'completed',
+      started_at: '2026-01-01T00:00:00Z',
+      finished_at: '2026-01-01T00:00:01Z',
+      duration_ms: 1000,
+      input_data: null,
+      output_data: null,
+      error: null,
+      attempt: 1,
+    },
+    {
+      id: 'step-2',
+      action_name: 'enrich_domain',
+      status: 'failed',
+      started_at: '2026-01-01T00:00:01Z',
+      finished_at: '2026-01-01T00:00:02Z',
+      duration_ms: 1000,
+      input_data: null,
+      output_data: null,
+      error: 'timeout after 30s',
+      attempt: 1,
+    },
+  ],
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+describe('RunDetailPage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(api.runs, 'get').mockResolvedValue(run)
+    vi.spyOn(api.playbooks, 'list').mockResolvedValue([
+      {
+        id: 'pb-1',
+        name: 'Triage IP',
+        description: null,
+        partner: null,
+        execution_order: 1,
+        module_path: '',
+        function_name: '',
+        trigger_type: null,
+        trigger_config: {},
+        enabled: true,
+        version: 1,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ])
+  })
+
+  it('renders the playbook name, step count and timeline for the run', async () => {
+    renderWithProviders(<RunDetailPage />, {
+      initialEntries: ['/runs/r-1'],
+      routePath: '/runs/:id',
+    })
+
+    expect(await screen.findByText('Triage IP')).toBeInTheDocument()
+    expect(await screen.findByText('lookup_ip')).toBeInTheDocument()
+    expect(screen.getByText('enrich_domain')).toBeInTheDocument()
+    // The failed step auto-expands so the error text should be visible
+    expect(screen.getByText('timeout after 30s')).toBeInTheDocument()
+  })
+
+  it('shows "Run not found" when the API returns no data', async () => {
+    vi.spyOn(api.runs, 'get').mockResolvedValue(
+      undefined as unknown as PlaybookRun,
+    )
+
+    renderWithProviders(<RunDetailPage />, {
+      initialEntries: ['/runs/missing'],
+      routePath: '/runs/:id',
+    })
+
+    expect(await screen.findByText('Run not found')).toBeInTheDocument()
+  })
+})

--- a/ui/src/pages/__tests__/RunsListPage.test.tsx
+++ b/ui/src/pages/__tests__/RunsListPage.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/utils'
+import { RunsListPage } from '@/pages/RunsListPage'
+import { api, type PlaybookRun } from '@/api'
+
+vi.mock('@/contexts/WorkspaceContext', () => ({
+  useWorkspace: () => ({ selectedTenantId: '', setSelectedTenantId: () => {}, tenants: [] }),
+}))
+
+function makeRun(overrides: Partial<PlaybookRun> = {}): PlaybookRun {
+  return {
+    id: overrides.id ?? 'r-1',
+    playbook_id: overrides.playbook_id ?? 'pb-1',
+    alert_id: null,
+    sequence_id: null,
+    sequence_position: null,
+    sequence_total: null,
+    status: overrides.status ?? 'completed',
+    started_at: '2026-01-01T00:00:00Z',
+    finished_at: '2026-01-01T00:00:01Z',
+    error: null,
+    result: null,
+    action_results: overrides.action_results ?? [],
+    created_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('RunsListPage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(api.playbooks, 'list').mockResolvedValue([
+      {
+        id: 'pb-1',
+        name: 'Triage IP',
+        description: null,
+        partner: null,
+        execution_order: 1,
+        module_path: '',
+        function_name: '',
+        trigger_type: null,
+        trigger_config: {},
+        enabled: true,
+        version: 1,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ])
+  })
+
+  it('renders the runs returned by the API with playbook names', async () => {
+    vi.spyOn(api.runs, 'list').mockResolvedValue({
+      runs: [makeRun({ id: 'r-1' }), makeRun({ id: 'r-2', status: 'failed' })],
+      total: 2,
+    })
+
+    renderWithProviders(<RunsListPage />)
+
+    // Row labels use <span>. The filter Select also renders <option> with the
+    // same text, so count just the row spans.
+    await screen.findAllByText('Triage IP')
+    const rowLabels = screen
+      .getAllByText('Triage IP')
+      .filter((el) => el.tagName.toLowerCase() === 'span')
+    expect(rowLabels.length).toBe(2)
+  })
+
+  it('shows the empty-state when there are no runs', async () => {
+    vi.spyOn(api.runs, 'list').mockResolvedValue({ runs: [], total: 0 })
+
+    renderWithProviders(<RunsListPage />)
+
+    expect(await screen.findByText('No playbook runs')).toBeInTheDocument()
+  })
+
+  it('expands a run row to reveal its timeline of action steps', async () => {
+    vi.spyOn(api.runs, 'list').mockResolvedValue({
+      runs: [
+        makeRun({
+          id: 'r-1',
+          action_results: [
+            {
+              id: 'step-1',
+              action_name: 'lookup_ip',
+              status: 'completed',
+              started_at: '2026-01-01T00:00:00Z',
+              finished_at: '2026-01-01T00:00:01Z',
+              duration_ms: 1000,
+              input_data: null,
+              output_data: null,
+              error: null,
+              attempt: 1,
+            },
+          ],
+        }),
+      ],
+      total: 1,
+    })
+
+    renderWithProviders(<RunsListPage />)
+
+    await screen.findAllByText('Triage IP')
+    // action_name is only rendered after the row is expanded
+    expect(screen.queryByText('lookup_ip')).not.toBeInTheDocument()
+
+    const rowSpan = screen
+      .getAllByText('Triage IP')
+      .find((el) => el.tagName.toLowerCase() === 'span')
+    expect(rowSpan).toBeDefined()
+    await userEvent.click(rowSpan as HTMLElement)
+    expect(await screen.findByText('lookup_ip')).toBeInTheDocument()
+    expect(screen.getByText('Action Steps')).toBeInTheDocument()
+  })
+})

--- a/ui/src/test/setup.ts
+++ b/ui/src/test/setup.ts
@@ -1,0 +1,75 @@
+import '@testing-library/jest-dom/vitest'
+import { afterEach, vi } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+// Node 25+ ships a stub `localStorage` on globalThis that lacks the DOM
+// `Storage` interface (no getItem/setItem/clear). jsdom inherits that broken
+// object, so we install a simple in-memory replacement for tests.
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>()
+  get length() {
+    return this.store.size
+  }
+  clear(): void {
+    this.store.clear()
+  }
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) as string) : null
+  }
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null
+  }
+  removeItem(key: string): void {
+    this.store.delete(key)
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value))
+  }
+}
+
+const storage = new MemoryStorage()
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  value: storage,
+})
+if (typeof window !== 'undefined') {
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: storage,
+  })
+}
+
+afterEach(() => {
+  cleanup()
+  storage.clear()
+  vi.restoreAllMocks()
+})
+
+// JSDOM lacks matchMedia which some Tailwind / framer-motion helpers call.
+if (!window.matchMedia) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+}
+
+// Avoid framer-motion LayoutGroup / animation complaints in jsdom.
+if (!window.ResizeObserver) {
+  window.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver
+}
+
+// jsdom does not implement scrollTo — stub it to silence warnings from
+// components that scroll on interaction.
+window.scrollTo = vi.fn() as unknown as typeof window.scrollTo
+Element.prototype.scrollTo = vi.fn() as unknown as Element['scrollTo']
+Element.prototype.scrollIntoView = vi.fn() as unknown as Element['scrollIntoView']

--- a/ui/src/test/utils.tsx
+++ b/ui/src/test/utils.tsx
@@ -1,0 +1,55 @@
+import type { ReactElement, ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, Routes, Route } from 'react-router'
+import { render, type RenderOptions } from '@testing-library/react'
+import { ToastProvider } from '@/components/ui/Toast'
+
+export function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+}
+
+interface TestProviderOptions {
+  initialEntries?: string[]
+  routePath?: string
+  queryClient?: QueryClient
+  withToast?: boolean
+}
+
+export function renderWithProviders(
+  ui: ReactElement,
+  {
+    initialEntries = ['/'],
+    routePath,
+    queryClient = createTestQueryClient(),
+    withToast = true,
+    ...rtlOptions
+  }: TestProviderOptions & Omit<RenderOptions, 'wrapper'> = {},
+) {
+  function Wrapper({ children }: { children: ReactNode }) {
+    const routed = routePath ? (
+      <Routes>
+        <Route path={routePath} element={children} />
+      </Routes>
+    ) : (
+      children
+    )
+
+    const withinToast = withToast ? <ToastProvider>{routed}</ToastProvider> : routed
+
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={initialEntries}>{withinToast}</MemoryRouter>
+      </QueryClientProvider>
+    )
+  }
+
+  return {
+    queryClient,
+    ...render(ui, { wrapper: Wrapper, ...rtlOptions }),
+  }
+}

--- a/ui/tsconfig.app.json
+++ b/ui/tsconfig.app.json
@@ -26,5 +26,12 @@
     "baseUrl": ".",
     "paths": { "@/*": ["./src/*"] }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
+    "src/test"
+  ]
 }

--- a/ui/tsconfig.test.json
+++ b/ui/tsconfig.test.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": [
+    "src",
+    "src/test",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx"
+  ],
+  "exclude": []
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
@@ -18,5 +19,12 @@ export default defineConfig({
         changeOrigin: true,
       },
     },
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    css: false,
   },
 })


### PR DESCRIPTION
## Summary

Closes #63.

- Installs Vitest 4, React Testing Library, jsdom and `@testing-library/jest-dom` under `ui/`.
- Adds 38 component tests across 11 files covering `AuthContext` (login/logout, token persistence, role-based gating, rehydration), the alerts + incidents list/detail flows, incident link/unlink, the playbook runs list + run detail timeline, the login form, and key UI primitives (`Badge`, `Button`, `ExecutionPlan`).
- Adds a dedicated `ui-test` job to `.github/workflows/build.yml` that runs `npm run lint`, `npm test` and `tsc -b` in `ui/` and gates the Docker `ui` image build.
- Preserves the strict Docker `ui` build: test files are excluded from `tsconfig.app.json` and live behind a new `tsconfig.test.json`.

## Test plan

- [x] `npm test` green in `ui/` (38 tests, 11 files)
- [x] `npm test` run three consecutive times locally — no flakes
- [x] `npm run lint` passes
- [x] `npx tsc -b` (the Docker `ui` build step) still passes
- [x] `npm run build` (vite) succeeds
- [ ] CI `ui-test` job passes on this PR