### PR TITLE
Fix mentions on timeline events and motion stub identity

### DIFF
--- a/src/opensoar/api/incidents.py
+++ b/src/opensoar/api/incidents.py
@@ -769,6 +769,7 @@ async def list_incident_timeline(
                 alert_id=activity.alert_id,
                 incident_id=activity.incident_id,
                 metadata_json=activity.metadata_json,
+                mentions=list(activity.mentions or []),
             )
         )
 

--- a/src/opensoar/schemas/activity.py
+++ b/src/opensoar/schemas/activity.py
@@ -61,6 +61,7 @@ class TimelineEvent(BaseModel):
     alert_id: uuid.UUID | None = None
     incident_id: uuid.UUID | None = None
     metadata_json: dict[str, Any] | None = None
+    mentions: list[str] = []
 
     model_config = {"from_attributes": True}
 

--- a/tests/test_incident_timeline_api.py
+++ b/tests/test_incident_timeline_api.py
@@ -335,3 +335,35 @@ class TestIncidentTimelineTenantScoping:
         details = [event.get("detail") for event in events]
         assert "Allowed comment" in details
         assert "Blocked comment" not in details
+
+
+class TestIncidentTimelineMentions:
+    async def test_timeline_exposes_mentions_on_comment_events(
+        self, client, registered_analyst
+    ):
+        mentioned = f"mention_{uuid.uuid4().hex[:6]}"
+        await client.post(
+            "/api/v1/auth/register",
+            json={
+                "username": mentioned,
+                "display_name": mentioned.title(),
+                "email": f"{mentioned}@opensoar.app",
+                "password": "testpassword123",
+            },
+        )
+
+        incident_id = await _create_incident(client, registered_analyst["headers"])
+        await client.post(
+            f"/api/v1/incidents/{incident_id}/comments",
+            json={"text": f"hey @{mentioned} take a look"},
+            headers=registered_analyst["headers"],
+        )
+
+        resp = await client.get(
+            f"/api/v1/incidents/{incident_id}/timeline?event_type=comment",
+            headers=registered_analyst["headers"],
+        )
+        assert resp.status_code == 200
+        events = resp.json()["events"]
+        assert len(events) == 1
+        assert events[0]["mentions"] == [mentioned.lower()]

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -282,6 +282,7 @@ export interface TimelineEvent {
   alert_id: string | null
   incident_id: string | null
   metadata_json: Record<string, unknown> | null
+  mentions: string[]
 }
 
 export interface TimelineList {

--- a/ui/src/test/setup.ts
+++ b/ui/src/test/setup.ts
@@ -106,11 +106,18 @@ function stripMotionProps(props: Record<string, any>): Record<string, any> {
 // Stub framer-motion so tests don't wait on layout/exit animations.
 vi.mock('framer-motion', async () => {
   const actual = await vi.importActual<Record<string, unknown>>('framer-motion')
-  const makeComponent = (tag: string) =>
+  const componentCache = new Map<string, React.ComponentType<unknown>>()
+  const makeComponent = (tag: string) => {
+    const cached = componentCache.get(tag)
+    if (cached) return cached
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    React.forwardRef<unknown, any>((props, ref) =>
+    const Component = React.forwardRef<unknown, any>((props, ref) =>
       React.createElement(tag, { ...stripMotionProps(props), ref }),
     )
+    Component.displayName = `motion.${tag}`
+    componentCache.set(tag, Component as unknown as React.ComponentType<unknown>)
+    return Component
+  }
 
   return {
     ...actual,


### PR DESCRIPTION
## Summary
- Add `mentions: list[str]` to `TimelineEvent` (backend schema + UI type) and pass it through in the `/incidents/{id}/timeline` endpoint — fixes the TS2339 that broke Docker UI build on main after #74 + #75 merged.
- Cache `motion.*` components in the vitest setup stub by tag so `userEvent.type()` doesn't reset inputs between keystrokes — fixes the LoginPage / IncidentDetailPage test failures that appeared in the #72 rebase.

## Test plan
- [x] `ruff check src/ tests/` clean
- [x] `pytest tests/test_incident_timeline_api.py tests/test_mentions_api.py tests/test_mentions.py` — 36 passed, including a new regression test exposing mentions on comment timeline events
- [x] `npm run test` in `ui/` — 58/58 pass
- [x] `npx tsc -b` in `ui/` clean