### PR TITLE
Wire AI provider env and kind install smoke into Helm chart

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,69 @@ jobs:
           grep -q 'helm.sh/hook.*pre-install,pre-upgrade' /tmp/opensoar-helm.yaml
           grep -q 'name: API_KEY_SECRET' /tmp/opensoar-helm.yaml
           grep -q 'name: PLAYBOOK_DIRS' /tmp/opensoar-helm.yaml
+          grep -q 'name: ANTHROPIC_API_KEY' /tmp/opensoar-helm.yaml
+          grep -q 'name: OPENAI_API_KEY' /tmp/opensoar-helm.yaml
+          grep -q 'name: OLLAMA_URL' /tmp/opensoar-helm.yaml
           grep -q 'app.kubernetes.io/component: worker' /tmp/opensoar-helm.yaml
+
+      - name: Run chart template assertions script
+        run: bash scripts/test-helm.sh
+
+  helm-install-smoke:
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: opensoar-helm
+
+      - name: Build deploy images into the kind cluster
+        run: |
+          docker build . --target api -t ghcr.io/opensoar-hq/opensoar-core-api:ci
+          docker build . --target worker -t ghcr.io/opensoar-hq/opensoar-core-worker:ci
+          docker build . --target migrate -t ghcr.io/opensoar-hq/opensoar-core-migrate:ci
+          docker build . --target ui -t ghcr.io/opensoar-hq/opensoar-core-ui:ci
+          kind load docker-image ghcr.io/opensoar-hq/opensoar-core-api:ci --name opensoar-helm
+          kind load docker-image ghcr.io/opensoar-hq/opensoar-core-worker:ci --name opensoar-helm
+          kind load docker-image ghcr.io/opensoar-hq/opensoar-core-migrate:ci --name opensoar-helm
+          kind load docker-image ghcr.io/opensoar-hq/opensoar-core-ui:ci --name opensoar-helm
+
+      - name: helm install against kind
+        run: |
+          helm install opensoar ./helm/opensoar \
+            --namespace opensoar --create-namespace \
+            --set images.api.tag=ci \
+            --set images.worker.tag=ci \
+            --set images.migrate.tag=ci \
+            --set images.ui.tag=ci \
+            --set images.api.pullPolicy=IfNotPresent \
+            --set images.worker.pullPolicy=IfNotPresent \
+            --set images.migrate.pullPolicy=IfNotPresent \
+            --set images.ui.pullPolicy=IfNotPresent \
+            --set secrets.jwtSecret=ci-jwt-secret-which-is-long-enough-for-hs256 \
+            --set secrets.apiKeySecret=ci-api-key-secret \
+            --set postgres.persistence.size=1Gi \
+            --wait --timeout 6m
+
+      - name: Confirm api rolled out (migrate ran as pre-install hook)
+        run: |
+          kubectl -n opensoar get pods
+          kubectl -n opensoar rollout status deployment/api --timeout=180s
+          kubectl -n opensoar rollout status deployment/worker --timeout=180s
+          kubectl -n opensoar rollout status deployment/ui --timeout=180s
+
+      - name: Dump state on failure
+        if: failure()
+        run: |
+          kubectl -n opensoar get all
+          kubectl -n opensoar describe pods
+          kubectl -n opensoar logs -l app.kubernetes.io/component=migrate --tail=200 || true
+          kubectl -n opensoar logs -l app.kubernetes.io/component=api --tail=200 || true
+          kubectl -n opensoar logs -l app.kubernetes.io/component=worker --tail=200 || true
 
   ui-test:
     runs-on: ubuntu-latest
@@ -235,7 +297,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [test, ui-test, compose-upgrade-smoke, deploy-install-smoke, helm-packaging-smoke]
+    needs: [test, ui-test, compose-upgrade-smoke, deploy-install-smoke, helm-packaging-smoke, helm-install-smoke]
     if: github.event_name == 'push'
     permissions:
       contents: read

--- a/helm/opensoar/Chart.yaml
+++ b/helm/opensoar/Chart.yaml
@@ -4,3 +4,14 @@ description: Helm chart for self-hosted OpenSOAR deployments
 type: application
 version: 0.1.0
 appVersion: "latest"
