### PR TITLE
Add Splunk integration (search, notables, ingest)

### DIFF
--- a/src/opensoar/integrations/loader.py
+++ b/src/opensoar/integrations/loader.py
@@ -26,6 +26,7 @@ class IntegrationLoader:
             ("abuseipdb", "opensoar.integrations.abuseipdb.connector", "AbuseIPDBIntegration"),
             ("slack", "opensoar.integrations.slack.connector", "SlackIntegration"),
             ("email", "opensoar.integrations.email.connector", "EmailIntegration"),
+            ("splunk", "opensoar.integrations.splunk.connector", "SplunkIntegration"),
         ]
         for type_name, module_path, class_name in builtins:
             try:

--- a/src/opensoar/integrations/splunk/connector.py
+++ b/src/opensoar/integrations/splunk/connector.py
@@ -1,0 +1,274 @@
+"""Splunk integration — search, notable events, and alert ingestion."""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import aiohttp
+
+from opensoar.integrations.base import ActionDefinition, HealthCheckResult, IntegrationBase
+from opensoar.integrations.splunk.normalize import normalize_splunk_notable
+
+_POLL_INTERVAL = 1.0
+_POLL_TIMEOUT = 300
+
+
+class SplunkIntegration(IntegrationBase):
+    integration_type = "splunk"
+    display_name = "Splunk"
+    description = "Splunk Enterprise / ES integration for search, notables, and alert ingestion"
+
+    def __init__(self, config: dict[str, Any]):
+        self._client: aiohttp.ClientSession | None = None
+        super().__init__(config)
+
+    def _validate_config(self, config: dict[str, Any]) -> None:
+        if "url" not in config:
+            raise ValueError("Splunk requires 'url' in config")
+        has_token = "token" in config
+        has_basic = "username" in config and "password" in config
+        if not (has_token or has_basic):
+            raise ValueError(
+                "Splunk requires 'token' or 'username'+'password' in config"
+            )
+
+    async def connect(self) -> None:
+        headers: dict[str, str] = {"Accept": "application/json"}
+        auth: aiohttp.BasicAuth | None = None
+
+        if "token" in self._config:
+            headers["Authorization"] = f"Bearer {self._config['token']}"
+        else:
+            auth = aiohttp.BasicAuth(
+                self._config["username"], self._config["password"]
+            )
+
+        verify_ssl = bool(self._config.get("verify_ssl", True))
+        connector = aiohttp.TCPConnector(ssl=verify_ssl)
+        self._client = aiohttp.ClientSession(
+            base_url=self._config["url"],
+            headers=headers,
+            auth=auth,
+            connector=connector,
+        )
+
+    async def disconnect(self) -> None:
+        if self._client:
+            await self._client.close()
+            self._client = None
+
+    async def health_check(self) -> HealthCheckResult:
+        if not self._client:
+            return HealthCheckResult(healthy=False, message="Not connected")
+
+        try:
+            async with self._client.get(
+                "/services/server/info", params={"output_mode": "json"}
+            ) as resp:
+                if resp.status == 200:
+                    data = await resp.json()
+                    version = None
+                    entry = (data.get("entry") or [{}])[0]
+                    version = (entry.get("content") or {}).get("version")
+                    return HealthCheckResult(
+                        healthy=True,
+                        message="OK",
+                        details={"version": version or ""},
+                    )
+                return HealthCheckResult(healthy=False, message=f"HTTP {resp.status}")
+        except Exception as e:  # pragma: no cover - network failure path
+            return HealthCheckResult(healthy=False, message=str(e))
+
+    def get_actions(self) -> list[ActionDefinition]:
+        return [
+            ActionDefinition(
+                name="run_search",
+                description="Dispatch an SPL search and return results",
+                parameters={
+                    "spl": {"type": "string"},
+                    "earliest": {"type": "string"},
+                    "latest": {"type": "string"},
+                },
+            ),
+            ActionDefinition(
+                name="list_indexes",
+                description="List available Splunk indexes",
+                parameters={},
+            ),
+            ActionDefinition(
+                name="ingest_alerts",
+                description="Poll a saved search for recent notable events",
+                parameters={"saved_search": {"type": "string"}},
+            ),
+            ActionDefinition(
+                name="create_notable_event",
+                description="Create a notable event via Splunk Enterprise Security",
+                parameters={
+                    "rule_name": {"type": "string"},
+                    "description": {"type": "string"},
+                    "severity": {"type": "string"},
+                },
+            ),
+        ]
+
+    # ── SPL search job lifecycle ────────────────────────────
+
+    async def run_search(
+        self,
+        spl: str,
+        earliest: str | None = None,
+        latest: str | None = None,
+        max_count: int = 1000,
+    ) -> dict[str, Any]:
+        """Dispatch a search, poll until done, and return results."""
+        if not self._client:
+            raise RuntimeError("Not connected")
+
+        search = spl if spl.lstrip().startswith("search") else f"search {spl}"
+        body: dict[str, Any] = {
+            "search": search,
+            "output_mode": "json",
+            "exec_mode": "normal",
+        }
+        if earliest:
+            body["earliest_time"] = earliest
+        if latest:
+            body["latest_time"] = latest
+
+        async with self._client.post(
+            "/services/search/jobs", data=body
+        ) as resp:
+            if resp.status not in (200, 201):
+                text = await resp.text()
+                raise RuntimeError(f"Search dispatch failed: HTTP {resp.status} {text}")
+            data = await resp.json()
+
+        sid = data.get("sid")
+        if not sid:
+            raise RuntimeError("Splunk did not return a search id")
+
+        await self._wait_for_job(sid)
+        results = await self._fetch_job_results(sid, max_count=max_count)
+        return {"sid": sid, "results": results}
+
+    async def _wait_for_job(self, sid: str) -> None:
+        assert self._client is not None
+        elapsed = 0.0
+        while elapsed < _POLL_TIMEOUT:
+            async with self._client.get(
+                f"/services/search/jobs/{sid}", params={"output_mode": "json"}
+            ) as resp:
+                data = await resp.json()
+            entry = (data.get("entry") or [{}])[0]
+            content = entry.get("content") or {}
+            state = content.get("dispatchState")
+            if content.get("isDone"):
+                if state and state.upper() == "FAILED":
+                    raise RuntimeError(f"Splunk job {sid} dispatchState=FAILED")
+                return
+            await asyncio.sleep(_POLL_INTERVAL)
+            elapsed += _POLL_INTERVAL
+        raise RuntimeError(f"Splunk job {sid} did not complete in time")
+
+    async def _fetch_job_results(
+        self, sid: str, max_count: int = 1000
+    ) -> list[dict[str, Any]]:
+        assert self._client is not None
+        async with self._client.get(
+            f"/services/search/jobs/{sid}/results",
+            params={"output_mode": "json", "count": str(max_count)},
+        ) as resp:
+            data = await resp.json()
+        return list(data.get("results") or [])
+
+    # ── Indexes ─────────────────────────────────────────────
+
+    async def list_indexes(self) -> list[dict[str, Any]]:
+        if not self._client:
+            raise RuntimeError("Not connected")
+        async with self._client.get(
+            "/services/data/indexes", params={"output_mode": "json", "count": "0"}
+        ) as resp:
+            data = await resp.json()
+        entries = data.get("entry") or []
+        return [
+            {"name": e.get("name"), "content": e.get("content") or {}}
+            for e in entries
+        ]
+
+    # ── Ingest alerts via saved search ──────────────────────
+
+    async def ingest_alerts(self, saved_search: str) -> list[dict[str, Any]]:
+        """Re-dispatch a saved search and normalize its recent results."""
+        if not self._client:
+            raise RuntimeError("Not connected")
+
+        # Fetch metadata for the saved search (mostly for validation + SPL recovery)
+        path = f"/services/saved/searches/{saved_search}/history"
+        async with self._client.get(
+            path, params={"output_mode": "json"}
+        ) as resp:
+            meta = await resp.json()
+
+        # Dispatch the saved search synchronously and collect results
+        async with self._client.post(
+            f"/services/saved/searches/{saved_search}/dispatch",
+            data={"output_mode": "json"},
+        ) as resp:
+            if resp.status not in (200, 201):
+                text = await resp.text()
+                raise RuntimeError(
+                    f"Saved search dispatch failed: HTTP {resp.status} {text}"
+                )
+            data = await resp.json()
+
+        sid = data.get("sid") or _extract_sid_from_history(meta)
+        if not sid:
+            return []
+
+        await self._wait_for_job(sid)
+        rows = await self._fetch_job_results(sid)
+        return [normalize_splunk_notable(row) for row in rows]
+
+    # ── Notable event creation (Splunk ES) ──────────────────
+
+    async def create_notable_event(
+        self,
+        rule_name: str,
+        description: str | None = None,
+        severity: str = "medium",
+        **extra: Any,
+    ) -> dict[str, Any]:
+        """Create a notable event through the Splunk ES notable_update endpoint."""
+        if not self._client:
+            raise RuntimeError("Not connected")
+
+        body: dict[str, Any] = {
+            "rule_name": rule_name,
+            "severity": severity,
+            "output_mode": "json",
+        }
+        if description:
+            body["description"] = description
+        for k, v in extra.items():
+            if v is not None:
+                body[k] = v
+
+        async with self._client.post(
+            "/services/notable_update", data=body
+        ) as resp:
+            if resp.status >= 400:
+                text = await resp.text()
+                raise RuntimeError(
+                    f"Notable event creation failed: HTTP {resp.status} {text}"
+                )
+            return await resp.json()
+
+
+def _extract_sid_from_history(meta: dict[str, Any]) -> str | None:
+    entries = meta.get("entry") or []
+    for entry in entries:
+        sid = (entry.get("content") or {}).get("sid") or entry.get("name")
+        if sid:
+            return sid
+    return None

