### PR TITLE
Add Shodan integration

### DIFF
--- a/src/opensoar/config.py
+++ b/src/opensoar/config.py
@@ -28,6 +28,7 @@ class Settings(BaseSettings):
         return self
     vt_api_key: str | None = None
     abuseipdb_api_key: str | None = None
+    shodan_api_key: str | None = None
     anthropic_api_key: str | None = None
     openai_api_key: str | None = None
     ollama_url: str | None = None
@@ -39,6 +40,7 @@ class Settings(BaseSettings):
     enrichment_cache_ttl_virustotal: int = 24 * 3600
     enrichment_cache_ttl_abuseipdb: int = 12 * 3600
     enrichment_cache_ttl_greynoise: int = 6 * 3600
+    enrichment_cache_ttl_shodan: int = 24 * 3600
 
     @property
     def playbook_directories(self) -> list[str]:

--- a/src/opensoar/integrations/cache.py
+++ b/src/opensoar/integrations/cache.py
@@ -165,6 +165,7 @@ def default_ttl_for(source: str) -> int:
         "virustotal": getattr(settings, "enrichment_cache_ttl_virustotal", 24 * 3600),
         "abuseipdb": getattr(settings, "enrichment_cache_ttl_abuseipdb", 12 * 3600),
         "greynoise": getattr(settings, "enrichment_cache_ttl_greynoise", 6 * 3600),
+        "shodan": getattr(settings, "enrichment_cache_ttl_shodan", 24 * 3600),
     }
     return int(table.get(source, getattr(settings, "enrichment_cache_ttl_default", 3600)))
 

--- a/src/opensoar/integrations/loader.py
+++ b/src/opensoar/integrations/loader.py
@@ -24,6 +24,7 @@ class IntegrationLoader:
             ("elastic", "opensoar.integrations.elastic.connector", "ElasticIntegration"),
             ("virustotal", "opensoar.integrations.virustotal.connector", "VirusTotalIntegration"),
             ("abuseipdb", "opensoar.integrations.abuseipdb.connector", "AbuseIPDBIntegration"),
+            ("shodan", "opensoar.integrations.shodan.connector", "ShodanIntegration"),
             ("slack", "opensoar.integrations.slack.connector", "SlackIntegration"),
             ("email", "opensoar.integrations.email.connector", "EmailIntegration"),
             ("splunk", "opensoar.integrations.splunk.connector", "SplunkIntegration"),