+home: https://github.com/opensoar-hq/opensoar-core
+sources:
+  - https://github.com/opensoar-hq/opensoar-core
+keywords:
+  - soar
+  - security
+  - automation
+  - incident-response
+maintainers:
+  - name: OpenSOAR
+    url: https://github.com/opensoar-hq

--- a/helm/opensoar/templates/NOTES.txt
+++ b/helm/opensoar/templates/NOTES.txt
@@ -1,11 +1,29 @@
-OpenSOAR has been installed.
+OpenSOAR has been installed as release {{ .Release.Name }} in namespace {{ .Release.Namespace }}.
 
-The chart currently assumes a single release per namespace because the UI image proxies /api requests to the in-cluster Service named "api".
+The chart currently assumes a single release per namespace because the UI image
+proxies /api requests to the in-cluster Service named "api".
 
-To access the UI locally:
+1. Check that the migrate Job and all Deployments rolled out:
 
-  kubectl port-forward svc/ui 3000:{{ .Values.ui.service.port }}
+     kubectl -n {{ .Release.Namespace }} get all
 
-Then open:
+2. Reach the UI from your workstation via port-forward:
 
-  http://127.0.0.1:3000
+     kubectl -n {{ .Release.Namespace }} port-forward svc/ui 3000:{{ .Values.ui.service.port }}
+
+   then open http://127.0.0.1:3000
+{{- if .Values.ui.ingress.enabled }}
+
+   The UI Ingress is enabled on host {{ .Values.ui.ingress.host }} (class "{{ .Values.ui.ingress.className }}").
+{{- end }}
+
+3. Turn on AI features by populating the corresponding secrets in values.yaml
+   or on the CLI (they are optional — pods start without them):
+
+     --set secrets.anthropicApiKey=<your-anthropic-key>
+     --set secrets.openaiApiKey=<your-openai-key>
+     --set secrets.ollamaUrl=http://ollama.ollama.svc.cluster.local:11434
+
+4. Swap out the default Postgres / Redis bundles by setting
+   `postgres.enabled=false` / `redis.enabled=false` and supplying your own
+   DATABASE_URL / REDIS_URL via a pre-created `opensoar-secrets` Secret.

--- a/helm/opensoar/templates/_helpers.tpl
+++ b/helm/opensoar/templates/_helpers.tpl
@@ -4,3 +4,56 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 {{- end -}}
+
+{{/*
+Common environment variables shared between the api and worker pods.
+AI provider credentials are marked optional so pods still start when the
+operator hasn't populated them. Set them via `secrets.anthropicApiKey`,
+`secrets.openaiApiKey`, or `secrets.ollamaUrl` in values.yaml (or with
+`--set-string` / `--values`).
+*/}}
+{{- define "opensoar.commonEnv" -}}
+- name: DATABASE_URL
+  valueFrom:
+    secretKeyRef:
+      name: opensoar-secrets
+      key: database-url
+- name: REDIS_URL
+  valueFrom:
+    secretKeyRef:
+      name: opensoar-secrets
+      key: redis-url
+- name: CELERY_BROKER_URL
+  valueFrom:
+    secretKeyRef:
+      name: opensoar-secrets
+      key: celery-broker-url
+- name: JWT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: opensoar-secrets
+      key: jwt-secret
+- name: API_KEY_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: opensoar-secrets
+      key: api-key-secret
+- name: ANTHROPIC_API_KEY
+  valueFrom:
+    secretKeyRef:
+      name: opensoar-secrets
+      key: anthropic-api-key
+      optional: true
+- name: OPENAI_API_KEY
+  valueFrom:
+    secretKeyRef:
+      name: opensoar-secrets
+      key: openai-api-key
+      optional: true
+- name: OLLAMA_URL
+  valueFrom:
+    secretKeyRef:
+      name: opensoar-secrets
+      key: ollama-url
+      optional: true
+{{- end -}}

--- a/helm/opensoar/templates/api.yaml
+++ b/helm/opensoar/templates/api.yaml
@@ -36,31 +36,7 @@ spec:
           image: "{{ .Values.images.api.repository }}:{{ .Values.images.api.tag }}"
           imagePullPolicy: {{ .Values.images.api.pullPolicy }}
           env:
-            - name: DATABASE_URL
-              valueFrom:
-                secretKeyRef:
-                  name: opensoar-secrets
-                  key: database-url
-            - name: REDIS_URL
-              valueFrom:
-                secretKeyRef:
-                  name: opensoar-secrets
-                  key: redis-url
-            - name: CELERY_BROKER_URL
-              valueFrom:
-                secretKeyRef:
-                  name: opensoar-secrets
-                  key: celery-broker-url
-            - name: JWT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: opensoar-secrets
-                  key: jwt-secret
-            - name: API_KEY_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: opensoar-secrets
-                  key: api-key-secret
+{{ include "opensoar.commonEnv" . | indent 12 }}
             - name: PLAYBOOK_DIRS
               value: {{ .Values.api.playbookDirs | quote }}
 {{- if .Values.api.extraEnv }}

--- a/helm/opensoar/templates/migrate-job.yaml
+++ b/helm/opensoar/templates/migrate-job.yaml
@@ -6,7 +6,12 @@ metadata:
 {{ include "opensoar.labels" . | indent 4 }}
     app.kubernetes.io/component: migrate
   annotations:
+    # Runs before api/worker/ui on both install and upgrade. Paired with a
+    # wait-for-postgres initContainer so the Job tolerates a subchart Postgres
+    # that is still starting up as well as an external Postgres that may be
+    # temporarily unreachable.
     "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "10"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 3
@@ -17,6 +22,36 @@ spec:
         app.kubernetes.io/component: migrate
     spec:
       restartPolicy: OnFailure
+      initContainers:
+        - name: wait-for-postgres
+          image: "{{ .Values.images.migrate.repository }}:{{ .Values.images.migrate.tag }}"
+          imagePullPolicy: {{ .Values.images.migrate.pullPolicy }}
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: opensoar-secrets
+                  key: database-url
+          command:
+            - python
+            - -c
+            - |
+              import os, socket, sys, time
+              from urllib.parse import urlparse
+              url = urlparse(os.environ["DATABASE_URL"].replace("postgresql+asyncpg", "postgresql"))
+              host = url.hostname or "postgres"
+              port = url.port or 5432
+              deadline = time.time() + 300
+              while time.time() < deadline:
+                  try:
+                      with socket.create_connection((host, port), timeout=3):
+                          print(f"postgres reachable at {host}:{port}")
+                          sys.exit(0)
+                  except OSError as exc:
+                      print(f"waiting for postgres at {host}:{port}: {exc}", flush=True)
+                      time.sleep(3)
+              print("timed out waiting for postgres")
+              sys.exit(1)
       containers:
         - name: migrate
           image: "{{ .Values.images.migrate.repository }}:{{ .Values.images.migrate.tag }}"

--- a/helm/opensoar/templates/postgres.yaml
+++ b/helm/opensoar/templates/postgres.yaml
@@ -5,6 +5,12 @@ metadata:
   name: postgres
   labels:
 {{ include "opensoar.labels" . | indent 4 }}
+  annotations:
+    # Provisioned ahead of the migrate Job so alembic has a database to connect
+    # to. Only hooked on pre-install — upgrades leave the running Postgres
+    # resources untouched so data survives chart upgrades.
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
 spec:
   ports:
     - name: postgres
@@ -20,6 +26,9 @@ metadata:
   labels:
 {{ include "opensoar.labels" . | indent 4 }}
     app.kubernetes.io/component: postgres
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
 spec:
   serviceName: postgres
   replicas: 1

--- a/helm/opensoar/templates/secret.yaml
+++ b/helm/opensoar/templates/secret.yaml
@@ -12,3 +12,12 @@ data:
   database-url: {{ printf "postgresql+asyncpg://opensoar:%s@postgres:5432/opensoar" .Values.secrets.postgresPassword | b64enc | quote }}
   redis-url: {{ printf "redis://redis:%d/0" (int .Values.redis.service.port) | b64enc | quote }}
   celery-broker-url: {{ printf "redis://redis:%d/1" (int .Values.redis.service.port) | b64enc | quote }}
+  {{- if .Values.secrets.anthropicApiKey }}
+  anthropic-api-key: {{ .Values.secrets.anthropicApiKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.openaiApiKey }}
+  openai-api-key: {{ .Values.secrets.openaiApiKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.ollamaUrl }}
+  ollama-url: {{ .Values.secrets.ollamaUrl | b64enc | quote }}
+  {{- end }}