--- a/src/opensoar/integrations/splunk/normalize.py
+++ b/src/opensoar/integrations/splunk/normalize.py
@@ -1,0 +1,50 @@
+"""Normalize Splunk notable-event payloads into OpenSOAR alert shape."""
+from __future__ import annotations
+
+from typing import Any
+
+from opensoar.ingestion.normalize import extract_field, extract_iocs, normalize_severity
+
+
+def normalize_splunk_notable(payload: dict[str, Any]) -> dict[str, Any]:
+    """Convert a Splunk notable event (ES or savedsearch webhook) into an alert dict.
+
+    Splunk webhooks typically wrap the event under ``result`` with top-level
+    ``search_name``; the ES notable framework uses fields like ``rule_name``,
+    ``urgency``, ``src``, ``dest``, ``host``.
+    """
+    result = payload.get("result") if isinstance(payload.get("result"), dict) else payload
+
+    title = (
+        extract_field(result, "rule_name", "signature", "search_name")
+        or extract_field(payload, "search_name")
+        or "Splunk Notable"
+    )
+
+    raw_severity = extract_field(
+        result,
+        "severity",
+        "urgency",
+        "priority",
+    )
+
+    source_ip = extract_field(result, "src_ip", "src", "source_ip")
+    dest_ip = extract_field(result, "dest_ip", "dest", "destination_ip")
+    hostname = extract_field(result, "host", "hostname", "dvc")
+
+    return {
+        "source": "splunk",
+        "source_id": extract_field(
+            result, "event_id", "event_hash", "_cd", "sid"
+        ),
+        "title": str(title),
+        "description": extract_field(result, "description", "_raw"),
+        "severity": normalize_severity(raw_severity),
+        "status": "new",
+        "source_ip": source_ip,
+        "dest_ip": dest_ip,
+        "hostname": hostname,
+        "rule_name": str(title),
+        "iocs": extract_iocs(result),
+        "tags": result.get("tag", []) if isinstance(result.get("tag"), list) else [],
+    }

