### PR TITLE
Add Microsoft Defender for Endpoint integration

### DIFF
--- a/src/opensoar/integrations/loader.py
+++ b/src/opensoar/integrations/loader.py
@@ -27,6 +27,7 @@ class IntegrationLoader:
             ("slack", "opensoar.integrations.slack.connector", "SlackIntegration"),
             ("email", "opensoar.integrations.email.connector", "EmailIntegration"),
             ("splunk", "opensoar.integrations.splunk.connector", "SplunkIntegration"),
+            ("msdefender", "opensoar.integrations.msdefender.connector", "MSDefenderIntegration"),
         ]
         for type_name, module_path, class_name in builtins:
             try:

--- a/src/opensoar/integrations/msdefender/connector.py
+++ b/src/opensoar/integrations/msdefender/connector.py
@@ -1,0 +1,245 @@
+"""Microsoft Defender for Endpoint connector.
+
+Uses the Azure AD OAuth 2.0 client-credentials flow to obtain a bearer token
+for the Microsoft Defender for Endpoint API (``api.securitycenter.microsoft.com``).
+Exposes alert, machine, and indicator operations used by playbooks.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import aiohttp
+
+from opensoar.integrations.base import ActionDefinition, HealthCheckResult, IntegrationBase
+
+_API_BASE = "https://api.securitycenter.microsoft.com"
+_SCOPE = "https://api.securitycenter.microsoft.com/.default"
+_RESOURCE = "https://api.securitycenter.microsoft.com"
+
+
+class MSDefenderIntegration(IntegrationBase):
+    integration_type = "msdefender"
+    display_name = "Microsoft Defender for Endpoint"
+    description = (
+        "Microsoft Defender for Endpoint integration for alerts, machine isolation, "
+        "antivirus scans, and threat indicators"
+    )
+
+    def __init__(self, config: dict[str, Any]):
+        self._client: aiohttp.ClientSession | None = None
+        self._access_token: str | None = None
+        super().__init__(config)
+
+    # ── config / lifecycle ──────────────────────────────────
+
+    def _validate_config(self, config: dict[str, Any]) -> None:
+        for key in ("tenant_id", "client_id", "client_secret"):
+            if key not in config or not config[key]:
+                raise ValueError(
+                    f"Microsoft Defender requires '{key}' in config "
+                    f"(provide via environment-backed integration config)"
+                )
+
+    async def connect(self) -> None:
+        token = await self._fetch_access_token()
+        self._access_token = token
+        self._client = aiohttp.ClientSession(
+            base_url=_API_BASE,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+        )
+
+    async def _fetch_access_token(self) -> str:
+        tenant = self._config["tenant_id"]
+        token_url = (
+            f"https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token"
+        )
+        body = {
+            "grant_type": "client_credentials",
+            "client_id": self._config["client_id"],
+            "client_secret": self._config["client_secret"],
+            "scope": _SCOPE,
+            "resource": _RESOURCE,
+        }
+        token_session = aiohttp.ClientSession()
+        try:
+            async with token_session.post(
+                token_url,
+                data=body,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            ) as resp:
+                data = await resp.json()
+                if resp.status != 200 or "access_token" not in data:
+                    raise RuntimeError(
+                        f"Failed to obtain Defender access token: "
+                        f"status={resp.status} error={data.get('error', 'unknown')}"
+                    )
+                return str(data["access_token"])
+        finally:
+            await token_session.close()
+
+    async def disconnect(self) -> None:
+        if self._client:
+            await self._client.close()
+            self._client = None
+
+    async def health_check(self) -> HealthCheckResult:
+        if not self._client:
+            return HealthCheckResult(healthy=False, message="Not connected")
+        try:
+            async with self._client.get("/api/alerts", params={"$top": 1}) as resp:
+                if resp.status == 200:
+                    return HealthCheckResult(healthy=True, message="OK")
+                return HealthCheckResult(healthy=False, message=f"HTTP {resp.status}")
+        except Exception as e:  # pragma: no cover - exercised via mocking if needed
+            return HealthCheckResult(healthy=False, message=str(e))
+
+    # ── actions metadata ────────────────────────────────────
+
+    def get_actions(self) -> list[ActionDefinition]:
+        return [
+            ActionDefinition(
+                name="list_alerts",
+                description="List Defender alerts, optionally filtered via OData",
+                parameters={
+                    "odata_filter": {"type": "string"},
+                    "top": {"type": "integer"},
+                },
+            ),
+            ActionDefinition(
+                name="get_alert",
+                description="Fetch a single Defender alert by ID",
+                parameters={"alert_id": {"type": "string"}},
+            ),
+            ActionDefinition(
+                name="isolate_machine",
+                description="Isolate a machine from the network",
+                parameters={
+                    "machine_id": {"type": "string"},
+                    "comment": {"type": "string"},
+                    "isolation_type": {"type": "string"},
+                },
+            ),
+            ActionDefinition(
+                name="unisolate_machine",
+                description="Release a machine from isolation",
+                parameters={
+                    "machine_id": {"type": "string"},
+                    "comment": {"type": "string"},
+                },
+            ),
+            ActionDefinition(
+                name="list_machines",
+                description="List onboarded Defender machines",
+                parameters={
+                    "odata_filter": {"type": "string"},
+                    "top": {"type": "integer"},
+                },
+            ),
+            ActionDefinition(
+                name="run_antivirus_scan",
+                description="Trigger a Defender antivirus scan on a machine",
+                parameters={
+                    "machine_id": {"type": "string"},
+                    "scan_type": {"type": "string"},
+                    "comment": {"type": "string"},
+                },
+            ),
+            ActionDefinition(
+                name="list_indicators",
+                description="List custom threat indicators configured in Defender",
+                parameters={
+                    "odata_filter": {"type": "string"},
+                    "top": {"type": "integer"},
+                },
+            ),
+        ]
+
+    # ── action implementations ──────────────────────────────
+
+    def _require_client(self) -> aiohttp.ClientSession:
+        if not self._client:
+            raise RuntimeError("Not connected")
+        return self._client
+
+    @staticmethod
+    def _build_params(
+        odata_filter: str | None, top: int | None
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {}
+        if odata_filter:
+            params["$filter"] = odata_filter
+        if top is not None:
+            params["$top"] = top
+        return params
+
+    async def list_alerts(
+        self, odata_filter: str | None = None, top: int | None = None
+    ) -> list[dict[str, Any]]:
+        client = self._require_client()
+        params = self._build_params(odata_filter, top)
+        async with client.get("/api/alerts", params=params) as resp:
+            data = await resp.json()
+        return list(data.get("value", []))
+
+    async def get_alert(self, alert_id: str) -> dict[str, Any]:
+        client = self._require_client()
+        async with client.get(f"/api/alerts/{alert_id}") as resp:
+            return await resp.json()
+
+    async def isolate_machine(
+        self,
+        machine_id: str,
+        comment: str = "Isolated by OpenSOAR",
+        isolation_type: str = "Full",
+    ) -> dict[str, Any]:
+        client = self._require_client()
+        body = {"Comment": comment, "IsolationType": isolation_type}
+        async with client.post(
+            f"/api/machines/{machine_id}/isolate", json=body
+        ) as resp:
+            return await resp.json()
+
+    async def unisolate_machine(
+        self, machine_id: str, comment: str = "Unisolated by OpenSOAR"
+    ) -> dict[str, Any]:
+        client = self._require_client()
+        body = {"Comment": comment}
+        async with client.post(
+            f"/api/machines/{machine_id}/unisolate", json=body
+        ) as resp:
+            return await resp.json()
+
+    async def list_machines(
+        self, odata_filter: str | None = None, top: int | None = None
+    ) -> list[dict[str, Any]]:
+        client = self._require_client()
+        params = self._build_params(odata_filter, top)
+        async with client.get("/api/machines", params=params) as resp:
+            data = await resp.json()
+        return list(data.get("value", []))
+
+    async def run_antivirus_scan(
+        self,
+        machine_id: str,
+        scan_type: str = "Quick",
+        comment: str = "AV scan triggered by OpenSOAR",
+    ) -> dict[str, Any]:
+        client = self._require_client()
+        body = {"ScanType": scan_type, "Comment": comment}
+        async with client.post(
+            f"/api/machines/{machine_id}/runAntiVirusScan", json=body
+        ) as resp:
+            return await resp.json()
+
+    async def list_indicators(
+        self, odata_filter: str | None = None, top: int | None = None
+    ) -> list[dict[str, Any]]:
+        client = self._require_client()
+        params = self._build_params(odata_filter, top)
+        async with client.get("/api/indicators", params=params) as resp:
+            data = await resp.json()
+        return list(data.get("value", []))

--- a/src/opensoar/integrations/msdefender/normalize.py
+++ b/src/opensoar/integrations/msdefender/normalize.py
@@ -1,0 +1,50 @@
+"""Normalizer for Microsoft Defender for Endpoint alert payloads.
+
+Accepts both raw Defender alert objects (as returned by ``/api/alerts``) and
+webhook wrappers that nest the alert under an ``alert`` key.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from opensoar.ingestion.normalize import extract_field, extract_iocs, normalize_severity
+
+
+def normalize_msdefender_alert(payload: dict[str, Any]) -> dict[str, Any]:
+    alert = payload.get("alert", payload)
+
+    title = (
+        extract_field(alert, "title", "alertDisplayName", "threatName")
+        or "Microsoft Defender Alert"
+    )
+    severity = normalize_severity(extract_field(alert, "severity"))
+    source_id = extract_field(alert, "id", "alertId", "incidentId")
+
+    hostname = extract_field(
+        alert, "computerDnsName", "machineDnsName", "deviceName", "machineId"
+    )
+    source_ip = extract_field(alert, "sourceIp", "lastSeenIpAddress", "ipAddress")
+
+    category = extract_field(alert, "category")
+    detection_source = extract_field(alert, "detectionSource")
+    tags_raw = extract_field(alert, "tags", default=[])
+    tags: list[str] = list(tags_raw) if isinstance(tags_raw, list) else []
+    if category and category not in tags:
+        tags.append(str(category))
+    if detection_source and detection_source not in tags:
+        tags.append(str(detection_source))
+
+    return {
+        "source": "msdefender",
+        "source_id": source_id,
+        "title": str(title),
+        "description": extract_field(alert, "description", "alertDescription"),
+        "severity": severity,
+        "status": "new",
+        "source_ip": source_ip,
+        "dest_ip": extract_field(alert, "destinationIp"),
+        "hostname": hostname,
+        "rule_name": str(title),
+        "iocs": extract_iocs(alert),
+        "tags": tags,
+    }