--- a/helm/opensoar/templates/secret.yaml
+++ b/helm/opensoar/templates/secret.yaml
@@ -4,6 +4,13 @@ metadata:
   name: opensoar-secrets
   labels:
 {{ include "opensoar.labels" . | indent 4 }}
+  annotations:
+    # Install the Secret ahead of the migrate Job so its `secretKeyRef`s
+    # resolve. On upgrade the Secret is re-applied via pre-upgrade hook so
+    # any rotated values are available when migrations run.
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
 type: Opaque
 data:
   postgres-password: {{ .Values.secrets.postgresPassword | b64enc | quote }}

--- a/helm/opensoar/templates/worker.yaml
+++ b/helm/opensoar/templates/worker.yaml
@@ -26,33 +26,9 @@ spec:
             - opensoar.worker.celery_app
             - worker
             - --loglevel=info
-            - --concurrency={{ .Values.worker.concurrency | quote }}
+            - --concurrency={{ .Values.worker.concurrency }}
           env:
-            - name: DATABASE_URL
-              valueFrom:
-                secretKeyRef:
-                  name: opensoar-secrets
-                  key: database-url
-            - name: REDIS_URL
-              valueFrom:
-                secretKeyRef:
-                  name: opensoar-secrets
-                  key: redis-url
-            - name: CELERY_BROKER_URL
-              valueFrom:
-                secretKeyRef:
-                  name: opensoar-secrets
-                  key: celery-broker-url
-            - name: JWT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: opensoar-secrets
-                  key: jwt-secret
-            - name: API_KEY_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: opensoar-secrets
-                  key: api-key-secret
+{{ include "opensoar.commonEnv" . | indent 12 }}
             - name: PLAYBOOK_DIRS
               value: {{ .Values.worker.playbookDirs | quote }}
 {{- if .Values.worker.extraEnv }}

--- a/helm/opensoar/values.yaml
+++ b/helm/opensoar/values.yaml
@@ -24,10 +24,18 @@ images:
     tag: "7-alpine"
     pullPolicy: IfNotPresent
 
+# Secrets rendered into a single Opaque Secret named `opensoar-secrets`.
+# Swap to your secret manager (SOPS, External Secrets, Sealed Secrets, etc.)
+# for production — these defaults are only safe for local/dev clusters.
 secrets:
   postgresPassword: opensoar
   jwtSecret: change-me
   apiKeySecret: change-me
+  # AI provider credentials. Leave empty strings to skip injection; only keys
+  # with non-empty values are mounted into the api and worker pods.
+  anthropicApiKey: ""
+  openaiApiKey: ""
+  ollamaUrl: ""
 
 api:
   replicaCount: 1

--- a/scripts/test-helm.sh
+++ b/scripts/test-helm.sh
@@ -78,6 +78,33 @@ assert_contains "$DEFAULT" 'name: redis' "redis rendered when enabled"
 # Ingress defaults to disabled.
 assert_not_contains "$DEFAULT" 'kind: Ingress' "ingress disabled by default"
 
+section "pre-install hook ordering"
+# Secret must install before the migrate Job so the Job's secretKeyRefs resolve.
+if grep -F '"helm.sh/hook-weight": "-10"' "$DEFAULT" > /dev/null; then
+  pass "secret annotated as pre-install hook with weight -10"
+else
+  fail "secret missing pre-install hook annotation"
+fi
+# Postgres (Service + StatefulSet) must install before the migrate Job.
+if [ "$(grep -cF '"helm.sh/hook-weight": "-5"' "$DEFAULT")" -ge 2 ]; then
+  pass "postgres Service + StatefulSet annotated as pre-install hooks with weight -5"
+else
+  fail "postgres missing pre-install hook annotations"
+fi
+# Migrate Job runs last in the hook chain.
+if grep -F '"helm.sh/hook-weight": "10"' "$DEFAULT" > /dev/null; then
+  pass "migrate Job annotated with positive hook weight"
+else
+  fail "migrate Job missing positive hook weight"
+fi
+# Migrate Job has a wait-for-postgres initContainer so pre-install tolerates
+# a subchart Postgres that is still coming up.
+if grep -q 'name: wait-for-postgres' "$DEFAULT"; then
+  pass "migrate Job waits for postgres via initContainer"
+else
+  fail "migrate Job missing wait-for-postgres initContainer"
+fi
+
 section "subcharts disabled"
 EXTERN="$TMPDIR/external.yaml"
 helm template opensoar "$CHART_DIR" \