--- a/tests/test_splunk_integration.py
+++ b/tests/test_splunk_integration.py
@@ -1,0 +1,362 @@
+"""Tests for the Splunk integration connector and notable-event normalizer."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from opensoar.integrations.splunk.connector import SplunkIntegration
+from opensoar.integrations.splunk.normalize import normalize_splunk_notable
+
+
+# ── Config validation ───────────────────────────────────────
+
+
+class TestSplunkConfig:
+    def test_requires_url(self):
+        with pytest.raises(ValueError, match="url"):
+            SplunkIntegration({"token": "abc"})
+
+    def test_requires_auth(self):
+        with pytest.raises(ValueError, match="token"):
+            SplunkIntegration({"url": "https://splunk.example.com:8089"})
+
+    def test_accepts_token(self):
+        conn = SplunkIntegration(
+            {"url": "https://splunk.example.com:8089", "token": "abc"}
+        )
+        assert conn.integration_type == "splunk"
+        assert conn.display_name == "Splunk"
+
+    def test_accepts_basic_auth(self):
+        conn = SplunkIntegration(
+            {
+                "url": "https://splunk.example.com:8089",
+                "username": "admin",
+                "password": "changeme",
+            }
+        )
+        assert conn is not None
+
+    def test_rejects_username_without_password(self):
+        with pytest.raises(ValueError):
+            SplunkIntegration(
+                {"url": "https://splunk.example.com:8089", "username": "admin"}
+            )
+
+
+# ── Actions descriptor ──────────────────────────────────────
+
+
+class TestSplunkActions:
+    def test_get_actions_lists_supported(self):
+        conn = SplunkIntegration(
+            {"url": "https://splunk.example.com:8089", "token": "abc"}
+        )
+        names = {a.name for a in conn.get_actions()}
+        assert "run_search" in names
+        assert "list_indexes" in names
+        assert "ingest_alerts" in names
+        assert "create_notable_event" in names
+
+
+# ── Helper to build a mock aiohttp response ─────────────────
+
+
+def _mock_response(status: int = 200, json_data: dict | None = None, text: str = ""):
+    resp = MagicMock()
+    resp.status = status
+    resp.json = AsyncMock(return_value=json_data or {})
+    resp.text = AsyncMock(return_value=text)
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock(return_value=None)
+    return resp
+
+
+class _MockClient:
+    def __init__(self):
+        self.get = MagicMock()
+        self.post = MagicMock()
+        self.close = AsyncMock()
+
+
+# ── run_search lifecycle ────────────────────────────────────
+
+
+class TestRunSearch:
+    @pytest.mark.asyncio
+    async def test_run_search_polls_job_until_done(self):
+        conn = SplunkIntegration(
+            {"url": "https://splunk.example.com:8089", "token": "abc"}
+        )
+        mock_client = _MockClient()
+
+        # POST /services/search/jobs → returns sid
+        create_resp = _mock_response(
+            201, {"sid": "1234.5"}, text="<sid>1234.5</sid>"
+        )
+        mock_client.post.return_value = create_resp
+
+        # GET /services/search/jobs/{sid} → DONE; then GET results
+        status_running = _mock_response(
+            200, {"entry": [{"content": {"isDone": False, "dispatchState": "RUNNING"}}]}
+        )
+        status_done = _mock_response(
+            200, {"entry": [{"content": {"isDone": True, "dispatchState": "DONE"}}]}
+        )
+        results_resp = _mock_response(
+            200, {"results": [{"_raw": "hit1"}, {"_raw": "hit2"}]}
+        )
+        mock_client.get.side_effect = [status_running, status_done, results_resp]
+
+        conn._client = mock_client
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            out = await conn.run_search("search index=main", earliest="-15m")
+
+        assert out["sid"] == "1234.5"
+        assert len(out["results"]) == 2
+        assert out["results"][0]["_raw"] == "hit1"
+
+        # creation call shape
+        post_kwargs = mock_client.post.call_args
+        assert "/services/search/jobs" in post_kwargs.args[0]
+        body = post_kwargs.kwargs["data"]
+        assert body["search"].startswith("search ")
+        assert body["output_mode"] == "json"
+
+    @pytest.mark.asyncio
+    async def test_run_search_raises_when_not_connected(self):
+        conn = SplunkIntegration(
+            {"url": "https://splunk.example.com:8089", "token": "abc"}
+        )
+        with pytest.raises(RuntimeError, match="Not connected"):
+            await conn.run_search("search index=main")
+
+    @pytest.mark.asyncio
+    async def test_run_search_raises_when_job_fails(self):
+        conn = SplunkIntegration(
+            {"url": "https://splunk.example.com:8089", "token": "abc"}
+        )
+        mock_client = _MockClient()
+        mock_client.post.return_value = _mock_response(201, {"sid": "9"})
+        mock_client.get.return_value = _mock_response(
+            200, {"entry": [{"content": {"isDone": True, "dispatchState": "FAILED"}}]}
+        )
+        conn._client = mock_client
+
+        with pytest.raises(RuntimeError, match="FAILED"):
+            await conn.run_search("bad spl")
+
+
+# ── list_indexes ────────────────────────────────────────────
+
+
+class TestListIndexes:
+    @pytest.mark.asyncio
+    async def test_list_indexes_returns_names(self):
+        conn = SplunkIntegration(
+            {"url": "https://splunk.example.com:8089", "token": "abc"}
+        )
+        mock_client = _MockClient()
+        mock_client.get.return_value = _mock_response(
+            200,
+            {
+                "entry": [
+                    {"name": "main", "content": {"totalEventCount": 42}},
+                    {"name": "_internal", "content": {"totalEventCount": 1000}},
+                ]
+            },
+        )
+        conn._client = mock_client
+
+        indexes = await conn.list_indexes()
+        assert "main" in [i["name"] for i in indexes]
+        assert "_internal" in [i["name"] for i in indexes]
+
+        url_arg = mock_client.get.call_args.args[0]
+        assert "/services/data/indexes" in url_arg
+
+
+# ── ingest_alerts via saved search ──────────────────────────
+
+
+class TestIngestAlerts:
+    @pytest.mark.asyncio
+    async def test_ingest_alerts_returns_normalized_alerts(self):
+        conn = SplunkIntegration(
+            {"url": "https://splunk.example.com:8089", "token": "abc"}
+        )
+        mock_client = _MockClient()
+
+        # Mock the saved search history endpoint
+        mock_client.get.return_value = _mock_response(
+            200,
+            {
+                "entry": [
+                    {
+                        "name": "abc-history-1",
+                        "content": {
+                            "sid": "hist-1",
+                            "eventSearch": "search index=notable",
+                        },
+                    }
+                ]
+            },
+        )
+        # Mock the job results endpoint (called afterwards)
+        mock_client.post.return_value = _mock_response(201, {"sid": "hist-1"})
+        # results fetch
+        results = _mock_response(
+            200,
+            {
+                "results": [
+                    {
+                        "event_id": "n-1",
+                        "rule_name": "Brute Force",
+                        "severity": "high",
+                        "src": "10.0.0.1",
+                        "dest": "10.0.0.2",
+                        "host": "srv01",
+                    }
+                ]
+            },
+        )
+        status_done = _mock_response(
+            200,
+            {"entry": [{"content": {"isDone": True, "dispatchState": "DONE"}}]},
+        )
+        # The ingest path re-dispatches the saved search then polls + fetches results
+        mock_client.get.side_effect = [
+            mock_client.get.return_value,  # saved search metadata
+            status_done,
+            results,
+        ]
+
+        conn._client = mock_client
+        alerts = await conn.ingest_alerts(saved_search="Notable Alerts")
+
+        assert len(alerts) == 1
+        assert alerts[0]["source"] == "splunk"
+        assert alerts[0]["severity"] == "high"
+        assert alerts[0]["title"] == "Brute Force"
+        assert alerts[0]["source_ip"] == "10.0.0.1"
+
+
+# ── create_notable_event (ES) ───────────────────────────────
+
+
+class TestCreateNotableEvent:
+    @pytest.mark.asyncio
+    async def test_create_notable_event_posts_to_es_endpoint(self):
+        conn = SplunkIntegration(
+            {"url": "https://splunk.example.com:8089", "token": "abc"}
+        )
+        mock_client = _MockClient()
+        mock_client.post.return_value = _mock_response(
+            200, {"success": True, "message": "created"}
+        )
+        conn._client = mock_client
+
+        out = await conn.create_notable_event(
+            rule_name="Suspicious Login",
+            description="Multiple failed logins",
+            severity="high",
+            src="10.0.0.5",
+        )
+        assert out["success"] is True
+
+        url_arg = mock_client.post.call_args.args[0]
+        assert "notable_event" in url_arg or "/services/notable_update" in url_arg
+        body = mock_client.post.call_args.kwargs["data"]
+        assert body["rule_name"] == "Suspicious Login"
+        assert body["severity"] == "high"
+
+
+# ── health_check ────────────────────────────────────────────
+
+
+class TestHealthCheck:
+    @pytest.mark.asyncio
+    async def test_health_check_ok(self):
+        conn = SplunkIntegration(
+            {"url": "https://splunk.example.com:8089", "token": "abc"}
+        )
+        mock_client = _MockClient()
+        mock_client.get.return_value = _mock_response(
+            200,
+            {"entry": [{"content": {"version": "9.1.2"}}]},
+        )
+        conn._client = mock_client
+
+        hc = await conn.health_check()
+        assert hc.healthy is True
+        assert "9.1.2" in (hc.details or {}).get("version", "")
+
+    @pytest.mark.asyncio
+    async def test_health_check_not_connected(self):
+        conn = SplunkIntegration(
+            {"url": "https://splunk.example.com:8089", "token": "abc"}
+        )
+        hc = await conn.health_check()
+        assert hc.healthy is False
+
+
+# ── Notable-event normalizer ────────────────────────────────
+
+
+class TestNormalizeSplunkNotable:
+    def test_normalize_minimal(self):
+        payload = {
+            "rule_name": "Suspicious SSH",
+            "severity": "high",
+            "src": "192.168.1.10",
+            "dest": "10.0.0.1",
+            "host": "web01",
+            "event_id": "evt-1",
+        }
+        out = normalize_splunk_notable(payload)
+        assert out["source"] == "splunk"
+        assert out["source_id"] == "evt-1"
+        assert out["title"] == "Suspicious SSH"
+        assert out["severity"] == "high"
+        assert out["source_ip"] == "192.168.1.10"
+        assert out["dest_ip"] == "10.0.0.1"
+        assert out["hostname"] == "web01"
+        assert out["status"] == "new"
+
+    def test_normalize_webhook_wrapped(self):
+        """Splunk webhook wraps the notable inside `result`."""
+        payload = {
+            "result": {
+                "rule_name": "DNS Exfil",
+                "urgency": "critical",
+                "src_ip": "10.0.0.7",
+            },
+            "search_name": "ES - DNS Exfil",
+        }
+        out = normalize_splunk_notable(payload)
+        assert out["title"] == "DNS Exfil"
+        assert out["severity"] == "critical"
+        assert out["source_ip"] == "10.0.0.7"
+
+    def test_normalize_missing_fields_defaults(self):
+        out = normalize_splunk_notable({})
+        assert out["source"] == "splunk"
+        assert out["title"]  # non-empty fallback
+        assert out["severity"] in {"critical", "high", "medium", "low"}
+
+
+# ── Loader registration ─────────────────────────────────────
+
+
+class TestLoaderRegistration:
+    def test_builtin_loader_includes_splunk(self):
+        from opensoar.integrations.loader import IntegrationLoader
+
+        loader = IntegrationLoader()
+        loader.discover_builtin()
+        assert "splunk" in loader.available_types()
+        cls = loader.get_connector("splunk")
+        assert cls is not None
+        assert cls.integration_type == "splunk"


### PR DESCRIPTION
## Summary
- New `splunk` connector under `src/opensoar/integrations/splunk/` supporting token and basic auth
- Implements `run_search` (SPL via `services/search/jobs` with job polling), `list_indexes`, `ingest_alerts` (saved-search dispatch with normalization), and `create_notable_event` (ES `notable_update`)
- Adds a notable-event normalizer that handles both raw ES rows and webhook-wrapped `result` envelopes, and registers the connector in the built-in integration loader

## Test plan
- [x] `ruff check src/ tests/` clean
- [x] 18 new unit tests in `tests/test_splunk_integration.py` pass (mock aiohttp search-job lifecycle, indexes, saved search ingest, notable creation, health check, normalizer, loader registration)
- [ ] CI: test, api, worker, migrate, ui

Closes #78