### PR TITLE
Support @mentions in alert and incident comments

### DIFF
--- a/migrations/versions/a7c9d2e1b4f6_add_mentions_to_activities.py
+++ b/migrations/versions/a7c9d2e1b4f6_add_mentions_to_activities.py
@@ -1,0 +1,29 @@
+"""add mentions column to activities
+
+Revision ID: a7c9d2e1b4f6
+Revises: f1a2b3c4d5e6
+Create Date: 2026-04-17
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "a7c9d2e1b4f6"
+down_revision: Union[str, Sequence[str], None] = "f1a2b3c4d5e6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "activities",
+        sa.Column("mentions", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("activities", "mentions")

--- a/src/opensoar/api/activities.py
+++ b/src/opensoar/api/activities.py
@@ -8,11 +8,60 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from opensoar.api.deps import get_db
 from opensoar.auth.jwt import get_current_analyst, require_analyst
+from opensoar.comments.mentions import parse_mention_tokens
+from opensoar.comments.resolver import ResolvedMention, resolve_mentions
+from opensoar.notifications import MentionNotification, dispatch_mention_notifications
 from opensoar.plugins import enforce_tenant_access
 from opensoar.models.activity import Activity
 from opensoar.models.alert import Alert
 from opensoar.models.analyst import Analyst
 from opensoar.schemas.activity import ActivityList, ActivityResponse, CommentCreate, CommentUpdate
+
+
+async def _resolve_comment_mentions(
+    *,
+    request: Request,
+    session: AsyncSession,
+    analyst: Analyst,
+    text: str,
+) -> list[ResolvedMention]:
+    tokens = parse_mention_tokens(text)
+    if not tokens:
+        return []
+    return await resolve_mentions(
+        app=request.app,
+        session=session,
+        usernames=tokens,
+        analyst=analyst,
+        request=request,
+    )
+
+
+async def _notify_mentions(
+    *,
+    actor: Analyst,
+    mentions: list[ResolvedMention],
+    resource_type: str,
+    resource_id: uuid.UUID,
+    comment_id: uuid.UUID,
+    text: str,
+) -> None:
+    if not mentions:
+        return
+    await dispatch_mention_notifications(
+        [
+            MentionNotification(
+                recipient_username=m.username,
+                recipient_id=m.analyst_id,
+                actor_username=actor.username,
+                resource_type=resource_type,
+                resource_id=str(resource_id),
+                comment_id=str(comment_id),
+                comment_text=text,
+            )
+            for m in mentions
+        ]
+    )
 
 router = APIRouter(prefix="/alerts", tags=["activities"])
 
@@ -84,16 +133,28 @@ async def add_comment(
         session=session,
     )
 
+    resolved = await _resolve_comment_mentions(
+        request=request, session=session, analyst=analyst, text=body.text
+    )
     activity = Activity(
         alert_id=alert_id,
         analyst_id=analyst.id,
         analyst_username=analyst.username,
         action="comment",
         detail=body.text,
+        mentions=[m.username for m in resolved],
     )
     session.add(activity)
     await session.commit()
     await session.refresh(activity)
+    await _notify_mentions(
+        actor=analyst,
+        mentions=resolved,
+        resource_type="alert",
+        resource_id=alert_id,
+        comment_id=activity.id,
+        text=body.text,
+    )
     return ActivityResponse.model_validate(activity)
 
 
@@ -147,6 +208,24 @@ async def edit_comment(
     activity.metadata_json = {**(activity.metadata_json or {}), "edit_history": history}
     activity.detail = body.text
 
+    resolved = await _resolve_comment_mentions(
+        request=request, session=session, analyst=analyst, text=body.text
+    )
+    previously_notified = set(activity.mentions or [])
+    activity.mentions = [m.username for m in resolved]
+
     await session.commit()
     await session.refresh(activity)
+
+    # Only fire notifications for usernames that weren't in the previous
+    # version of the comment so edits don't spam analysts repeatedly.
+    new_mentions = [m for m in resolved if m.username not in previously_notified]
+    await _notify_mentions(
+        actor=analyst,
+        mentions=new_mentions,
+        resource_type="alert",
+        resource_id=alert_id,
+        comment_id=activity.id,
+        text=body.text,
+    )
     return ActivityResponse.model_validate(activity)

--- a/src/opensoar/api/auth.py
+++ b/src/opensoar/api/auth.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
 import bcrypt
-from fastapi import APIRouter, Depends, HTTPException, Request
-from sqlalchemy import select
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from opensoar.api.deps import get_db
 from opensoar.auth.jwt import create_access_token, require_analyst
 from opensoar.auth.rbac import VALID_ANALYST_ROLES
 from opensoar.models.analyst import Analyst
-from opensoar.plugins import dispatch_audit_event, get_analyst_roles, get_auth_capabilities
+from opensoar.plugins import (
+    dispatch_audit_event,
+    enforce_tenant_access,
+    get_analyst_roles,
+    get_auth_capabilities,
+)
 from opensoar.schemas.audit import AuditEvent
 from opensoar.schemas.auth import AuthCapabilitiesResponse
 from opensoar.schemas.analyst import (
@@ -19,6 +24,7 @@ from opensoar.schemas.analyst import (
     AnalystRoleResponse,
     AnalystResponse,
     AnalystUpdate,
+    MentionableAnalyst,
     PasswordChangeRequest,
     PasswordResetRequest,
     TokenResponse,
@@ -268,6 +274,55 @@ async def list_analysts(
 ):
     result = await session.execute(select(Analyst).order_by(Analyst.username))
     return [AnalystResponse.model_validate(a) for a in result.scalars().all()]
+
+
+@router.get("/analysts/mentionable", response_model=list[MentionableAnalyst])
+async def list_mentionable_analysts(
+    request: Request,
+    q: str | None = Query(default=None, max_length=100),
+    limit: int = Query(default=10, ge=1, le=50),
+    session: AsyncSession = Depends(get_db),
+    analyst: Analyst = Depends(require_analyst),
+):
+    """Return analysts the caller may ``@mention`` in a comment.
+
+    Results are scoped to active analysts in the caller's tenant — any
+    registered ``tenant_access_validators`` plugin decides what "tenant" means.
+    Optional ``q`` is a case-insensitive prefix filter on ``username`` or
+    ``display_name`` for the autocomplete dropdown.
+    """
+    query = (
+        select(Analyst)
+        .where(Analyst.is_active.is_(True))
+        .order_by(Analyst.username)
+    )
+    if q:
+        pattern = f"{q.lower()}%"
+        query = query.where(
+            func.lower(Analyst.username).like(pattern)
+            | func.lower(Analyst.display_name).like(pattern)
+        )
+    # Fetch a small over-size, filter through the tenant hook, then truncate.
+    rows = (await session.execute(query.limit(limit * 4))).scalars().all()
+
+    visible: list[Analyst] = []
+    for candidate in rows:
+        try:
+            await enforce_tenant_access(
+                request.app,
+                resource=candidate,
+                resource_type="analyst",
+                action="mention",
+                analyst=analyst,
+                request=request,
+                session=session,
+            )
+        except HTTPException:
+            continue
+        visible.append(candidate)
+        if len(visible) >= limit:
+            break
+    return [MentionableAnalyst.model_validate(a) for a in visible]
 
 
 @router.patch("/analysts/{analyst_id}", response_model=AnalystResponse)

--- a/src/opensoar/api/incidents.py
+++ b/src/opensoar/api/incidents.py
@@ -10,6 +10,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from opensoar.api.deps import get_db
 from opensoar.auth.jwt import get_current_analyst
 from opensoar.auth.rbac import Permission, require_permission
+from opensoar.comments.mentions import parse_mention_tokens
+from opensoar.comments.resolver import ResolvedMention, resolve_mentions
+from opensoar.notifications import MentionNotification, dispatch_mention_notifications
 from opensoar.plugins import apply_tenant_access_query, enforce_tenant_access
 from opensoar.models.activity import Activity
 from opensoar.models.alert import Alert
@@ -679,16 +682,27 @@ async def add_incident_comment(
         session=session,
     )
 
+    resolved = await _resolve_incident_comment_mentions(
+        request=request, session=session, analyst=analyst, text=body.text
+    )
     activity = Activity(
         incident_id=incident_id,
         analyst_id=analyst.id,
         analyst_username=analyst.username,
         action="comment",
         detail=body.text,
+        mentions=[m.username for m in resolved],
     )
     session.add(activity)
     await session.commit()
     await session.refresh(activity)
+    await _notify_incident_mentions(
+        actor=analyst,
+        mentions=resolved,
+        resource_id=incident_id,
+        comment_id=activity.id,
+        text=body.text,
+    )
     return ActivityResponse.model_validate(activity)
 
 
@@ -740,6 +754,66 @@ async def edit_incident_comment(
     activity.metadata_json = {**(activity.metadata_json or {}), "edit_history": history}
     activity.detail = body.text
 
+    resolved = await _resolve_incident_comment_mentions(
+        request=request, session=session, analyst=analyst, text=body.text
+    )
+    previously_notified = set(activity.mentions or [])
+    activity.mentions = [m.username for m in resolved]
+
     await session.commit()
     await session.refresh(activity)
+
+    new_mentions = [m for m in resolved if m.username not in previously_notified]
+    await _notify_incident_mentions(
+        actor=analyst,
+        mentions=new_mentions,
+        resource_id=incident_id,
+        comment_id=activity.id,
+        text=body.text,
+    )
     return ActivityResponse.model_validate(activity)
+
+
+async def _resolve_incident_comment_mentions(
+    *,
+    request: Request,
+    session: AsyncSession,
+    analyst: Analyst,
+    text: str,
+) -> list[ResolvedMention]:
+    tokens = parse_mention_tokens(text)
+    if not tokens:
+        return []
+    return await resolve_mentions(
+        app=request.app,
+        session=session,
+        usernames=tokens,
+        analyst=analyst,
+        request=request,
+    )
+
+
+async def _notify_incident_mentions(
+    *,
+    actor: Analyst,
+    mentions: list[ResolvedMention],
+    resource_id: uuid.UUID,
+    comment_id: uuid.UUID,
+    text: str,
+) -> None:
+    if not mentions:
+        return
+    await dispatch_mention_notifications(
+        [
+            MentionNotification(
+                recipient_username=m.username,
+                recipient_id=m.analyst_id,
+                actor_username=actor.username,
+                resource_type="incident",
+                resource_id=str(resource_id),
+                comment_id=str(comment_id),
+                comment_text=text,
+            )
+            for m in mentions
+        ]
+    )

--- a/src/opensoar/comments/__init__.py
+++ b/src/opensoar/comments/__init__.py
@@ -1,0 +1,4 @@
+"""Helpers for alert and incident comment processing."""
+from opensoar.comments.mentions import parse_mention_tokens
+
+__all__ = ["parse_mention_tokens"]

--- a/src/opensoar/comments/mentions.py
+++ b/src/opensoar/comments/mentions.py
@@ -1,0 +1,36 @@
+"""Parse ``@username`` mention tokens out of comment text.
+
+Usernames may contain lowercase ASCII letters, digits, underscores, dots, and
+hyphens.  A mention must be preceded by a non-word character (or the start of
+the string) so that email addresses like ``alice@example.com`` do not match.
+Results are returned lowercased, deduplicated, and in the order they first
+appear so downstream callers can line them up with a username lookup without
+further processing.
+"""
+from __future__ import annotations
+
+import re
+
+# Word-boundary guard: the token must not be glued to the tail of another word
+# (defeats ``alice@example.com``).  We rely on ``(?<![\w.])`` rather than ``\b``
+# because ``\b`` treats ``.`` as a boundary and we want to keep dotted usernames.
+_MENTION_RE = re.compile(r"(?<![\w@.])@([A-Za-z0-9_][A-Za-z0-9_.\-]{0,63})")
+
+
+def parse_mention_tokens(text: str | None) -> list[str]:
+    """Extract unique, order-preserving lowercase usernames from ``text``."""
+    if not text:
+        return []
+
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for match in _MENTION_RE.finditer(text):
+        raw = match.group(1).rstrip(".-_")
+        if not raw:
+            continue
+        token = raw.lower()
+        if token in seen:
+            continue
+        seen.add(token)
+        ordered.append(token)
+    return ordered

--- a/src/opensoar/comments/resolver.py
+++ b/src/opensoar/comments/resolver.py
@@ -1,0 +1,82 @@
+"""Resolve parsed mention tokens against the current tenant's analyst list.
+
+The resolver delegates tenant filtering to the optional
+``tenant_access_validators`` plugin surface so a cross-tenant mention is
+treated exactly like a username that does not exist (silently dropped).
+The caller can then store only the validated usernames and dispatch
+notifications to those analysts.
+"""
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+from fastapi import FastAPI, HTTPException
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from opensoar.models.analyst import Analyst
+from opensoar.plugins import enforce_tenant_access
+
+
+@dataclass(frozen=True)
+class ResolvedMention:
+    username: str
+    analyst_id: uuid.UUID
+
+
+async def resolve_mentions(
+    *,
+    app: FastAPI,
+    session: AsyncSession,
+    usernames: list[str],
+    analyst: Analyst | None,
+    request,
+) -> list[ResolvedMention]:
+    """Return the subset of ``usernames`` that the caller may mention.
+
+    - Usernames matched case-insensitively against ``analysts.username``.
+    - Inactive analysts are skipped.
+    - Analysts outside the caller's tenant are skipped (a tenant plugin can
+      raise ``HTTPException`` from :func:`enforce_tenant_access`; we treat that
+      as "invisible" and simply drop the token rather than error the comment).
+    - Duplicates are collapsed; output order matches the input order.
+    """
+    if not usernames:
+        return []
+
+    lowered = [u.lower() for u in usernames]
+    result = await session.execute(
+        select(Analyst).where(
+            func.lower(Analyst.username).in_(lowered),
+            Analyst.is_active.is_(True),
+        )
+    )
+    found = {a.username.lower(): a for a in result.scalars().all()}
+
+    resolved: list[ResolvedMention] = []
+    seen: set[str] = set()
+    for token in lowered:
+        if token in seen:
+            continue
+        seen.add(token)
+        target = found.get(token)
+        if target is None:
+            continue
+        try:
+            await enforce_tenant_access(
+                app,
+                resource=target,
+                resource_type="analyst",
+                action="mention",
+                analyst=analyst,
+                request=request,
+                session=session,
+            )
+        except HTTPException:
+            # Mention crosses a tenant boundary — silently drop.
+            continue
+        resolved.append(
+            ResolvedMention(username=target.username.lower(), analyst_id=target.id)
+        )
+    return resolved

--- a/src/opensoar/models/activity.py
+++ b/src/opensoar/models/activity.py
@@ -29,3 +29,4 @@ class Activity(Base):
     detail: Mapped[str | None] = mapped_column(Text)
     metadata_json: Mapped[dict | None] = mapped_column(JSONB)
     analyst_username: Mapped[str | None] = mapped_column(String(100))
+    mentions: Mapped[list[str] | None] = mapped_column(JSONB)

--- a/src/opensoar/notifications.py
+++ b/src/opensoar/notifications.py
@@ -1,0 +1,75 @@
+"""In-app mention notifications with a pluggable hook surface.
+
+Core ships a no-op registry.  Downstream surfaces (email, Slack, WebSocket
+delivery, an ``in_app_notifications`` table, etc.) register handlers via
+:func:`register_notification_hook`.  The comment routers call
+:func:`dispatch_mention_notifications` once per comment with one
+:class:`MentionNotification` per resolved recipient.
+"""
+from __future__ import annotations
+
+import inspect
+import logging
+import uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MentionNotification:
+    """Payload delivered to each registered notification hook."""
+
+    recipient_username: str
+    recipient_id: uuid.UUID | None
+    actor_username: str | None
+    resource_type: str  # "alert" | "incident"
+    resource_id: str
+    comment_id: str
+    comment_text: str
+
+
+NotificationHook = Callable[
+    [MentionNotification],
+    Awaitable[None] | None,
+]
+
+_hooks: list[NotificationHook] = []
+
+
+def register_notification_hook(hook: NotificationHook) -> None:
+    """Register ``hook`` to receive every future mention notification."""
+    _hooks.append(hook)
+
+
+def clear_notification_hooks() -> None:
+    """Remove all registered hooks (primarily for tests)."""
+    _hooks.clear()
+
+
+def _iter_hooks() -> list[NotificationHook]:
+    # Snapshot so hooks can register/unregister during dispatch.
+    return list(_hooks)
+
+
+async def dispatch_mention_notifications(
+    notifications: list[MentionNotification],
+) -> None:
+    """Fire every registered hook for every notification.
+
+    Hook exceptions are logged but never propagated — one misbehaving sink must
+    not break the comment write path.
+    """
+    if not notifications:
+        return
+    for notification in notifications:
+        for hook in _iter_hooks():
+            try:
+                result = hook(notification)
+                if inspect.isawaitable(result):
+                    await result
+            except Exception:  # pragma: no cover - defensive
+                logger.exception(
+                    "Mention notification hook %r raised", hook
+                )

--- a/src/opensoar/schemas/activity.py
+++ b/src/opensoar/schemas/activity.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
 class ActivityResponse(BaseModel):
@@ -16,10 +16,18 @@ class ActivityResponse(BaseModel):
     action: str
     detail: str | None = None
     metadata_json: dict[str, Any] | None = None
+    mentions: list[str] = []
     created_at: datetime
     updated_at: datetime
 
     model_config = {"from_attributes": True}
+
+    @field_validator("mentions", mode="before")
+    @classmethod
+    def _coerce_mentions(cls, value: Any) -> list[str]:
+        if value is None:
+            return []
+        return value
 
 
 class ActivityList(BaseModel):

--- a/src/opensoar/schemas/analyst.py
+++ b/src/opensoar/schemas/analyst.py
@@ -54,6 +54,16 @@ class AnalystRoleResponse(BaseModel):
     label: str
 
 
+class MentionableAnalyst(BaseModel):
+    """Minimal analyst projection used by the comment mention autocomplete."""
+
+    id: uuid.UUID
+    username: str
+    display_name: str
+
+    model_config = {"from_attributes": True}
+
+
 class PasswordChangeRequest(BaseModel):
     current_password: str
     new_password: str

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -1,0 +1,113 @@
+"""Unit tests for the @mention parser and notification dispatcher."""
+from __future__ import annotations
+
+from opensoar.comments.mentions import parse_mention_tokens
+from opensoar.notifications import (
+    MentionNotification,
+    clear_notification_hooks,
+    dispatch_mention_notifications,
+    register_notification_hook,
+)
+
+
+class TestParseMentionTokens:
+    def test_extracts_single_mention(self):
+        assert parse_mention_tokens("hello @alice") == ["alice"]
+
+    def test_extracts_multiple_mentions(self):
+        assert parse_mention_tokens("ping @alice and @bob") == ["alice", "bob"]
+
+    def test_deduplicates_repeated_mentions(self):
+        assert parse_mention_tokens("@alice @alice @alice") == ["alice"]
+
+    def test_preserves_insertion_order(self):
+        assert parse_mention_tokens("@charlie @alice @bob @alice") == [
+            "charlie",
+            "alice",
+            "bob",
+        ]
+
+    def test_normalizes_to_lowercase(self):
+        assert parse_mention_tokens("hey @Alice and @BOB") == ["alice", "bob"]
+
+    def test_allows_underscore_dot_dash_digits(self):
+        text = "cc @sec.ops @dr_who @a-team @user2"
+        assert parse_mention_tokens(text) == ["sec.ops", "dr_who", "a-team", "user2"]
+
+    def test_ignores_email_addresses(self):
+        # The "@" following a word character should not match.
+        assert parse_mention_tokens("mail alice@example.com please") == []
+
+    def test_empty_and_none_safe(self):
+        assert parse_mention_tokens("") == []
+        assert parse_mention_tokens(None) == []  # type: ignore[arg-type]
+
+    def test_lone_at_sign_is_not_a_mention(self):
+        assert parse_mention_tokens("look @ this") == []
+
+    def test_trailing_punctuation_is_stripped(self):
+        assert parse_mention_tokens("hey @alice, @bob!") == ["alice", "bob"]
+
+
+class TestNotificationHooks:
+    def setup_method(self):
+        clear_notification_hooks()
+
+    def teardown_method(self):
+        clear_notification_hooks()
+
+    async def test_hook_fires_once_per_mention(self):
+        captured: list[MentionNotification] = []
+
+        async def hook(notification: MentionNotification) -> None:
+            captured.append(notification)
+
+        register_notification_hook(hook)
+
+        await dispatch_mention_notifications(
+            [
+                MentionNotification(
+                    recipient_username="alice",
+                    recipient_id=None,
+                    actor_username="charlie",
+                    resource_type="alert",
+                    resource_id="abc",
+                    comment_id="c1",
+                    comment_text="hey @alice",
+                ),
+                MentionNotification(
+                    recipient_username="bob",
+                    recipient_id=None,
+                    actor_username="charlie",
+                    resource_type="alert",
+                    resource_id="abc",
+                    comment_id="c1",
+                    comment_text="hey @bob",
+                ),
+            ]
+        )
+
+        assert [n.recipient_username for n in captured] == ["alice", "bob"]
+
+    async def test_sync_hook_is_supported(self):
+        captured: list[MentionNotification] = []
+
+        def hook(notification: MentionNotification) -> None:
+            captured.append(notification)
+
+        register_notification_hook(hook)
+
+        await dispatch_mention_notifications(
+            [
+                MentionNotification(
+                    recipient_username="alice",
+                    recipient_id=None,
+                    actor_username="charlie",
+                    resource_type="incident",
+                    resource_id="i1",
+                    comment_id="c2",
+                    comment_text="@alice look",
+                )
+            ]
+        )
+        assert len(captured) == 1

--- a/tests/test_mentions_api.py
+++ b/tests/test_mentions_api.py
@@ -1,0 +1,246 @@
+"""Integration tests for @mentions inside alert and incident comments."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi import HTTPException
+
+from opensoar.notifications import clear_notification_hooks, register_notification_hook
+from opensoar.plugins import register_tenant_access_validator
+
+
+async def _register_analyst(client, username: str) -> dict:
+    """Register a fresh analyst and return headers + payload."""
+    resp = await client.post(
+        "/api/v1/auth/register",
+        json={
+            "username": username,
+            "display_name": username.title(),
+            "email": f"{username}@opensoar.app",
+            "password": "testpassword123",
+        },
+    )
+    data = resp.json()
+    return {
+        "token": data["access_token"],
+        "analyst": data["analyst"],
+        "headers": {"Authorization": f"Bearer {data['access_token']}"},
+    }
+
+
+@pytest.fixture(autouse=True)
+def _clear_notification_hooks():
+    clear_notification_hooks()
+    yield
+    clear_notification_hooks()
+
+
+class TestAlertCommentMentions:
+    async def test_known_mention_is_stored(self, client, registered_analyst):
+        mentioned = await _register_analyst(client, f"mentioned_{uuid.uuid4().hex[:6]}")
+
+        alert_resp = await client.post(
+            "/api/v1/webhooks/alerts",
+            json={"rule_name": "Mention Alert", "severity": "low"},
+        )
+        alert_id = alert_resp.json()["alert_id"]
+
+        comment = await client.post(
+            f"/api/v1/alerts/{alert_id}/comments",
+            json={"text": f"@{mentioned['analyst']['username']} please review"},
+            headers=registered_analyst["headers"],
+        )
+        assert comment.status_code == 200
+        body = comment.json()
+        assert body["mentions"] == [mentioned["analyst"]["username"].lower()]
+
+    async def test_unknown_mentions_are_ignored(self, client, registered_analyst):
+        alert_resp = await client.post(
+            "/api/v1/webhooks/alerts",
+            json={"rule_name": "Unknown Mention Alert", "severity": "low"},
+        )
+        alert_id = alert_resp.json()["alert_id"]
+
+        comment = await client.post(
+            f"/api/v1/alerts/{alert_id}/comments",
+            json={"text": "hi @nobody_here_yet please take a look"},
+            headers=registered_analyst["headers"],
+        )
+        assert comment.status_code == 200
+        body = comment.json()
+        # Unknown usernames must not error the whole comment.
+        assert body["detail"] == "hi @nobody_here_yet please take a look"
+        assert body["mentions"] == []
+
+    async def test_cross_tenant_mentions_are_rejected(self, client, registered_analyst):
+        from opensoar.main import app
+
+        # Register an analyst and tag them as belonging to a separate tenant via
+        # a custom validator.  The tenant hook rejects read access for the
+        # caller so the mentioned user looks invisible across tenants.
+        other = await _register_analyst(client, f"other_{uuid.uuid4().hex[:6]}")
+
+        alert_resp = await client.post(
+            "/api/v1/webhooks/alerts",
+            json={"rule_name": "Cross Tenant Mention", "severity": "low"},
+        )
+        alert_id = alert_resp.json()["alert_id"]
+
+        async def validator(**kwargs):
+            resource = kwargs.get("resource")
+            resource_type = kwargs.get("resource_type")
+            # Reject visibility of the "other" analyst only — everything else
+            # passes through.
+            if resource_type == "analyst" and resource is not None:
+                if getattr(resource, "username", None) == other["analyst"]["username"]:
+                    raise HTTPException(status_code=403, detail="cross tenant")
+
+        original = list(app.state.tenant_access_validators)
+        app.state.tenant_access_validators = []
+        register_tenant_access_validator(app, validator)
+        try:
+            comment = await client.post(
+                f"/api/v1/alerts/{alert_id}/comments",
+                json={"text": f"@{other['analyst']['username']} hi"},
+                headers=registered_analyst["headers"],
+            )
+        finally:
+            app.state.tenant_access_validators = original
+
+        assert comment.status_code == 200
+        # Cross-tenant mention treated like an unknown user — ignored, not an error.
+        assert comment.json()["mentions"] == []
+
+    async def test_notification_hook_fires_per_mention(self, client, registered_analyst):
+        alice = await _register_analyst(client, f"alice_{uuid.uuid4().hex[:6]}")
+        bob = await _register_analyst(client, f"bob_{uuid.uuid4().hex[:6]}")
+
+        captured: list[str] = []
+
+        async def hook(notification):
+            captured.append(notification.recipient_username)
+
+        register_notification_hook(hook)
+
+        alert_resp = await client.post(
+            "/api/v1/webhooks/alerts",
+            json={"rule_name": "Notify Alert", "severity": "low"},
+        )
+        alert_id = alert_resp.json()["alert_id"]
+
+        await client.post(
+            f"/api/v1/alerts/{alert_id}/comments",
+            json={
+                "text": (
+                    f"@{alice['analyst']['username']} and "
+                    f"@{bob['analyst']['username']} please triage"
+                )
+            },
+            headers=registered_analyst["headers"],
+        )
+
+        assert sorted(captured) == sorted(
+            [
+                alice["analyst"]["username"].lower(),
+                bob["analyst"]["username"].lower(),
+            ]
+        )
+
+    async def test_edit_recomputes_mentions(self, client, registered_analyst):
+        mentioned = await _register_analyst(client, f"edit_{uuid.uuid4().hex[:6]}")
+
+        alert_resp = await client.post(
+            "/api/v1/webhooks/alerts",
+            json={"rule_name": "Edit Mention Alert", "severity": "low"},
+        )
+        alert_id = alert_resp.json()["alert_id"]
+
+        comment = await client.post(
+            f"/api/v1/alerts/{alert_id}/comments",
+            json={"text": "no mention yet"},
+            headers=registered_analyst["headers"],
+        )
+        comment_id = comment.json()["id"]
+        assert comment.json()["mentions"] == []
+
+        edited = await client.patch(
+            f"/api/v1/alerts/{alert_id}/comments/{comment_id}",
+            json={"text": f"now @{mentioned['analyst']['username']}"},
+            headers=registered_analyst["headers"],
+        )
+        assert edited.status_code == 200
+        assert edited.json()["mentions"] == [mentioned["analyst"]["username"].lower()]
+
+
+class TestIncidentCommentMentions:
+    async def test_known_mention_is_stored(self, client, registered_analyst):
+        mentioned = await _register_analyst(client, f"incmention_{uuid.uuid4().hex[:6]}")
+
+        incident = await client.post(
+            "/api/v1/incidents",
+            json={"title": "Mention Incident", "severity": "low"},
+            headers=registered_analyst["headers"],
+        )
+        incident_id = incident.json()["id"]
+
+        comment = await client.post(
+            f"/api/v1/incidents/{incident_id}/comments",
+            json={"text": f"@{mentioned['analyst']['username']} FYI"},
+            headers=registered_analyst["headers"],
+        )
+        assert comment.status_code == 200
+        assert comment.json()["mentions"] == [mentioned["analyst"]["username"].lower()]
+
+    async def test_notification_hook_fires_per_mention(self, client, registered_analyst):
+        alice = await _register_analyst(client, f"iali_{uuid.uuid4().hex[:6]}")
+
+        captured: list[str] = []
+
+        def hook(notification):
+            captured.append(notification.recipient_username)
+
+        register_notification_hook(hook)
+
+        incident = await client.post(
+            "/api/v1/incidents",
+            json={"title": "Notify Incident", "severity": "low"},
+            headers=registered_analyst["headers"],
+        )
+        incident_id = incident.json()["id"]
+
+        await client.post(
+            f"/api/v1/incidents/{incident_id}/comments",
+            json={"text": f"@{alice['analyst']['username']} help please"},
+            headers=registered_analyst["headers"],
+        )
+        assert captured == [alice["analyst"]["username"].lower()]
+
+
+class TestMentionSuggestEndpoint:
+    async def test_lists_mentionable_analysts(self, client, registered_analyst):
+        other = await _register_analyst(client, f"sugg_{uuid.uuid4().hex[:6]}")
+
+        resp = await client.get(
+            f"/api/v1/auth/analysts/mentionable?q={other['analyst']['username'][:4]}",
+            headers=registered_analyst["headers"],
+        )
+        assert resp.status_code == 200
+        usernames = [a["username"] for a in resp.json()]
+        assert other["analyst"]["username"] in usernames
+
+    async def test_filters_by_prefix(self, client, registered_analyst):
+        target = await _register_analyst(client, f"filterme_{uuid.uuid4().hex[:6]}")
+
+        resp = await client.get(
+            "/api/v1/auth/analysts/mentionable?q=filterme",
+            headers=registered_analyst["headers"],
+        )
+        assert resp.status_code == 200
+        usernames = [a["username"] for a in resp.json()]
+        assert target["analyst"]["username"] in usernames
+        assert all(u.lower().startswith("filterme") for u in usernames)
+
+    async def test_requires_auth(self, client):
+        resp = await client.get("/api/v1/auth/analysts/mentionable")
+        assert resp.status_code in (401, 403)

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -200,8 +200,15 @@ export interface Activity {
   action: string
   detail: string | null
   metadata_json: Record<string, unknown> | null
+  mentions: string[]
   created_at: string
   updated_at: string
+}
+
+export interface MentionableAnalyst {
+  id: string
+  username: string
+  display_name: string
 }
 
 export interface ActivityList {
@@ -377,6 +384,14 @@ export const api = {
     roles: () => fetchJSON<AnalystRole[]>('/auth/roles'),
     changePassword: (data: { current_password: string; new_password: string }) =>
       postJSON<{ detail: string }>('/auth/change-password', data),
+    mentionable: (q?: string) => {
+      const sp = new URLSearchParams()
+      if (q) sp.set('q', q)
+      const qs = sp.toString()
+      return fetchJSON<MentionableAnalyst[]>(
+        `/auth/analysts/mentionable${qs ? `?${qs}` : ''}`,
+      )
+    },
   },
   webhooks: {
     createAlert: (payload: Record<string, unknown>) =>

--- a/ui/src/components/mentions/MentionComposer.tsx
+++ b/ui/src/components/mentions/MentionComposer.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useRef, useState } from 'react'
+import { api, type MentionableAnalyst } from '@/api'
+import { Input } from '@/components/ui/Input'
+import { cn } from '@/lib/utils'
+
+interface MentionComposerProps {
+  value: string
+  onChange: (next: string) => void
+  onSubmit?: () => void
+  placeholder?: string
+  className?: string
+  autoFocus?: boolean
+}
+
+/**
+ * Comment composer with inline `@username` autocomplete.
+ *
+ * The dropdown appears whenever the caret sits inside an `@token` at the end
+ * of a word.  Arrow keys move through suggestions, Enter/Tab accepts, Escape
+ * dismisses.  Outside a mention, Enter calls `onSubmit` so parent pages keep
+ * their current "enter to post" behavior.
+ */
+export function MentionComposer({
+  value,
+  onChange,
+  onSubmit,
+  placeholder,
+  className,
+  autoFocus,
+}: MentionComposerProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [query, setQuery] = useState<string | null>(null)
+  const [suggestions, setSuggestions] = useState<MentionableAnalyst[]>([])
+  const [activeIndex, setActiveIndex] = useState(0)
+
+  // Detect an active `@token` at the caret so we know whether to open the menu.
+  function detectQuery(next: string, caret: number): string | null {
+    const before = next.slice(0, caret)
+    const at = before.lastIndexOf('@')
+    if (at < 0) return null
+    // `@` must be at the start or follow whitespace so email addresses stay quiet.
+    const prev = at === 0 ? ' ' : before[at - 1]
+    if (!/\s/.test(prev)) return null
+    const token = before.slice(at + 1)
+    if (/\s/.test(token)) return null
+    return token
+  }
+
+  useEffect(() => {
+    if (query === null) return
+    let cancelled = false
+    api.auth
+      .mentionable(query || undefined)
+      .then((rows) => {
+        if (!cancelled) {
+          setSuggestions(rows)
+          setActiveIndex(0)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setSuggestions([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [query])
+
+  const showMenu = query !== null && suggestions.length > 0
+
+  function applyMention(username: string) {
+    const input = inputRef.current
+    if (!input) return
+    const caret = input.selectionStart ?? value.length
+    const before = value.slice(0, caret)
+    const at = before.lastIndexOf('@')
+    if (at < 0) return
+    const next = `${value.slice(0, at)}@${username} ${value.slice(caret)}`
+    onChange(next)
+    setQuery(null)
+    setSuggestions([])
+    // Restore caret just after the inserted mention + trailing space.
+    const newCaret = at + username.length + 2
+    requestAnimationFrame(() => {
+      input.focus()
+      input.setSelectionRange(newCaret, newCaret)
+    })
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (showMenu) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setActiveIndex((i) => (i + 1) % suggestions.length)
+        return
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setActiveIndex((i) => (i - 1 + suggestions.length) % suggestions.length)
+        return
+      }
+      if (e.key === 'Enter' || e.key === 'Tab') {
+        e.preventDefault()
+        applyMention(suggestions[activeIndex].username)
+        return
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        setQuery(null)
+        return
+      }
+    }
+    if (e.key === 'Enter' && !showMenu && value.trim() && onSubmit) {
+      e.preventDefault()
+      onSubmit()
+    }
+  }
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const next = e.target.value
+    onChange(next)
+    setQuery(detectQuery(next, e.target.selectionStart ?? next.length))
+  }
+
+  return (
+    <div className={cn('relative', className)}>
+      <Input
+        ref={inputRef}
+        type="text"
+        value={value}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        onBlur={() => setTimeout(() => setQuery(null), 120)}
+        placeholder={placeholder}
+        autoFocus={autoFocus}
+        className="text-sm"
+      />
+      {showMenu && (
+        <div
+          role="listbox"
+          data-testid="mention-suggestions"
+          className="absolute left-0 right-0 bottom-full mb-1 max-h-48 overflow-y-auto rounded-md border border-border bg-surface shadow-lg z-20"
+        >
+          {suggestions.map((person, index) => (
+            <button
+              key={person.id}
+              type="button"
+              role="option"
+              aria-selected={index === activeIndex}
+              onMouseDown={(e) => {
+                e.preventDefault()
+                applyMention(person.username)
+              }}
+              onMouseEnter={() => setActiveIndex(index)}
+              className={cn(
+                'w-full text-left px-3 py-1.5 text-xs flex items-center gap-2 border-none bg-transparent cursor-pointer',
+                index === activeIndex ? 'bg-surface-hover text-heading' : 'text-text',
+              )}
+            >
+              <span className="font-medium">@{person.username}</span>
+              <span className="text-muted">{person.display_name}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/ui/src/components/mentions/MentionText.tsx
+++ b/ui/src/components/mentions/MentionText.tsx
@@ -1,0 +1,61 @@
+import { Fragment } from 'react'
+import { Link } from 'react-router'
+import { cn } from '@/lib/utils'
+
+interface MentionTextProps {
+  text: string
+  /** Usernames validated server-side. Only these render as linked pills. */
+  mentions?: string[]
+  className?: string
+}
+
+const MENTION_PATTERN = /(?<![\w@.])@([A-Za-z0-9_][A-Za-z0-9_.-]{0,63})/g
+
+/**
+ * Render comment text with validated `@username` tokens promoted to pills
+ * linking to the analyst profile.  Tokens that weren't resolved server-side
+ * render as plain text so unknown mentions don't mislead operators.
+ */
+export function MentionText({ text, mentions = [], className }: MentionTextProps) {
+  const resolved = new Set(mentions.map((m) => m.toLowerCase()))
+  const parts: React.ReactNode[] = []
+  let lastIndex = 0
+  let key = 0
+
+  for (const match of text.matchAll(MENTION_PATTERN)) {
+    const index = match.index ?? 0
+    const username = match[1].replace(/[._-]+$/, '')
+    if (!username) continue
+    if (index > lastIndex) {
+      parts.push(<Fragment key={key++}>{text.slice(lastIndex, index)}</Fragment>)
+    }
+    const lower = username.toLowerCase()
+    if (resolved.has(lower)) {
+      parts.push(
+        <Link
+          key={key++}
+          to={`/settings/analysts/${lower}`}
+          data-testid="mention-pill"
+          className="inline-flex items-center px-1.5 py-0.5 rounded bg-accent/15 text-accent hover:bg-accent/25 hover:no-underline transition-colors font-medium"
+        >
+          @{username}
+        </Link>,
+      )
+    } else {
+      parts.push(
+        <Fragment key={key++}>{`@${username}`}</Fragment>,
+      )
+    }
+    lastIndex = index + match[0].length
+    // Trailing punctuation we stripped for username — push it back as text.
+    const trailing = match[0].slice(1 + username.length)
+    if (trailing) {
+      parts.push(<Fragment key={key++}>{trailing}</Fragment>)
+    }
+  }
+  if (lastIndex < text.length) {
+    parts.push(<Fragment key={key++}>{text.slice(lastIndex)}</Fragment>)
+  }
+
+  return <span className={cn(className)}>{parts}</span>
+}

--- a/ui/src/pages/AlertDetailPage.tsx
+++ b/ui/src/pages/AlertDetailPage.tsx
@@ -15,6 +15,8 @@ import { JsonViewer } from '@/components/ui/JsonViewer'
 import { Drawer } from '@/components/ui/Drawer'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card'
 import { Input, Label, Textarea } from '@/components/ui/Input'
+import { MentionComposer } from '@/components/mentions/MentionComposer'
+import { MentionText } from '@/components/mentions/MentionText'
 import { Select } from '@/components/ui/Select'
 import { Dropdown, DropdownItem, DropdownSeparator } from '@/components/ui/Dropdown'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogBody, DialogFooter } from '@/components/ui/Dialog'
@@ -327,15 +329,10 @@ function TimelineEntry({
         {/* Comment body — editable */}
         {isComment && editing ? (
           <div className="mt-1 space-y-1.5">
-            <Input
-              type="text"
+            <MentionComposer
               value={editText}
-              onChange={(e) => setEditText(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && editText.trim()) editMutation.mutate(editText.trim())
-                if (e.key === 'Escape') setEditing(false)
-              }}
-              className="!text-xs"
+              onChange={setEditText}
+              onSubmit={() => editText.trim() && editMutation.mutate(editText.trim())}
               autoFocus
             />
             <div className="flex gap-1">
@@ -349,7 +346,9 @@ function TimelineEntry({
           </div>
         ) : isComment && activity.detail ? (
           <div className="group/comment bg-surface-hover/50 px-3 py-2 rounded-md mt-1 relative">
-            <div className="text-text">{activity.detail}</div>
+            <div className="text-text">
+              <MentionText text={activity.detail} mentions={activity.mentions} />
+            </div>
             {isOwnComment && (
               <button
                 onClick={() => { setEditText(activity.detail || ''); setEditing(true) }}
@@ -830,15 +829,12 @@ export function AlertDetailPage() {
               </CardHeader>
               <CardContent>
                 <div className="flex gap-2 mb-4">
-                  <Input
-                    type="text"
-                    placeholder="Add a comment..."
+                  <MentionComposer
                     value={commentText}
-                    onChange={(e) => setCommentText(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' && commentText.trim()) commentMutation.mutate(commentText.trim())
-                    }}
-                    className="flex-1 text-sm"
+                    onChange={setCommentText}
+                    onSubmit={() => commentMutation.mutate(commentText.trim())}
+                    placeholder="Add a comment... Use @ to mention an analyst."
+                    className="flex-1"
                   />
                   <Button
                     size="sm"

--- a/ui/src/pages/IncidentDetailPage.tsx
+++ b/ui/src/pages/IncidentDetailPage.tsx
@@ -6,6 +6,8 @@ import { api, type Alert, type Activity, type Analyst, type Observable } from '@
 import { SeverityBadge, StatusBadge } from '@/components/ui/Badge'
 import { Button } from '@/components/ui/Button'
 import { Input, Label } from '@/components/ui/Input'
+import { MentionComposer } from '@/components/mentions/MentionComposer'
+import { MentionText } from '@/components/mentions/MentionText'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card'
 import { Select } from '@/components/ui/Select'
 import { Table, TableHeader, TableBody, TableHead, TableCell, TableHeaderRow } from '@/components/ui/Table'
@@ -104,15 +106,10 @@ function IncidentTimelineEntry({
 
         {isComment && editing ? (
           <div className="mt-1 space-y-1.5">
-            <Input
-              type="text"
+            <MentionComposer
               value={editText}
-              onChange={(e) => setEditText(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && editText.trim()) editMutation.mutate(editText.trim())
-                if (e.key === 'Escape') setEditing(false)
-              }}
-              className="!text-xs"
+              onChange={setEditText}
+              onSubmit={() => editText.trim() && editMutation.mutate(editText.trim())}
               autoFocus
             />
             <div className="flex gap-1">
@@ -126,7 +123,9 @@ function IncidentTimelineEntry({
           </div>
         ) : isComment && activity.detail ? (
           <div className="group/comment bg-surface-hover/50 px-3 py-2 rounded-md mt-1 relative">
-            <div className="text-text">{activity.detail}</div>
+            <div className="text-text">
+              <MentionText text={activity.detail} mentions={activity.mentions} />
+            </div>
             {isOwnComment && (
               <button
                 onClick={() => { setEditText(activity.detail || ''); setEditing(true) }}
@@ -516,15 +515,12 @@ export function IncidentDetailPage() {
             </CardHeader>
             <CardContent>
               <div className="flex gap-2 mb-4">
-                <Input
-                  type="text"
-                  placeholder="Add a comment..."
+                <MentionComposer
                   value={commentText}
-                  onChange={(e) => setCommentText(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' && commentText.trim()) commentMutation.mutate(commentText.trim())
-                  }}
-                  className="flex-1 text-sm"
+                  onChange={setCommentText}
+                  onSubmit={() => commentMutation.mutate(commentText.trim())}
+                  placeholder="Add a comment... Use @ to mention an analyst."
+                  className="flex-1"
                 />
                 <Button
                   size="sm"


### PR DESCRIPTION
## Summary
- Parse `@username` tokens on alert and incident comment create/edit, resolve them against the tenant-visible analyst list, and persist the normalized `mentions` array on the `activities` row.
- Cross-tenant mentions are treated like unknown usernames (silently dropped) via the existing `tenant_access_validators` plugin surface — a rogue mention never errors the comment.
- New `opensoar.notifications` module exposes a pluggable hook API (`register_notification_hook`) that fires one `MentionNotification` per resolved recipient, per comment. Edits only notify usernames that are new versus the prior version of the comment.
- New `GET /api/v1/auth/analysts/mentionable` endpoint backs the composer autocomplete (analyst-accessible, tenant-scoped, prefix-filtered).
- React: shared `MentionComposer` with arrow/Enter/Tab/Escape keyboard nav and a `MentionText` pill renderer that links validated mentions to the analyst profile route. Wired into both Alert and Incident detail pages for create and edit.

## Test plan
- [x] `ruff check src/ tests/` clean
- [x] `pytest tests/ -q` — 292 passed (includes new `test_mentions.py` + `test_mentions_api.py` covering parser, unknown mentions, cross-tenant rejection, notification hook, and the `/analysts/mentionable` endpoint)
- [x] Alembic `upgrade head` / `downgrade -1` / `upgrade head` round-trip on PostgreSQL
- [x] `npm run lint` and `npm run build` (strict `tsc -b`) clean

Closes #68