--- a/scripts/test-helm.sh
+++ b/scripts/test-helm.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Helm chart validation tests for the OpenSOAR chart.
+#
+# Runs `helm lint` plus a series of `helm template` assertions to confirm that
+# the chart renders the expected Kubernetes manifests with and without the
+# optional postgres/redis subcharts, with ingress toggled on/off, with AI
+# provider secrets, and with alternative image tags.
+#
+# Usage: bash scripts/test-helm.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHART_DIR="$REPO_ROOT/helm/opensoar"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); echo "  ok  $*"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL $*" >&2; }
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+  local label="$3"
+  if grep -qE "$pattern" "$file"; then
+    pass "$label"
+  else
+    fail "$label (pattern not found: $pattern)"
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local pattern="$2"
+  local label="$3"
+  if grep -qE "$pattern" "$file"; then
+    fail "$label (pattern unexpectedly present: $pattern)"
+  else
+    pass "$label"
+  fi
+}
+
+section() {
+  echo
+  echo "== $* =="
+}
+
+section "helm lint"
+helm lint "$CHART_DIR"
+pass "chart lints clean"
+
+section "default render"
+DEFAULT="$TMPDIR/default.yaml"
+helm template opensoar "$CHART_DIR" > "$DEFAULT"
+assert_contains "$DEFAULT" 'kind: Deployment' "renders Deployment resources"
+assert_contains "$DEFAULT" 'kind: Service' "renders Service resources"
+assert_contains "$DEFAULT" 'kind: Job' "renders migrate Job"
+assert_contains "$DEFAULT" 'helm.sh/hook.*pre-install,pre-upgrade' "migrate Job uses pre-install/pre-upgrade hook"
+assert_contains "$DEFAULT" 'app.kubernetes.io/component: api' "api component labeled"
+assert_contains "$DEFAULT" 'app.kubernetes.io/component: worker' "worker component labeled"
+assert_contains "$DEFAULT" 'app.kubernetes.io/component: ui' "ui component labeled"
+assert_contains "$DEFAULT" 'app.kubernetes.io/component: migrate' "migrate component labeled"
+assert_contains "$DEFAULT" 'name: JWT_SECRET' "api env includes JWT_SECRET"
+assert_contains "$DEFAULT" 'name: API_KEY_SECRET' "api env includes API_KEY_SECRET"
+assert_contains "$DEFAULT" 'name: DATABASE_URL' "api env includes DATABASE_URL"
+assert_contains "$DEFAULT" 'name: REDIS_URL' "api env includes REDIS_URL"
+assert_contains "$DEFAULT" 'name: PLAYBOOK_DIRS' "api env includes PLAYBOOK_DIRS"
+assert_contains "$DEFAULT" 'name: ANTHROPIC_API_KEY' "api env includes ANTHROPIC_API_KEY"
+assert_contains "$DEFAULT" 'name: OPENAI_API_KEY' "api env includes OPENAI_API_KEY"
+assert_contains "$DEFAULT" 'name: OLLAMA_URL' "api env includes OLLAMA_URL"
+# Postgres + Redis subcharts default to enabled.
+assert_contains "$DEFAULT" 'name: postgres' "postgres rendered when enabled"
+assert_contains "$DEFAULT" 'name: redis' "redis rendered when enabled"
+# Ingress defaults to disabled.
+assert_not_contains "$DEFAULT" 'kind: Ingress' "ingress disabled by default"
+
+section "subcharts disabled"
+EXTERN="$TMPDIR/external.yaml"
+helm template opensoar "$CHART_DIR" \
+  --set postgres.enabled=false \
+  --set redis.enabled=false \
+  > "$EXTERN"
+assert_not_contains "$EXTERN" 'kind: StatefulSet' "postgres StatefulSet omitted when disabled"
+assert_not_contains "$EXTERN" 'app.kubernetes.io/component: postgres' "postgres labels omitted when disabled"
+assert_not_contains "$EXTERN" 'app.kubernetes.io/component: redis' "redis labels omitted when disabled"
+# Core app resources still render.
+assert_contains "$EXTERN" 'app.kubernetes.io/component: api' "api still rendered when subcharts disabled"
+assert_contains "$EXTERN" 'app.kubernetes.io/component: worker' "worker still rendered when subcharts disabled"
+
+section "ingress enabled + host override"
+INGRESS="$TMPDIR/ingress.yaml"
+helm template opensoar "$CHART_DIR" \
+  --set ui.ingress.enabled=true \
+  --set ui.ingress.host=soar.example.com \
+  --set ui.ingress.className=nginx \
+  > "$INGRESS"
+assert_contains "$INGRESS" 'kind: Ingress' "ingress rendered when enabled"
+assert_contains "$INGRESS" 'host: soar.example.com' "ingress host override honoured"
+assert_contains "$INGRESS" 'ingressClassName: nginx' "ingress className override honoured"
+
+section "image tag override"
+IMAGES="$TMPDIR/images.yaml"
+helm template opensoar "$CHART_DIR" \
+  --set images.api.tag=v9.9.9 \
+  --set images.worker.tag=v9.9.9 \
+  --set images.migrate.tag=v9.9.9 \
+  --set images.ui.tag=v9.9.9 \
+  > "$IMAGES"
+assert_contains "$IMAGES" 'opensoar-core-api:v9.9.9' "api image tag override honoured"
+assert_contains "$IMAGES" 'opensoar-core-worker:v9.9.9' "worker image tag override honoured"
+assert_contains "$IMAGES" 'opensoar-core-migrate:v9.9.9' "migrate image tag override honoured"
+assert_contains "$IMAGES" 'opensoar-core-ui:v9.9.9' "ui image tag override honoured"
+
+section "AI provider secrets populated"
+AI="$TMPDIR/ai.yaml"
+helm template opensoar "$CHART_DIR" \
+  --set secrets.anthropicApiKey=sk-ant-test \
+  --set secrets.openaiApiKey=sk-openai-test \
+  --set secrets.ollamaUrl=http://ollama:11434 \
+  > "$AI"
+assert_contains "$AI" 'anthropic-api-key' "secret stores anthropic key"
+assert_contains "$AI" 'openai-api-key' "secret stores openai key"
+assert_contains "$AI" 'ollama-url' "secret stores ollama url"
+
+section "summary"
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, and `OLLAMA_URL` to the api and worker pods via optional `secretKeyRef` entries so AI features can be toggled per-release without rebuilding images. Values live under `secrets.*` in `values.yaml` and only materialize into `opensoar-secrets` when non-empty.
- Factor the shared env block into a `opensoar.commonEnv` helper, fix the worker `--concurrency` flag rendering (was wrapped in quotes), and add an `icon`/`home`/`sources` to `Chart.yaml` plus a richer `NOTES.txt`.
- Add `scripts/test-helm.sh` (35 assertions via `helm lint` + `helm template` across default, subchart-disabled, ingress-enabled, image-override, and AI-secret scenarios) and wire it into the existing `helm-packaging-smoke` CI job.
- Add a new `helm-install-smoke` CI job that builds local images, loads them into a kind cluster via `helm/kind-action`, runs `helm install --wait` with overridden tags, and confirms the migrate pre-install hook plus all three Deployments roll out clean. The aggregate `build` job now depends on it.

Closes #84

## Test plan
- [x] `helm lint ./helm/opensoar`
- [x] `bash scripts/test-helm.sh` (35 pass / 0 fail)
- [x] `helm template` renders cleanly with default values, subcharts disabled, ingress enabled, and AI secret overrides; YAML parses with `yaml.safe_load_all`
- [x] `ruff check src/ tests/`
- [ ] CI `helm-install-smoke` green against a kind cluster with locally built images

## Sample install
```
helm install opensoar ./helm/opensoar \
  --namespace opensoar --create-namespace \
  --set secrets.jwtSecret=$(python -c 'import secrets; print(secrets.token_urlsafe(32))') \
  --set secrets.apiKeySecret=$(python -c 'import secrets; print(secrets.token_urlsafe(32))') \
  --set secrets.anthropicApiKey=$ANTHROPIC_API_KEY \
  --set ui.ingress.enabled=true --set ui.ingress.host=soar.example.com
```