--- a/tests/test_msdefender.py
+++ b/tests/test_msdefender.py
@@ -1,0 +1,442 @@
+"""Tests for the Microsoft Defender for Endpoint integration."""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from opensoar.integrations.loader import IntegrationLoader
+from opensoar.integrations.msdefender.connector import MSDefenderIntegration
+from opensoar.integrations.msdefender.normalize import normalize_msdefender_alert
+
+
+# ── Mock HTTP plumbing ──────────────────────────────────────
+
+
+class _MockResp:
+    def __init__(self, payload: Any, status: int = 200) -> None:
+        self._payload = payload
+        self.status = status
+
+    async def __aenter__(self) -> "_MockResp":
+        return self
+
+    async def __aexit__(self, *a: object) -> None:
+        return None
+
+    async def json(self) -> Any:
+        return self._payload
+
+
+class _MockClient:
+    """Records every request and returns canned responses keyed by (method, path)."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.responses: dict[tuple[str, str], tuple[Any, int]] = {}
+        self.closed = False
+
+    def set_response(
+        self,
+        method: str,
+        path: str,
+        payload: Any,
+        status: int = 200,
+    ) -> None:
+        self.responses[(method.upper(), path)] = (payload, status)
+
+    def _record(self, method: str, path: str, **kwargs: Any) -> _MockResp:
+        self.calls.append({"method": method, "path": path, **kwargs})
+        payload, status = self.responses.get(
+            (method.upper(), path),
+            ({"value": []}, 200),
+        )
+        return _MockResp(payload, status)
+
+    def get(self, path: str, **kwargs: Any) -> _MockResp:
+        return self._record("GET", path, **kwargs)
+
+    def post(self, path: str, **kwargs: Any) -> _MockResp:
+        return self._record("POST", path, **kwargs)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+# ── Config validation + loader discovery ────────────────────
+
+
+class TestConfigValidation:
+    def test_missing_tenant_raises(self) -> None:
+        with pytest.raises(ValueError, match="tenant_id"):
+            MSDefenderIntegration({"client_id": "a", "client_secret": "b"})
+
+    def test_missing_client_id_raises(self) -> None:
+        with pytest.raises(ValueError, match="client_id"):
+            MSDefenderIntegration({"tenant_id": "t", "client_secret": "b"})
+
+    def test_missing_client_secret_raises(self) -> None:
+        with pytest.raises(ValueError, match="client_secret"):
+            MSDefenderIntegration({"tenant_id": "t", "client_id": "a"})
+
+    def test_valid_config(self) -> None:
+        integ = MSDefenderIntegration(
+            {"tenant_id": "t", "client_id": "a", "client_secret": "b"},
+        )
+        assert integ.integration_type == "msdefender"
+        assert integ.display_name == "Microsoft Defender for Endpoint"
+
+
+class TestLoaderDiscovery:
+    def test_loader_discovers_msdefender(self) -> None:
+        loader = IntegrationLoader()
+        loader.discover_builtin()
+        assert "msdefender" in loader.available_types()
+        cls = loader.get_connector("msdefender")
+        assert cls is not None
+        assert cls.integration_type == "msdefender"
+
+
+# ── OAuth token exchange ────────────────────────────────────
+
+
+class TestAuthTokenExchange:
+    async def test_connect_exchanges_client_credentials_for_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """connect() must POST to the tenant's OAuth token endpoint and cache the token."""
+        import opensoar.integrations.msdefender.connector as conn_mod
+
+        captured: dict[str, Any] = {}
+
+        class _TokenResp:
+            status = 200
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return None
+
+            async def json(self):
+                return {"access_token": "tok-123", "expires_in": 3600}
+
+        class _TokenSession:
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                captured["session_args"] = (args, kwargs)
+
+            def post(self, url: str, data: Any = None, **kwargs: Any) -> _TokenResp:
+                captured["token_url"] = url
+                captured["token_body"] = data
+                return _TokenResp()
+
+            async def close(self) -> None:
+                captured["token_closed"] = True
+
+        class _ApiSession:
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                captured["api_args"] = (args, kwargs)
+
+            async def close(self) -> None:
+                pass
+
+        calls = {"n": 0}
+
+        def _session_factory(*args: Any, **kwargs: Any):
+            calls["n"] += 1
+            # First ClientSession is for token exchange; second is the API client.
+            return _TokenSession(*args, **kwargs) if calls["n"] == 1 else _ApiSession(*args, **kwargs)
+
+        monkeypatch.setattr(conn_mod.aiohttp, "ClientSession", _session_factory)
+
+        integ = MSDefenderIntegration(
+            {"tenant_id": "my-tenant", "client_id": "cid", "client_secret": "sec"},
+        )
+        await integ.connect()
+
+        assert "my-tenant" in captured["token_url"]
+        assert "oauth2" in captured["token_url"]
+        body = captured["token_body"]
+        assert body["grant_type"] == "client_credentials"
+        assert body["client_id"] == "cid"
+        assert body["client_secret"] == "sec"
+        assert "securitycenter" in body["scope"] or "api.securitycenter" in body["resource"]
+        assert integ._access_token == "tok-123"
+        # Access token should be set on API session headers via base_url + headers kwargs.
+        api_kwargs = captured["api_args"][1]
+        assert api_kwargs["headers"]["Authorization"] == "Bearer tok-123"
+
+    async def test_connect_raises_when_token_endpoint_errors(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import opensoar.integrations.msdefender.connector as conn_mod
+
+        class _ErrResp:
+            status = 401
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return None
+
+            async def json(self):
+                return {"error": "invalid_client"}
+
+        class _Session:
+            def __init__(self, *a, **kw):
+                pass
+
+            def post(self, url: str, data: Any = None, **kwargs: Any) -> _ErrResp:
+                return _ErrResp()
+
+            async def close(self) -> None:
+                pass
+
+        monkeypatch.setattr(conn_mod.aiohttp, "ClientSession", _Session)
+
+        integ = MSDefenderIntegration(
+            {"tenant_id": "t", "client_id": "a", "client_secret": "b"},
+        )
+        with pytest.raises(RuntimeError, match="token"):
+            await integ.connect()
+
+
+# ── Method behavior (uses an injected mock client) ──────────
+
+
+def _prep(integ: MSDefenderIntegration) -> _MockClient:
+    """Attach a mock aiohttp-like client to an already-constructed integration."""
+    mock = _MockClient()
+    integ._client = mock  # type: ignore[assignment]
+    integ._access_token = "tok"
+    return mock
+
+
+def _make() -> MSDefenderIntegration:
+    return MSDefenderIntegration(
+        {"tenant_id": "t", "client_id": "cid", "client_secret": "sec"},
+    )
+
+
+class TestListAlerts:
+    async def test_hits_alerts_endpoint(self) -> None:
+        integ = _make()
+        mock = _prep(integ)
+        mock.set_response("GET", "/api/alerts", {"value": [{"id": "a1"}]})
+        result = await integ.list_alerts()
+        assert result == [{"id": "a1"}]
+        assert mock.calls[0]["method"] == "GET"
+        assert mock.calls[0]["path"] == "/api/alerts"
+
+    async def test_passes_odata_filter(self) -> None:
+        integ = _make()
+        mock = _prep(integ)
+        mock.set_response("GET", "/api/alerts", {"value": []})
+        await integ.list_alerts(odata_filter="status eq 'New'", top=50)
+        params = mock.calls[0]["params"]
+        assert params["$filter"] == "status eq 'New'"
+        assert params["$top"] == 50
+
+    async def test_requires_connection(self) -> None:
+        integ = _make()
+        with pytest.raises(RuntimeError, match="Not connected"):
+            await integ.list_alerts()
+
+
+class TestGetAlert:
+    async def test_fetches_single_alert_by_id(self) -> None:
+        integ = _make()
+        mock = _prep(integ)
+        mock.set_response("GET", "/api/alerts/abc-1", {"id": "abc-1", "severity": "High"})
+        result = await integ.get_alert("abc-1")
+        assert result["id"] == "abc-1"
+        assert mock.calls[0]["path"] == "/api/alerts/abc-1"
+
+
+class TestIsolateMachine:
+    async def test_posts_to_isolate_endpoint(self) -> None:
+        integ = _make()
+        mock = _prep(integ)
+        mock.set_response(
+            "POST", "/api/machines/m-1/isolate", {"id": "act-1", "status": "Pending"}
+        )
+        result = await integ.isolate_machine("m-1", comment="playbook", isolation_type="Full")
+        assert result["id"] == "act-1"
+        call = mock.calls[0]
+        assert call["method"] == "POST"
+        assert call["path"] == "/api/machines/m-1/isolate"
+        assert call["json"]["Comment"] == "playbook"
+        assert call["json"]["IsolationType"] == "Full"
+
+
+class TestUnisolateMachine:
+    async def test_posts_to_unisolate_endpoint(self) -> None:
+        integ = _make()
+        mock = _prep(integ)
+        mock.set_response("POST", "/api/machines/m-2/unisolate", {"id": "act-2"})
+        result = await integ.unisolate_machine("m-2", comment="resolved")
+        assert result["id"] == "act-2"
+        assert mock.calls[0]["path"] == "/api/machines/m-2/unisolate"
+        assert mock.calls[0]["json"]["Comment"] == "resolved"
+
+
+class TestListMachines:
+    async def test_returns_value_array(self) -> None:
+        integ = _make()
+        mock = _prep(integ)
+        mock.set_response(
+            "GET",
+            "/api/machines",
+            {"value": [{"id": "m-1"}, {"id": "m-2"}]},
+        )
+        result = await integ.list_machines()
+        assert len(result) == 2
+        assert result[0]["id"] == "m-1"
+
+    async def test_filter_and_top(self) -> None:
+        integ = _make()
+        mock = _prep(integ)
+        mock.set_response("GET", "/api/machines", {"value": []})
+        await integ.list_machines(odata_filter="riskScore eq 'High'", top=25)
+        params = mock.calls[0]["params"]
+        assert params["$filter"] == "riskScore eq 'High'"
+        assert params["$top"] == 25
+
+
+class TestRunAntivirusScan:
+    async def test_posts_to_run_av_scan(self) -> None:
+        integ = _make()
+        mock = _prep(integ)
+        mock.set_response(
+            "POST", "/api/machines/m-3/runAntiVirusScan", {"id": "act-av-1"}
+        )
+        result = await integ.run_antivirus_scan("m-3", scan_type="Quick", comment="triage")
+        assert result["id"] == "act-av-1"
+        call = mock.calls[0]
+        assert call["method"] == "POST"
+        assert call["path"] == "/api/machines/m-3/runAntiVirusScan"
+        assert call["json"]["ScanType"] == "Quick"
+        assert call["json"]["Comment"] == "triage"
+
+
+class TestListIndicators:
+    async def test_returns_indicator_list(self) -> None:
+        integ = _make()
+        mock = _prep(integ)
+        mock.set_response(
+            "GET",
+            "/api/indicators",
+            {"value": [{"id": "i-1", "indicatorValue": "1.2.3.4"}]},
+        )
+        result = await integ.list_indicators()
+        assert result == [{"id": "i-1", "indicatorValue": "1.2.3.4"}]
+        assert mock.calls[0]["path"] == "/api/indicators"
+
+
+class TestDisconnect:
+    async def test_disconnect_closes_client(self) -> None:
+        integ = _make()
+        mock = _prep(integ)
+        await integ.disconnect()
+        assert mock.closed is True
+
+
+class TestGetActions:
+    def test_exposes_all_methods_as_actions(self) -> None:
+        integ = _make()
+        names = {a.name for a in integ.get_actions()}
+        assert {
+            "list_alerts",
+            "get_alert",
+            "isolate_machine",
+            "unisolate_machine",
+            "list_machines",
+            "run_antivirus_scan",
+            "list_indicators",
+        }.issubset(names)
+
+
+class TestHealthCheck:
+    async def test_healthy_when_alerts_endpoint_200(self) -> None:
+        integ = _make()
+        mock = _prep(integ)
+        mock.set_response("GET", "/api/alerts", {"value": []})
+        result = await integ.health_check()
+        assert result.healthy is True
+
+    async def test_unhealthy_when_not_connected(self) -> None:
+        integ = _make()
+        integ._client = None
+        result = await integ.health_check()
+        assert result.healthy is False
+
+
+# ── Webhook normalizer ──────────────────────────────────────
+
+
+class TestNormalizer:
+    def test_basic_defender_alert(self) -> None:
+        payload = {
+            "id": "da-1",
+            "title": "Suspicious PowerShell",
+            "description": "Encoded command executed",
+            "severity": "High",
+            "status": "New",
+            "computerDnsName": "HOST-01",
+            "machineId": "m-abc",
+            "category": "Execution",
+            "detectionSource": "WindowsDefenderAv",
+        }
+        result = normalize_msdefender_alert(payload)
+        assert result["source"] == "msdefender"
+        assert result["source_id"] == "da-1"
+        assert result["title"] == "Suspicious PowerShell"
+        assert result["severity"] == "high"
+        assert result["hostname"] == "HOST-01"
+        assert result["rule_name"] == "Suspicious PowerShell"
+        assert "Execution" in result.get("tags", [])
+
+    def test_severity_normalized_from_informational(self) -> None:
+        payload = {"id": "x", "title": "Info", "severity": "Informational"}
+        result = normalize_msdefender_alert(payload)
+        assert result["severity"] == "low"
+
+    def test_extracts_iocs_from_evidence(self) -> None:
+        payload = {
+            "id": "da-2",
+            "title": "C2 Beacon",
+            "severity": "Medium",
+            "evidence": [
+                {"entityType": "Ip", "ipAddress": "203.0.113.9"},
+                {"entityType": "File", "sha256": "a" * 64},
+                {"entityType": "Url", "url": "http://evil.example.com/a"},
+            ],
+        }
+        result = normalize_msdefender_alert(payload)
+        iocs = result["iocs"]
+        assert "203.0.113.9" in iocs.get("ips", [])
+        assert ("a" * 64) in iocs.get("hashes", [])
+        # Domain or URL depending on extractor. Accept either.
+        assert (
+            "evil.example.com" in iocs.get("domains", [])
+            or "http://evil.example.com/a" in iocs.get("urls", [])
+        )
+
+    def test_falls_back_on_missing_title(self) -> None:
+        payload = {"id": "x", "severity": "Low"}
+        result = normalize_msdefender_alert(payload)
+        assert result["title"]  # non-empty fallback
+        assert result["source"] == "msdefender"
+
+    def test_handles_alert_wrapper(self) -> None:
+        payload = {
+            "alert": {
+                "id": "nested-1",
+                "title": "Nested alert",
+                "severity": "Critical",
+            }
+        }
+        result = normalize_msdefender_alert(payload)
+        assert result["source_id"] == "nested-1"
+        assert result["severity"] == "critical"


### PR DESCRIPTION
## Summary
- New `src/opensoar/integrations/msdefender/` connector using Azure AD client-credentials OAuth (tenant_id + client_id + client_secret) to reach `api.securitycenter.microsoft.com`.
- Methods: `list_alerts`, `get_alert`, `isolate_machine`, `unisolate_machine`, `list_machines`, `run_antivirus_scan`, `list_indicators`.
- Webhook normalizer at `msdefender/normalize.py` that maps Defender alert payloads onto the OpenSOAR alert schema (severity, hostname, tags, IOCs).
- Registered with `IntegrationLoader.discover_builtin()` for auto-discovery.

## Test plan
- [x] `ruff check src/ tests/` clean
- [x] Unit tests pass: auth token exchange, each of the seven methods, loader discovery, normalizer paths (26 new tests)
- [x] Existing integration loader + normalize tests still pass

Closes #77