### PR TITLE
Aggregate incident timeline from linked alert activities

### DIFF
--- a/src/opensoar/api/incidents.py
+++ b/src/opensoar/api/incidents.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from opensoar.api.deps import get_db
@@ -17,7 +17,14 @@ from opensoar.models.analyst import Analyst
 from opensoar.models.incident import Incident
 from opensoar.models.incident_alert import IncidentAlert
 from opensoar.models.observable import Observable
-from opensoar.schemas.activity import ActivityList, ActivityResponse, CommentCreate, CommentUpdate
+from opensoar.schemas.activity import (
+    ActivityList,
+    ActivityResponse,
+    CommentCreate,
+    CommentUpdate,
+    TimelineEvent,
+    TimelineList,
+)
 from opensoar.schemas.alert import AlertResponse
 from opensoar.schemas.incident import (
     IncidentCreate,
@@ -653,6 +660,116 @@ async def list_incident_activities(
         activities=[ActivityResponse.model_validate(a) for a in activities],
         total=total,
     )
+
+
+@router.get("/{incident_id}/timeline", response_model=TimelineList)
+async def list_incident_timeline(
+    incident_id: uuid.UUID,
+    event_type: str = Query(default="all", pattern="^(all|alert|incident|comment)$"),
+    limit: int = Query(default=50, le=200),
+    offset: int = Query(default=0, ge=0),
+    request: Request = None,
+    session: AsyncSession = Depends(get_db),
+    analyst: Analyst | None = Depends(get_current_analyst),
+):
+    """Return a merged chronology of the incident and its linked alerts.
+
+    Events cover incident lifecycle activity (creation, status/severity/assignment
+    changes, linking, comments, observables) and activities on every linked alert
+    (comments, playbook runs, status changes). Tenant scoping is enforced by
+    re-validating the incident and filtering the linked-alert set through the
+    registered tenant validators, matching the pattern used elsewhere in this
+    router so optional plugins can scope results.
+    """
+    incident = (
+        await session.execute(select(Incident).where(Incident.id == incident_id))
+    ).scalar_one_or_none()
+    if not incident:
+        raise HTTPException(status_code=404, detail="Incident not found")
+
+    await enforce_tenant_access(
+        request.app,
+        resource=incident,
+        resource_type="incident",
+        action="read",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
+
+    # Resolve which linked alerts the caller may see so we don't leak activity
+    # from alerts that belong to other tenants.
+    linked_alert_query = (
+        select(Alert.id)
+        .join(IncidentAlert, IncidentAlert.alert_id == Alert.id)
+        .where(IncidentAlert.incident_id == incident_id)
+    )
+    linked_alert_query = await apply_tenant_access_query(
+        request.app,
+        query=linked_alert_query,
+        resource_type="alert",
+        action="list",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
+    visible_alert_ids = list(
+        (await session.execute(linked_alert_query)).scalars().all()
+    )
+
+    # Combine activities on the incident with activities on the alerts the
+    # caller is allowed to see.
+    conditions = [Activity.incident_id == incident_id]
+    if visible_alert_ids:
+        conditions.append(Activity.alert_id.in_(visible_alert_ids))
+
+    base_where = or_(*conditions)
+
+    query = select(Activity).where(base_where)
+    count_query = select(func.count(Activity.id)).where(base_where)
+
+    if event_type == "alert":
+        query = query.where(Activity.alert_id.isnot(None))
+        count_query = count_query.where(Activity.alert_id.isnot(None))
+    elif event_type == "incident":
+        query = query.where(
+            Activity.incident_id == incident_id,
+            Activity.alert_id.is_(None),
+        )
+        count_query = count_query.where(
+            Activity.incident_id == incident_id,
+            Activity.alert_id.is_(None),
+        )
+    elif event_type == "comment":
+        query = query.where(Activity.action == "comment")
+        count_query = count_query.where(Activity.action == "comment")
+
+    query = query.order_by(Activity.created_at.desc()).offset(offset).limit(limit)
+
+    total = (await session.execute(count_query)).scalar() or 0
+    result = await session.execute(query)
+    activities = result.scalars().all()
+
+    events: list[TimelineEvent] = []
+    for activity in activities:
+        source = "alert" if activity.alert_id is not None else "incident"
+        events.append(
+            TimelineEvent(
+                id=activity.id,
+                source=source,
+                action=activity.action,
+                detail=activity.detail,
+                created_at=activity.created_at,
+                updated_at=activity.updated_at,
+                analyst_id=activity.analyst_id,
+                analyst_username=activity.analyst_username,
+                alert_id=activity.alert_id,
+                incident_id=activity.incident_id,
+                metadata_json=activity.metadata_json,
+            )
+        )
+
+    return TimelineList(events=events, total=total)
 
 
 @router.post("/{incident_id}/comments", response_model=ActivityResponse)

--- a/src/opensoar/schemas/activity.py
+++ b/src/opensoar/schemas/activity.py
@@ -33,3 +33,30 @@ class CommentCreate(BaseModel):
 
 class CommentUpdate(BaseModel):
     text: str
+
+
+class TimelineEvent(BaseModel):
+    """A single entry in an aggregated incident timeline.
+
+    `source` distinguishes whether the event came from an alert activity or an
+    incident activity so the UI can render per-source filters and badges.
+    """
+
+    id: uuid.UUID
+    source: str  # "incident" | "alert"
+    action: str
+    detail: str | None = None
+    created_at: datetime
+    updated_at: datetime
+    analyst_id: uuid.UUID | None = None
+    analyst_username: str | None = None
+    alert_id: uuid.UUID | None = None
+    incident_id: uuid.UUID | None = None
+    metadata_json: dict[str, Any] | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class TimelineList(BaseModel):
+    events: list[TimelineEvent]
+    total: int

--- a/tests/test_incident_timeline_api.py
+++ b/tests/test_incident_timeline_api.py
@@ -1,0 +1,337 @@
+"""Tests for aggregated incident timeline API (GET /incidents/{id}/timeline)."""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import HTTPException
+
+from opensoar.plugins import register_tenant_access_validator
+
+
+async def _create_incident(client, headers, title="Timeline Incident", severity="medium"):
+    resp = await client.post(
+        "/api/v1/incidents",
+        json={"title": title, "severity": severity},
+        headers=headers,
+    )
+    return resp.json()["id"]
+
+
+async def _create_alert(client, rule_name="Timeline Alert", partner="acme-corp"):
+    resp = await client.post(
+        "/api/v1/webhooks/alerts",
+        json={
+            "rule_name": rule_name,
+            "severity": "high",
+            "source_ip": "10.0.0.9",
+            "partner": partner,
+        },
+    )
+    return resp.json()["alert_id"]
+
+
+async def _link(client, headers, incident_id, alert_id):
+    await client.post(
+        f"/api/v1/incidents/{incident_id}/alerts",
+        json={"alert_id": str(alert_id)},
+        headers=headers,
+    )
+
+
+class TestIncidentTimelineBasics:
+    async def test_timeline_endpoint_exists(self, client, registered_analyst):
+        incident_id = await _create_incident(client, registered_analyst["headers"])
+
+        resp = await client.get(
+            f"/api/v1/incidents/{incident_id}/timeline",
+            headers=registered_analyst["headers"],
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "events" in body
+        assert "total" in body
+
+    async def test_timeline_returns_404_for_missing_incident(self, client, registered_analyst):
+        resp = await client.get(
+            f"/api/v1/incidents/{uuid.uuid4()}/timeline",
+            headers=registered_analyst["headers"],
+        )
+        assert resp.status_code == 404
+
+    async def test_timeline_requires_auth_when_tenant_validator_blocks(self, client, registered_analyst):
+        from opensoar.main import app
+
+        incident_id = await _create_incident(client, registered_analyst["headers"], title="Blocked Timeline")
+
+        async def validator(**kwargs):
+            resource = kwargs.get("resource")
+            if resource is not None and getattr(resource, "title", "").startswith("Blocked"):
+                raise HTTPException(status_code=403, detail="Tenant access denied")
+
+        original_validators = list(app.state.tenant_access_validators)
+        app.state.tenant_access_validators = []
+        register_tenant_access_validator(app, validator)
+        try:
+            resp = await client.get(
+                f"/api/v1/incidents/{incident_id}/timeline",
+                headers=registered_analyst["headers"],
+            )
+        finally:
+            app.state.tenant_access_validators = original_validators
+
+        assert resp.status_code == 403
+
+
+class TestIncidentTimelineAggregation:
+    async def test_timeline_merges_alert_and_incident_activities(self, client, registered_analyst):
+        incident_id = await _create_incident(client, registered_analyst["headers"])
+        alert_id = await _create_alert(client)
+        await _link(client, registered_analyst["headers"], incident_id, alert_id)
+
+        # Add an alert-side comment
+        await client.post(
+            f"/api/v1/alerts/{alert_id}/comments",
+            json={"text": "Alert-level comment"},
+            headers=registered_analyst["headers"],
+        )
+        # Add an incident-side comment
+        await client.post(
+            f"/api/v1/incidents/{incident_id}/comments",
+            json={"text": "Incident-level comment"},
+            headers=registered_analyst["headers"],
+        )
+
+        resp = await client.get(
+            f"/api/v1/incidents/{incident_id}/timeline",
+            headers=registered_analyst["headers"],
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        sources = {event["source"] for event in body["events"]}
+        assert "incident" in sources
+        assert "alert" in sources
+        actions = [event["action"] for event in body["events"]]
+        assert "incident_created" in actions
+        assert "alert_linked" in actions
+        assert "comment" in actions
+        # Alert-side activities should carry alert_id reference
+        alert_events = [event for event in body["events"] if event["source"] == "alert"]
+        assert any(event["alert_id"] == str(alert_id) for event in alert_events)
+
+    async def test_timeline_sorted_desc(self, client, registered_analyst):
+        incident_id = await _create_incident(client, registered_analyst["headers"])
+        alert_id = await _create_alert(client)
+        await _link(client, registered_analyst["headers"], incident_id, alert_id)
+
+        resp = await client.get(
+            f"/api/v1/incidents/{incident_id}/timeline",
+            headers=registered_analyst["headers"],
+        )
+        events = resp.json()["events"]
+        assert len(events) >= 2
+        timestamps = [event["created_at"] for event in events]
+        assert timestamps == sorted(timestamps, reverse=True)
+
+    async def test_timeline_only_includes_linked_alert_activities(self, client, registered_analyst):
+        incident_id = await _create_incident(client, registered_analyst["headers"])
+        linked_alert = await _create_alert(client, rule_name="Linked Alert")
+        unrelated_alert = await _create_alert(client, rule_name="Unrelated Alert")
+        await _link(client, registered_analyst["headers"], incident_id, linked_alert)
+
+        # Comment on the unrelated alert should not leak into the timeline
+        await client.post(
+            f"/api/v1/alerts/{unrelated_alert}/comments",
+            json={"text": "Unrelated"},
+            headers=registered_analyst["headers"],
+        )
+        await client.post(
+            f"/api/v1/alerts/{linked_alert}/comments",
+            json={"text": "Linked"},
+            headers=registered_analyst["headers"],
+        )
+
+        resp = await client.get(
+            f"/api/v1/incidents/{incident_id}/timeline",
+            headers=registered_analyst["headers"],
+        )
+        events = resp.json()["events"]
+        details = [event.get("detail") for event in events]
+        assert "Linked" in details
+        assert "Unrelated" not in details
+
+
+class TestIncidentTimelineFilters:
+    async def test_filter_alert_only(self, client, registered_analyst):
+        incident_id = await _create_incident(client, registered_analyst["headers"])
+        alert_id = await _create_alert(client)
+        await _link(client, registered_analyst["headers"], incident_id, alert_id)
+        await client.post(
+            f"/api/v1/alerts/{alert_id}/comments",
+            json={"text": "Alert-only"},
+            headers=registered_analyst["headers"],
+        )
+
+        resp = await client.get(
+            f"/api/v1/incidents/{incident_id}/timeline?event_type=alert",
+            headers=registered_analyst["headers"],
+        )
+        assert resp.status_code == 200
+        events = resp.json()["events"]
+        assert len(events) >= 1
+        assert all(event["source"] == "alert" for event in events)
+
+    async def test_filter_incident_only(self, client, registered_analyst):
+        incident_id = await _create_incident(client, registered_analyst["headers"])
+        alert_id = await _create_alert(client)
+        await _link(client, registered_analyst["headers"], incident_id, alert_id)
+
+        resp = await client.get(
+            f"/api/v1/incidents/{incident_id}/timeline?event_type=incident",
+            headers=registered_analyst["headers"],
+        )
+        assert resp.status_code == 200
+        events = resp.json()["events"]
+        assert len(events) >= 1
+        assert all(event["source"] == "incident" for event in events)
+
+    async def test_filter_comments_only(self, client, registered_analyst):
+        incident_id = await _create_incident(client, registered_analyst["headers"])
+        alert_id = await _create_alert(client)
+        await _link(client, registered_analyst["headers"], incident_id, alert_id)
+
+        await client.post(
+            f"/api/v1/alerts/{alert_id}/comments",
+            json={"text": "Alert comment"},
+            headers=registered_analyst["headers"],
+        )
+        await client.post(
+            f"/api/v1/incidents/{incident_id}/comments",
+            json={"text": "Incident comment"},
+            headers=registered_analyst["headers"],
+        )
+
+        resp = await client.get(
+            f"/api/v1/incidents/{incident_id}/timeline?event_type=comment",
+            headers=registered_analyst["headers"],
+        )
+        assert resp.status_code == 200
+        events = resp.json()["events"]
+        assert len(events) == 2
+        assert all(event["action"] == "comment" for event in events)
+
+
+class TestIncidentTimelinePagination:
+    async def test_pagination_limit_and_offset(self, client, registered_analyst):
+        incident_id = await _create_incident(client, registered_analyst["headers"])
+
+        for idx in range(5):
+            await client.post(
+                f"/api/v1/incidents/{incident_id}/comments",
+                json={"text": f"Comment {idx}"},
+                headers=registered_analyst["headers"],
+            )
+
+        resp = await client.get(
+            f"/api/v1/incidents/{incident_id}/timeline?limit=2&offset=0",
+            headers=registered_analyst["headers"],
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["events"]) == 2
+        assert data["total"] >= 6  # 5 comments + incident_created
+
+        page_two = await client.get(
+            f"/api/v1/incidents/{incident_id}/timeline?limit=2&offset=2",
+            headers=registered_analyst["headers"],
+        )
+        assert page_two.status_code == 200
+        page_two_data = page_two.json()
+        assert len(page_two_data["events"]) == 2
+        first_page_ids = {event["id"] for event in data["events"]}
+        second_page_ids = {event["id"] for event in page_two_data["events"]}
+        assert first_page_ids.isdisjoint(second_page_ids)
+
+    async def test_pagination_limit_cap(self, client, registered_analyst):
+        incident_id = await _create_incident(client, registered_analyst["headers"])
+        resp = await client.get(
+            f"/api/v1/incidents/{incident_id}/timeline?limit=500",
+            headers=registered_analyst["headers"],
+        )
+        # Matches alert activities API which caps at 200
+        assert resp.status_code == 422
+
+
+class TestIncidentTimelineTenantScoping:
+    async def test_tenant_validator_blocks_timeline(self, client, registered_analyst):
+        from opensoar.main import app
+
+        incident_id = await _create_incident(
+            client, registered_analyst["headers"], title="Blocked Timeline Access"
+        )
+
+        async def validator(**kwargs):
+            resource = kwargs.get("resource")
+            if resource is not None and getattr(resource, "title", "").startswith("Blocked"):
+                raise HTTPException(status_code=403, detail="Tenant access denied")
+
+        original_validators = list(app.state.tenant_access_validators)
+        app.state.tenant_access_validators = []
+        register_tenant_access_validator(app, validator)
+        try:
+            resp = await client.get(
+                f"/api/v1/incidents/{incident_id}/timeline",
+                headers=registered_analyst["headers"],
+            )
+        finally:
+            app.state.tenant_access_validators = original_validators
+
+        assert resp.status_code == 403
+
+    async def test_tenant_validator_scopes_linked_alert_activities(
+        self, client, registered_analyst
+    ):
+        """Alert activities from alerts the validator blocks must not leak through."""
+        from opensoar.main import app
+
+        incident_id = await _create_incident(client, registered_analyst["headers"])
+        allowed_alert = await _create_alert(client, rule_name="Allowed", partner="acme-corp")
+        blocked_alert = await _create_alert(client, rule_name="Blocked", partner="globex")
+
+        await _link(client, registered_analyst["headers"], incident_id, allowed_alert)
+        await _link(client, registered_analyst["headers"], incident_id, blocked_alert)
+
+        await client.post(
+            f"/api/v1/alerts/{allowed_alert}/comments",
+            json={"text": "Allowed comment"},
+            headers=registered_analyst["headers"],
+        )
+        await client.post(
+            f"/api/v1/alerts/{blocked_alert}/comments",
+            json={"text": "Blocked comment"},
+            headers=registered_analyst["headers"],
+        )
+
+        from opensoar.models.alert import Alert
+
+        async def validator(**kwargs):
+            query = kwargs.get("query")
+            if query is not None and kwargs.get("resource_type") == "alert":
+                return query.where(Alert.partner != "globex")
+            return None
+
+        original_validators = list(app.state.tenant_access_validators)
+        app.state.tenant_access_validators = []
+        register_tenant_access_validator(app, validator)
+        try:
+            resp = await client.get(
+                f"/api/v1/incidents/{incident_id}/timeline",
+                headers=registered_analyst["headers"],
+            )
+        finally:
+            app.state.tenant_access_validators = original_validators
+
+        assert resp.status_code == 200
+        events = resp.json()["events"]
+        details = [event.get("detail") for event in events]
+        assert "Allowed comment" in details
+        assert "Blocked comment" not in details

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -209,6 +209,29 @@ export interface ActivityList {
   total: number
 }
 
+export type TimelineEventSource = 'incident' | 'alert'
+
+export interface TimelineEvent {
+  id: string
+  source: TimelineEventSource
+  action: string
+  detail: string | null
+  created_at: string
+  updated_at: string
+  analyst_id: string | null
+  analyst_username: string | null
+  alert_id: string | null
+  incident_id: string | null
+  metadata_json: Record<string, unknown> | null
+}
+
+export interface TimelineList {
+  events: TimelineEvent[]
+  total: number
+}
+
+export type TimelineFilter = 'all' | 'alert' | 'incident' | 'comment'
+
 export interface AvailableAction {
   name: string
   integration: string
@@ -496,6 +519,14 @@ export const api = {
       patchJSON<Incident2>(`/incidents/${id}`, data),
     alerts: (id: string) => fetchJSON<Alert[]>(`/incidents/${id}/alerts`),
     activities: (id: string) => fetchJSON<ActivityList>(`/incidents/${id}/activities`),
+    timeline: (id: string, params?: { event_type?: TimelineFilter; limit?: number; offset?: number }) => {
+      const qs = new URLSearchParams()
+      if (params?.event_type && params.event_type !== 'all') qs.set('event_type', params.event_type)
+      if (params?.limit) qs.set('limit', String(params.limit))
+      if (params?.offset) qs.set('offset', String(params.offset))
+      const q = qs.toString()
+      return fetchJSON<TimelineList>(`/incidents/${id}/timeline${q ? `?${q}` : ''}`)
+    },
     addComment: (id: string, text: string) =>
       postJSON<Activity>(`/incidents/${id}/comments`, { text }),
     editComment: (id: string, commentId: string, text: string) =>

--- a/ui/src/pages/IncidentDetailPage.tsx
+++ b/ui/src/pages/IncidentDetailPage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useParams, useNavigate, Link } from 'react-router'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { ArrowLeft, Clock, Link2, Unlink, Shield, MessageSquare, Pencil, History, UserCheck, Users, Search } from 'lucide-react'
-import { api, type Alert, type Activity, type Analyst, type Observable } from '@/api'
+import { api, type Alert, type Analyst, type Observable, type TimelineEvent, type TimelineFilter } from '@/api'
 import { SeverityBadge, StatusBadge } from '@/components/ui/Badge'
 import { Button } from '@/components/ui/Button'
 import { Input, Label } from '@/components/ui/Input'
@@ -46,7 +46,7 @@ const ACTION_COLORS: Record<string, string> = {
 function IncidentTimelineEntry({
   activity, incidentId, isOwnComment,
 }: {
-  activity: Activity
+  activity: TimelineEvent
   incidentId: string
   isOwnComment: boolean
 }) {
@@ -57,9 +57,14 @@ function IncidentTimelineEntry({
   const [showHistory, setShowHistory] = useState(false)
 
   const editMutation = useMutation({
-    mutationFn: (text: string) => api.incidents.editComment(incidentId, activity.id, text),
+    mutationFn: (text: string) => {
+      if (activity.source === 'alert' && activity.alert_id) {
+        return api.alerts.editComment(activity.alert_id, activity.id, text)
+      }
+      return api.incidents.editComment(incidentId, activity.id, text)
+    },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['incident-activities', incidentId] })
+      queryClient.invalidateQueries({ queryKey: ['incident-timeline', incidentId] })
       setEditing(false)
       toast.success('Comment updated')
     },
@@ -92,6 +97,11 @@ function IncidentTimelineEntry({
           <span className={cn('font-medium', isComment ? 'text-accent' : 'text-heading')}>
             {isComment ? (activity.analyst_username || 'System') : (ACTION_LABELS[activity.action] || activity.action)}
           </span>
+          {activity.source === 'alert' && (
+            <span className="px-1.5 py-0.5 text-[9px] uppercase tracking-wide rounded bg-surface-hover text-muted border border-border">
+              alert
+            </span>
+          )}
           <Tooltip content={formatDate(activity.created_at)}>
             <span className="text-muted">{timeAgo(activity.created_at)}</span>
           </Tooltip>
@@ -182,6 +192,7 @@ export function IncidentDetailPage() {
     value: '',
     source: '',
   })
+  const [timelineFilter, setTimelineFilter] = useState<TimelineFilter>('all')
 
   const { data: incident, isLoading } = useQuery({
     queryKey: ['incident', id],
@@ -195,9 +206,9 @@ export function IncidentDetailPage() {
     enabled: !!id,
   })
 
-  const { data: activities } = useQuery({
-    queryKey: ['incident-activities', id],
-    queryFn: () => api.incidents.activities(id!),
+  const { data: timeline } = useQuery({
+    queryKey: ['incident-timeline', id, timelineFilter],
+    queryFn: () => api.incidents.timeline(id!, { event_type: timelineFilter }),
     enabled: !!id,
   })
 
@@ -215,7 +226,7 @@ export function IncidentDetailPage() {
   const invalidateIncident = () => {
     queryClient.invalidateQueries({ queryKey: ['incident', id] })
     queryClient.invalidateQueries({ queryKey: ['incident-alerts', id] })
-    queryClient.invalidateQueries({ queryKey: ['incident-activities', id] })
+    queryClient.invalidateQueries({ queryKey: ['incident-timeline', id] })
     queryClient.invalidateQueries({ queryKey: ['incident-observables', id] })
     queryClient.invalidateQueries({ queryKey: ['incidents'] })
   }
@@ -258,7 +269,7 @@ export function IncidentDetailPage() {
     mutationFn: (text: string) => api.incidents.addComment(id!, text),
     onSuccess: () => {
       setCommentText('')
-      queryClient.invalidateQueries({ queryKey: ['incident-activities', id] })
+      queryClient.invalidateQueries({ queryKey: ['incident-timeline', id] })
       toast.success('Comment added')
     },
     onError: () => toast.error('Failed to add comment'),
@@ -535,22 +546,46 @@ export function IncidentDetailPage() {
                 </Button>
               </div>
 
-              {(!activities || activities.total === 0) ? (
+              <div className="flex gap-1 mb-4" role="tablist" aria-label="Timeline filters">
+                {([
+                  { value: 'all', label: 'All' },
+                  { value: 'incident', label: 'Incident events' },
+                  { value: 'alert', label: 'Alert events' },
+                  { value: 'comment', label: 'Comments' },
+                ] as Array<{ value: TimelineFilter; label: string }>).map((chip) => (
+                  <button
+                    key={chip.value}
+                    role="tab"
+                    aria-selected={timelineFilter === chip.value}
+                    onClick={() => setTimelineFilter(chip.value)}
+                    className={cn(
+                      'px-2.5 py-1 text-[11px] rounded-full border cursor-pointer transition-colors',
+                      timelineFilter === chip.value
+                        ? 'bg-accent/10 border-accent/40 text-accent'
+                        : 'bg-transparent border-border text-muted hover:text-heading hover:border-border/60',
+                    )}
+                  >
+                    {chip.label}
+                  </button>
+                ))}
+              </div>
+
+              {(!timeline || timeline.total === 0) ? (
                 <div className="text-center py-6">
-                  <div className="text-xs text-muted">No activity yet. Comments and incident lifecycle events will appear here.</div>
+                  <div className="text-xs text-muted">No activity yet. Comments, alert events, and incident lifecycle events will appear here.</div>
                 </div>
               ) : (
                 <div className="relative">
-                  {activities.activities.length > 1 && (
+                  {timeline.events.length > 1 && (
                     <div className="absolute left-[7px] top-4 bottom-4 w-px border-l-2 border-dashed border-border/40" />
                   )}
                   <div className="space-y-0">
-                    {activities.activities.map((activity) => (
+                    {timeline.events.map((event) => (
                       <IncidentTimelineEntry
-                        key={activity.id}
-                        activity={activity}
+                        key={event.id}
+                        activity={event}
                         incidentId={id!}
-                        isOwnComment={activity.action === 'comment' && analyst?.id === activity.analyst_id}
+                        isOwnComment={event.action === 'comment' && analyst?.id === event.analyst_id}
                       />
                     ))}
                   </div>


### PR DESCRIPTION
## Summary
- Add `GET /incidents/{id}/timeline` that merges incident lifecycle activity with activities on every linked alert into a single descending chronology, with tenant validators re-applied so plugins can scope results.
- Support `event_type` filtering (`all`/`alert`/`incident`/`comment`) plus `limit`/`offset` pagination matching the alert activities API.
- Switch the incident detail page Timeline card to the new endpoint, adding filter chips and a per-event source badge, and route edits on alert-sourced comments back to the alert endpoint.

## Test plan
- [x] `pytest tests/test_incident_timeline_api.py` (13 new tests) covers ordering, pagination caps, filter chips, tenant-scoped alert-activity leakage, and incident-level tenant blocking
- [x] `pytest tests/` full suite, 283 passing
- [x] `ruff check src/ tests/`
- [x] `tsc -b` for the UI
- [ ] No frontend unit test harness is wired up in the repo yet (no Vitest/Jest), so UI logic is covered via existing Playwright e2e suites

Closes #65