--- a/src/opensoar/integrations/shodan/connector.py
+++ b/src/opensoar/integrations/shodan/connector.py
@@ -1,0 +1,212 @@
+"""Shodan integration (issue #79).
+
+Provides host, search, DNS, and account lookups against the Shodan REST API
+(https://api.shodan.io). Read operations flow through the shared
+``EnrichmentCache`` (issue #67) so repeat lookups skip upstream and respect
+a per-source TTL configured in :mod:`opensoar.config`.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import aiohttp
+
+from opensoar.core.decorators import action
+from opensoar.integrations import cache as _cache_module
+from opensoar.integrations.base import ActionDefinition, HealthCheckResult, IntegrationBase
+
+_SOURCE = "shodan"
+_BASE_URL = "https://api.shodan.io"
+
+
+class ShodanIntegration(IntegrationBase):
+    integration_type = "shodan"
+    display_name = "Shodan"
+    description = "Shodan infrastructure enrichment — host info, search, and DNS lookups"
+
+    def __init__(self, config: dict[str, Any]):
+        self._client: aiohttp.ClientSession | None = None
+        super().__init__(config)
+
+    def _validate_config(self, config: dict[str, Any]) -> None:
+        if "api_key" not in config:
+            raise ValueError("Shodan requires 'api_key' in config")
+
+    async def connect(self) -> None:
+        # Shodan authenticates via the ``key`` query string parameter, not a
+        # header — attaching it once here keeps every method call clean.
+        self._client = aiohttp.ClientSession(
+            base_url=_BASE_URL,
+            headers={"Accept": "application/json"},
+        )
+
+    async def disconnect(self) -> None:
+        if self._client:
+            await self._client.close()
+            self._client = None
+
+    async def health_check(self) -> HealthCheckResult:
+        if not self._client:
+            return HealthCheckResult(healthy=False, message="Not connected")
+
+        try:
+            async with self._client.get("/api-info", params=self._auth_params()) as resp:
+                if resp.status == 200:
+                    return HealthCheckResult(healthy=True, message="OK")
+                return HealthCheckResult(healthy=False, message=f"HTTP {resp.status}")
+        except Exception as e:
+            return HealthCheckResult(healthy=False, message=str(e))
+
+    def get_actions(self) -> list[ActionDefinition]:
+        return [
+            ActionDefinition(
+                name="host_info",
+                description="Get Shodan host record for an IP",
+                parameters={"ip": {"type": "string"}},
+            ),
+            ActionDefinition(
+                name="search",
+                description="Run a Shodan search query",
+                parameters={"query": {"type": "string"}},
+            ),
+            ActionDefinition(
+                name="dns_resolve",
+                description="Resolve a hostname to an IP via Shodan DNS",
+                parameters={"domain": {"type": "string"}},
+            ),
+            ActionDefinition(
+                name="dns_reverse",
+                description="Reverse-resolve an IP to hostnames via Shodan DNS",
+                parameters={"ip": {"type": "string"}},
+            ),
+            ActionDefinition(
+                name="account_profile",
+                description="Fetch the authenticated account profile",
+            ),
+            ActionDefinition(
+                name="api_info",
+                description="Fetch API plan and quota information",
+            ),
+        ]
+
+    # ── Public enrichment methods ──────────────────────────────────
+
+    async def host_info(self, ip: str) -> dict:
+        self._require_connected()
+        return await self._cached_get(
+            obs_type="ip",
+            cache_value=ip,
+            path=f"/shodan/host/{ip}",
+        )
+
+    async def search(self, query: str) -> dict:
+        self._require_connected()
+        return await self._cached_get(
+            obs_type="search",
+            cache_value=query,
+            path="/shodan/host/search",
+            extra_params={"query": query},
+        )
+
+    async def dns_resolve(self, domain: str) -> dict:
+        self._require_connected()
+        return await self._cached_get(
+            obs_type="domain",
+            cache_value=domain,
+            path="/dns/resolve",
+            extra_params={"hostnames": domain},
+        )
+
+    async def dns_reverse(self, ip: str) -> dict:
+        self._require_connected()
+        return await self._cached_get(
+            obs_type="ip_reverse",
+            cache_value=ip,
+            path="/dns/reverse",
+            extra_params={"ips": ip},
+        )
+
+    async def account_profile(self) -> dict:
+        self._require_connected()
+        async with self._client.get(  # type: ignore[union-attr]
+            "/account/profile", params=self._auth_params()
+        ) as resp:
+            return await resp.json()
+
+    async def api_info(self) -> dict:
+        self._require_connected()
+        async with self._client.get(  # type: ignore[union-attr]
+            "/api-info", params=self._auth_params()
+        ) as resp:
+            return await resp.json()
+
+    # ── Internal helpers ───────────────────────────────────────────
+
+    def _require_connected(self) -> None:
+        if not self._client:
+            raise RuntimeError("Not connected")
+
+    def _auth_params(self, extra: dict[str, str] | None = None) -> dict[str, str]:
+        params = {"key": self._config["api_key"]}
+        if extra:
+            params.update(extra)
+        return params
+
+    async def _cached_get(
+        self,
+        *,
+        obs_type: str,
+        cache_value: str,
+        path: str,
+        extra_params: dict[str, str] | None = None,
+    ) -> dict:
+        async def _fetch() -> dict:
+            async with self._client.get(  # type: ignore[union-attr]
+                path, params=self._auth_params(extra_params)
+            ) as resp:
+                return await resp.json()
+
+        return await _cache_module.get_default_cache().get_or_fetch(
+            source=_SOURCE,
+            obs_type=obs_type,
+            value=cache_value,
+            fetcher=_fetch,
+            ttl_seconds=_cache_module.default_ttl_for(_SOURCE),
+        )
+
+
+# ── Playbook-exposed action stubs ──────────────────────────────────
+# These mirror the VirusTotal / AbuseIPDB pattern — they provide default
+# no-op behavior for playbooks when the integration isn't configured.
+
+
+@action(name="shodan.host_info", timeout=30, retries=2, retry_backoff=2.0)
+async def host_info(ip: str) -> dict:
+    """Look up an IP on Shodan."""
+    return {"ip": ip, "source": "shodan", "note": "Configure Shodan integration for live lookups"}
+
+
+@action(name="shodan.search", timeout=30, retries=2, retry_backoff=2.0)
+async def search(query: str) -> dict:
+    """Run a Shodan search query."""
+    return {
+        "query": query,
+        "source": "shodan",
+        "note": "Configure Shodan integration for live lookups",
+    }
+
+
+@action(name="shodan.dns_resolve", timeout=30, retries=2, retry_backoff=2.0)
+async def dns_resolve(domain: str) -> dict:
+    """Resolve a domain via Shodan DNS."""
+    return {
+        "domain": domain,
+        "source": "shodan",
+        "note": "Configure Shodan integration for live lookups",
+    }
+
+
+@action(name="shodan.dns_reverse", timeout=30, retries=2, retry_backoff=2.0)
+async def dns_reverse(ip: str) -> dict:
+    """Reverse-resolve an IP via Shodan DNS."""
+    return {"ip": ip, "source": "shodan", "note": "Configure Shodan integration for live lookups"}

--- a/tests/test_shodan_integration.py
+++ b/tests/test_shodan_integration.py
@@ -1,0 +1,259 @@
+"""Tests for the Shodan integration (issue #79).
+
+Covers connector construction, action surface, HTTP method wiring against a
+mocked aiohttp client, and cache behavior (hit/miss/expiry) via the shared
+``EnrichmentCache`` from issue #67.
+"""
+from __future__ import annotations
+
+import pytest
+
+from opensoar.integrations import cache as cache_module
+from opensoar.integrations.base import HealthCheckResult
+from opensoar.integrations.cache import EnrichmentCache, InMemoryCacheBackend
+from opensoar.integrations.shodan.connector import ShodanIntegration
+
+
+class _MockResp:
+    def __init__(self, payload, status: int = 200):
+        self._payload = payload
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return None
+
+    async def json(self):
+        return self._payload
+
+
+class _MockClient:
+    """Collects (path, params) calls and returns canned payloads per path."""
+
+    def __init__(self, responses: dict[str, object]):
+        self._responses = responses
+        self.calls: list[tuple[str, dict | None]] = []
+
+    def get(self, path: str, params=None):
+        self.calls.append((path, params))
+        resp = self._responses.get(path, self._responses.get("*", {}))
+        if isinstance(resp, tuple):
+            payload, status = resp
+            return _MockResp(payload, status=status)
+        return _MockResp(resp)
+
+
+@pytest.fixture
+def fresh_cache(monkeypatch):
+    """Swap the module-level cache for an isolated in-memory one per test."""
+    backend = InMemoryCacheBackend()
+    cache = EnrichmentCache(backend=backend)
+    monkeypatch.setattr(cache_module, "get_default_cache", lambda: cache)
+    return cache, backend
+
+
+class TestShodanConstruction:
+    def test_requires_api_key(self):
+        with pytest.raises(ValueError):
+            ShodanIntegration({})
+
+    def test_integration_metadata(self):
+        integ = ShodanIntegration({"api_key": "k"})
+        assert integ.integration_type == "shodan"
+        assert integ.display_name == "Shodan"
+        assert "shodan" in integ.description.lower() or "infrastructure" in integ.description.lower()
+
+    def test_actions_surface_covers_required_methods(self):
+        integ = ShodanIntegration({"api_key": "k"})
+        names = {a.name for a in integ.get_actions()}
+        assert {
+            "host_info",
+            "search",
+            "dns_resolve",
+            "dns_reverse",
+            "account_profile",
+            "api_info",
+        }.issubset(names)
+
+
+class TestShodanHealthCheck:
+    async def test_not_connected(self):
+        integ = ShodanIntegration({"api_key": "k"})
+        result = await integ.health_check()
+        assert isinstance(result, HealthCheckResult)
+        assert result.healthy is False
+
+    async def test_ok_when_api_info_returns_200(self):
+        integ = ShodanIntegration({"api_key": "k"})
+        integ._client = _MockClient({"/api-info": {"plan": "dev"}})
+        result = await integ.health_check()
+        assert result.healthy is True
+
+    async def test_unhealthy_on_non_200(self):
+        integ = ShodanIntegration({"api_key": "k"})
+
+        class _Fail:
+            def get(self, path, params=None):
+                return _MockResp({"error": "unauthorized"}, status=401)
+
+        integ._client = _Fail()
+        result = await integ.health_check()
+        assert result.healthy is False
+        assert "401" in result.message
+
+
+class TestShodanHostInfo:
+    async def test_host_info_hits_correct_path_and_returns_payload(self, fresh_cache):
+        integ = ShodanIntegration({"api_key": "k"})
+        mock = _MockClient({"/shodan/host/1.2.3.4": {"ip_str": "1.2.3.4", "ports": [22, 80]}})
+        integ._client = mock
+
+        result = await integ.host_info("1.2.3.4")
+
+        assert result["ip_str"] == "1.2.3.4"
+        assert 22 in result["ports"]
+        assert mock.calls[0][0] == "/shodan/host/1.2.3.4"
+
+    async def test_host_info_cache_hit_skips_upstream(self, fresh_cache):
+        integ = ShodanIntegration({"api_key": "k"})
+        mock = _MockClient({"/shodan/host/1.2.3.4": {"ip_str": "1.2.3.4"}})
+        integ._client = mock
+
+        first = await integ.host_info("1.2.3.4")
+        second = await integ.host_info("1.2.3.4")
+
+        assert first == second
+        assert len(mock.calls) == 1  # second served from cache
+
+    async def test_host_info_cache_miss_after_expiry(self, fresh_cache):
+        _, backend = fresh_cache
+        integ = ShodanIntegration({"api_key": "k"})
+        mock = _MockClient({"/shodan/host/1.2.3.4": {"ip_str": "1.2.3.4"}})
+        integ._client = mock
+
+        await integ.host_info("1.2.3.4")
+        # Jump past any reasonable TTL.
+        backend._fast_forward(48 * 3600)
+        await integ.host_info("1.2.3.4")
+
+        assert len(mock.calls) == 2
+
+
+class TestShodanSearch:
+    async def test_search_passes_query_param(self, fresh_cache):
+        integ = ShodanIntegration({"api_key": "k"})
+        mock = _MockClient({"/shodan/host/search": {"matches": [{"ip_str": "9.9.9.9"}]}})
+        integ._client = mock
+
+        result = await integ.search("apache port:80")
+
+        assert result["matches"][0]["ip_str"] == "9.9.9.9"
+        path, params = mock.calls[0]
+        assert path == "/shodan/host/search"
+        assert params is not None
+        assert params.get("query") == "apache port:80"
+
+    async def test_search_is_cached_per_query(self, fresh_cache):
+        integ = ShodanIntegration({"api_key": "k"})
+        mock = _MockClient({"/shodan/host/search": {"matches": []}})
+        integ._client = mock
+
+        await integ.search("apache")
+        await integ.search("apache")
+        await integ.search("nginx")
+
+        # apache repeats → 1 upstream call for "apache" + 1 for "nginx"
+        assert len(mock.calls) == 2
+
+
+class TestShodanDNS:
+    async def test_dns_resolve_serializes_hostnames(self, fresh_cache):
+        integ = ShodanIntegration({"api_key": "k"})
+        mock = _MockClient({"/dns/resolve": {"example.com": "93.184.216.34"}})
+        integ._client = mock
+
+        result = await integ.dns_resolve("example.com")
+
+        assert result["example.com"] == "93.184.216.34"
+        path, params = mock.calls[0]
+        assert path == "/dns/resolve"
+        assert params is not None
+        assert params.get("hostnames") == "example.com"
+
+    async def test_dns_reverse_serializes_ips(self, fresh_cache):
+        integ = ShodanIntegration({"api_key": "k"})
+        mock = _MockClient({"/dns/reverse": {"8.8.8.8": ["dns.google"]}})
+        integ._client = mock
+
+        result = await integ.dns_reverse("8.8.8.8")
+
+        assert result["8.8.8.8"] == ["dns.google"]
+        path, params = mock.calls[0]
+        assert path == "/dns/reverse"
+        assert params is not None
+        assert params.get("ips") == "8.8.8.8"
+
+    async def test_dns_resolve_cache_hit(self, fresh_cache):
+        integ = ShodanIntegration({"api_key": "k"})
+        mock = _MockClient({"/dns/resolve": {"example.com": "93.184.216.34"}})
+        integ._client = mock
+
+        await integ.dns_resolve("example.com")
+        await integ.dns_resolve("example.com")
+
+        assert len(mock.calls) == 1
+
+
+class TestShodanAccountEndpoints:
+    async def test_account_profile(self, fresh_cache):
+        integ = ShodanIntegration({"api_key": "k"})
+        mock = _MockClient({"/account/profile": {"member": True}})
+        integ._client = mock
+
+        result = await integ.account_profile()
+
+        assert result["member"] is True
+        assert mock.calls[0][0] == "/account/profile"
+
+    async def test_api_info(self, fresh_cache):
+        integ = ShodanIntegration({"api_key": "k"})
+        mock = _MockClient({"/api-info": {"plan": "dev", "query_credits": 100}})
+        integ._client = mock
+
+        result = await integ.api_info()
+
+        assert result["plan"] == "dev"
+        assert mock.calls[0][0] == "/api-info"
+
+
+class TestShodanErrors:
+    async def test_host_info_without_connect_raises(self, fresh_cache):
+        integ = ShodanIntegration({"api_key": "k"})
+        with pytest.raises(RuntimeError):
+            await integ.host_info("1.2.3.4")
+
+    async def test_search_without_connect_raises(self, fresh_cache):
+        integ = ShodanIntegration({"api_key": "k"})
+        with pytest.raises(RuntimeError):
+            await integ.search("anything")
+
+
+class TestShodanCacheConfig:
+    def test_default_ttl_24_hours(self):
+        from opensoar.integrations.cache import default_ttl_for
+
+        assert default_ttl_for("shodan") == 24 * 3600
+
+
+class TestShodanLoaderDiscovery:
+    def test_loader_discovers_shodan(self):
+        from opensoar.integrations.loader import IntegrationLoader
+
+        loader = IntegrationLoader()
+        loader.discover_builtin()
+        assert "shodan" in loader.available_types()
+        cls = loader.get_connector("shodan")
+        assert cls is not None
+        assert cls.integration_type == "shodan"


### PR DESCRIPTION
## Summary
- New `src/opensoar/integrations/shodan/` connector with API-key auth
- Methods: `host_info`, `search`, `dns_resolve`, `dns_reverse`, `account_profile`, `api_info`
- Cache-aware via the shared `EnrichmentCache` from #67 with a 24h default TTL (configurable via `enrichment_cache_ttl_shodan`)
- Registered in `IntegrationLoader` so discovery picks it up alongside VirusTotal/AbuseIPDB

## Test plan
- [x] 20 new tests in `tests/test_shodan_integration.py` covering construction, action surface, HTTP wiring, health check, cache hit/miss/expiry, DNS, and loader discovery
- [x] `ruff check src/ tests/` clean
- [x] Pre-existing unit suites still green (`test_enrichment_cache`, `test_integration_loader`, normalize/decorators/triggers/scheduler)

Closes #79