### PR TITLE
Clustered workers with priority queues (high/default/low)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,11 +133,47 @@ services:
       redis:
         condition: service_healthy
 
-  worker:
+  # Hot-path worker: consumes latency-sensitive playbook executions.
+  # Scales independently from the low-priority worker so background
+  # enrichment never starves interactive runs.
+  worker-hot:
     build:
       context: .
       target: worker
-    command: celery -A opensoar.worker.celery_app worker --loglevel=info --concurrency=4
+    command: >
+      celery -A opensoar.worker.celery_app worker
+      --loglevel=info
+      --concurrency=${WORKER_HOT_CONCURRENCY:-4}
+      -Q ${WORKER_HOT_QUEUES:-high,default}
+      -n hot@%h
+    environment:
+      DATABASE_URL: postgresql+asyncpg://opensoar:${POSTGRES_PASSWORD:-opensoar_dev}@postgres:5432/opensoar
+      REDIS_URL: redis://redis:6379/0
+      JWT_SECRET: ${JWT_SECRET:-test-secret-which-is-long-enough-for-hs256}
+      API_KEY_SECRET: ${API_KEY_SECRET:-test-api-key-secret}
+      PLAYBOOK_DIRS: /app/playbooks
+    volumes:
+      - ./src:/app/src
+      - ./playbooks:/app/playbooks
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  # Low-priority worker: observable enrichment and other background tasks.
+  worker-low:
+    build:
+      context: .
+      target: worker
+    command: >
+      celery -A opensoar.worker.celery_app worker
+      --loglevel=info
+      --concurrency=${WORKER_LOW_CONCURRENCY:-2}
+      -Q ${WORKER_LOW_QUEUES:-low}
+      -n low@%h
     environment:
       DATABASE_URL: postgresql+asyncpg://opensoar:${POSTGRES_PASSWORD:-opensoar_dev}@postgres:5432/opensoar
       REDIS_URL: redis://redis:6379/0

--- a/src/opensoar/core/decorators.py
+++ b/src/opensoar/core/decorators.py
@@ -30,6 +30,7 @@ class PlaybookMeta:
     description: str = ""
     enabled: bool = True
     order: int = 1000
+    priority: str = "default"
 
 
 @dataclass
@@ -154,6 +155,9 @@ def action(
     return decorator
 
 
+_VALID_PLAYBOOK_PRIORITIES = ("high", "default", "low")
+
+
 def playbook(
     trigger: str | None = None,
     *,
@@ -161,7 +165,14 @@ def playbook(
     description: str = "",
     name: str | None = None,
     order: int = 1000,
+    priority: str = "default",
 ) -> Callable:
+    if priority not in _VALID_PLAYBOOK_PRIORITIES:
+        raise ValueError(
+            f"Invalid playbook priority {priority!r}; "
+            f"expected one of {_VALID_PLAYBOOK_PRIORITIES}"
+        )
+
     def decorator(func: Callable) -> Callable:
         meta = PlaybookMeta(
             name=name or func.__name__,
@@ -169,6 +180,7 @@ def playbook(
             conditions=conditions or {},
             description=description,
             order=order,
+            priority=priority,
         )
         func._soar_playbook = meta
 

--- a/src/opensoar/worker/celery_app.py
+++ b/src/opensoar/worker/celery_app.py
@@ -1,6 +1,8 @@
 from celery import Celery
+from kombu import Queue
 
 from opensoar.config import settings
+from opensoar.worker.routing import QUEUE_DEFAULT, QUEUE_HIGH, QUEUE_LOW
 
 celery_app = Celery(
     "opensoar",
@@ -17,6 +19,22 @@ celery_app.conf.update(
     task_track_started=True,
     task_acks_late=True,
     worker_prefetch_multiplier=1,
+    # ── Clustered workers / priority queues (issue #85) ─────────────────────
+    # Three named queues; a worker process consumes one or more of them via
+    # ``celery worker -Q high,default`` (hot path) or ``-Q low`` (background).
+    task_default_queue=QUEUE_DEFAULT,
+    task_queues=(
+        Queue(QUEUE_HIGH),
+        Queue(QUEUE_DEFAULT),
+        Queue(QUEUE_LOW),
+    ),
+    # Static routing: observable enrichment is always background work.
+    # Playbook execution is routed dynamically at enqueue time (see
+    # ``opensoar.worker.tasks.execute_playbook_task``) because the queue
+    # depends on each playbook's declared priority.
+    task_routes={
+        "opensoar.enrich_observable": {"queue": QUEUE_LOW},
+    },
 )
 
 celery_app.autodiscover_tasks(["opensoar.worker"])

--- a/src/opensoar/worker/routing.py
+++ b/src/opensoar/worker/routing.py
@@ -1,0 +1,78 @@
+"""Queue routing helpers for Celery clustered workers (issue #85).
+
+Three logical priority classes map 1:1 to Celery queues:
+
+    ``high``     — latency-sensitive playbooks (e.g. auto-containment).
+    ``default``  — general-purpose playbooks and unknown priorities.
+    ``low``      — background work (observable enrichment, backfills).
+
+A @playbook is tagged with a priority via the decorator's ``priority`` kwarg
+(default ``"default"``). At enqueue time, ``execute_playbook_task`` looks up
+the registered playbook's priority and routes the task onto the matching
+queue. Callers can override with an explicit ``priority=`` kwarg on
+``delay()``.
+
+Operators run two Celery worker processes: one consuming ``high,default`` and
+one consuming ``low``. Either can scale independently without starving the
+other.
+"""
+from __future__ import annotations
+
+QUEUE_HIGH = "high"
+QUEUE_DEFAULT = "default"
+QUEUE_LOW = "low"
+
+VALID_PRIORITIES: frozenset[str] = frozenset({QUEUE_HIGH, QUEUE_DEFAULT, QUEUE_LOW})
+
+# Ordering used when a sequence task spans multiple playbooks with differing
+# priorities — the most urgent wins so nothing lingers behind a low-priority
+# peer in the same batch.
+_PRIORITY_RANK = {QUEUE_HIGH: 0, QUEUE_DEFAULT: 1, QUEUE_LOW: 2}
+
+
+def queue_for_priority(priority: str | None) -> str:
+    """Map a priority string to its queue name.
+
+    Unknown or ``None`` values fall back to ``default`` — routing must never
+    raise at enqueue time.
+    """
+    if priority in VALID_PRIORITIES:
+        return priority  # type: ignore[return-value]
+    return QUEUE_DEFAULT
+
+
+def queue_for_playbook(playbook_name: str) -> str:
+    """Look up the queue for a registered playbook name.
+
+    If the playbook is unknown (not yet imported on the enqueuing side, or a
+    typo) we fall back to ``default`` rather than raising — the worker will
+    still surface the real "playbook not found" error when it runs.
+    """
+    # Local import to avoid a circular dependency with the decorators module
+    # at worker-module import time.
+    from opensoar.core.decorators import get_playbook_registry
+
+    registered = get_playbook_registry().get(playbook_name)
+    if registered is None:
+        return QUEUE_DEFAULT
+    return queue_for_priority(registered.meta.priority)
+
+
+def highest_priority_queue(playbook_names: list[str]) -> str:
+    """Return the most-urgent queue across a list of playbook names.
+
+    Used by ``execute_playbook_sequence_task`` so a batch containing a
+    ``high`` playbook does not get starved behind ``low``-queue work.
+    """
+    if not playbook_names:
+        return QUEUE_DEFAULT
+
+    best = QUEUE_DEFAULT
+    best_rank = _PRIORITY_RANK[best]
+    for name in playbook_names:
+        q = queue_for_playbook(name)
+        rank = _PRIORITY_RANK.get(q, _PRIORITY_RANK[QUEUE_DEFAULT])
+        if rank < best_rank:
+            best = q
+            best_rank = rank
+    return best

--- a/src/opensoar/worker/tasks.py
+++ b/src/opensoar/worker/tasks.py
@@ -5,9 +5,47 @@ import logging
 import uuid
 from collections.abc import Callable
 
+from celery import Task
+
 from opensoar.worker.celery_app import celery_app
+from opensoar.worker.routing import (
+    QUEUE_DEFAULT,
+    highest_priority_queue,
+    queue_for_playbook,
+    queue_for_priority,
+)
 
 logger = logging.getLogger(__name__)
+
+
+class _PlaybookRoutedTask(Task):
+    """Celery Task that picks its queue from the playbook's priority.
+
+    The playbook name is always the first positional arg (either a string for
+    ``execute_playbook`` or a list[str] for ``execute_playbook_sequence``).
+    Callers may override the chosen queue with ``priority="high"`` etc on
+    ``delay()``. The override is stripped before the task runs — workers
+    never see it.
+    """
+
+    abstract = True
+
+    def _resolve_queue(self, args: tuple, priority_override: str | None) -> str:
+        if priority_override is not None:
+            return queue_for_priority(priority_override)
+        if not args:
+            return QUEUE_DEFAULT
+        first = args[0]
+        if isinstance(first, str):
+            return queue_for_playbook(first)
+        if isinstance(first, list):
+            return highest_priority_queue([n for n in first if isinstance(n, str)])
+        return QUEUE_DEFAULT
+
+    def delay(self, *args, **kwargs):
+        priority = kwargs.pop("priority", None)
+        queue = self._resolve_queue(args, priority)
+        return self.apply_async(args=args, kwargs=kwargs, queue=queue)
 
 
 def _run_async(coro):
@@ -122,7 +160,12 @@ async def _execute_sequence(
     }
 
 
-@celery_app.task(name="opensoar.execute_playbook", bind=True, max_retries=3)
+@celery_app.task(
+    name="opensoar.execute_playbook",
+    bind=True,
+    max_retries=3,
+    base=_PlaybookRoutedTask,
+)
 def execute_playbook_task(self, playbook_name: str, alert_id: str | None = None) -> dict:
     logger.info(f"Executing playbook '{playbook_name}' (alert_id={alert_id})")
 
@@ -135,7 +178,12 @@ def execute_playbook_task(self, playbook_name: str, alert_id: str | None = None)
         raise self.retry(exc=e, countdown=2**self.request.retries)
 
 
-@celery_app.task(name="opensoar.execute_playbook_sequence", bind=True, max_retries=3)
+@celery_app.task(
+    name="opensoar.execute_playbook_sequence",
+    bind=True,
+    max_retries=3,
+    base=_PlaybookRoutedTask,
+)
 def execute_playbook_sequence_task(self, playbook_names: list[str], alert_id: str | None = None) -> dict:
     logger.info(f"Executing playbook sequence {playbook_names} (alert_id={alert_id})")
 

--- a/tests/test_worker_routing.py
+++ b/tests/test_worker_routing.py
@@ -1,0 +1,181 @@
+"""Tests for Celery queue routing (issue #85: clustered workers).
+
+Verifies:
+- ``@playbook(priority=...)`` accepts/validates priority, default is "default".
+- ``execute_playbook_task`` routes to the playbook's declared queue.
+- ``execute_playbook_task`` accepts an explicit ``priority`` override.
+- ``enrich_observable_task`` is routed to the ``low`` queue via task_routes.
+- ``celery_app`` declares the ``high`` / ``default`` / ``low`` queues.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from opensoar.core.decorators import (
+    PlaybookMeta,
+    get_playbook_registry,
+    playbook,
+)
+from opensoar.worker.celery_app import celery_app
+from opensoar.worker.routing import (
+    QUEUE_DEFAULT,
+    QUEUE_HIGH,
+    QUEUE_LOW,
+    VALID_PRIORITIES,
+    queue_for_playbook,
+    queue_for_priority,
+)
+
+
+class TestPlaybookPriorityDecorator:
+    def test_default_priority_is_default(self):
+        @playbook(trigger="webhook", name="test_prio_default")
+        async def pb(alert):
+            pass
+
+        meta: PlaybookMeta = get_playbook_registry()["test_prio_default"].meta
+        assert meta.priority == "default"
+
+    def test_high_priority(self):
+        @playbook(trigger="webhook", name="test_prio_high", priority="high")
+        async def pb(alert):
+            pass
+
+        meta: PlaybookMeta = get_playbook_registry()["test_prio_high"].meta
+        assert meta.priority == "high"
+
+    def test_low_priority(self):
+        @playbook(trigger="webhook", name="test_prio_low", priority="low")
+        async def pb(alert):
+            pass
+
+        meta: PlaybookMeta = get_playbook_registry()["test_prio_low"].meta
+        assert meta.priority == "low"
+
+    def test_invalid_priority_raises(self):
+        with pytest.raises(ValueError, match="priority"):
+
+            @playbook(trigger="webhook", name="test_prio_invalid", priority="urgent")
+            async def pb(alert):
+                pass
+
+
+class TestRoutingHelpers:
+    def test_valid_priorities_set(self):
+        assert VALID_PRIORITIES == {QUEUE_HIGH, QUEUE_DEFAULT, QUEUE_LOW}
+
+    def test_queue_for_priority_maps_directly(self):
+        assert queue_for_priority("high") == QUEUE_HIGH
+        assert queue_for_priority("default") == QUEUE_DEFAULT
+        assert queue_for_priority("low") == QUEUE_LOW
+
+    def test_queue_for_priority_unknown_falls_back_to_default(self):
+        assert queue_for_priority("bogus") == QUEUE_DEFAULT
+        assert queue_for_priority(None) == QUEUE_DEFAULT
+
+    def test_queue_for_playbook_reads_meta_priority(self):
+        @playbook(trigger="webhook", name="test_q_high_pb", priority="high")
+        async def pb_high(alert):
+            pass
+
+        assert queue_for_playbook("test_q_high_pb") == QUEUE_HIGH
+
+    def test_queue_for_playbook_unknown_name_defaults(self):
+        assert queue_for_playbook("nonexistent_pb_xyz") == QUEUE_DEFAULT
+
+
+class TestExecutePlaybookTaskRouting:
+    def test_delay_routes_to_playbook_declared_queue(self):
+        @playbook(trigger="webhook", name="test_exec_high", priority="high")
+        async def pb_high(alert):
+            pass
+
+        from opensoar.worker.tasks import execute_playbook_task
+
+        with patch.object(execute_playbook_task, "apply_async") as mock_apply:
+            execute_playbook_task.delay("test_exec_high", "alert-123")
+
+        mock_apply.assert_called_once()
+        kwargs = mock_apply.call_args.kwargs
+        assert kwargs.get("queue") == QUEUE_HIGH
+        assert kwargs.get("args") == ("test_exec_high", "alert-123")
+
+    def test_delay_default_priority_goes_to_default_queue(self):
+        @playbook(trigger="webhook", name="test_exec_default")
+        async def pb_default(alert):
+            pass
+
+        from opensoar.worker.tasks import execute_playbook_task
+
+        with patch.object(execute_playbook_task, "apply_async") as mock_apply:
+            execute_playbook_task.delay("test_exec_default")
+
+        kwargs = mock_apply.call_args.kwargs
+        assert kwargs.get("queue") == QUEUE_DEFAULT
+
+    def test_explicit_priority_override_wins(self):
+        @playbook(trigger="webhook", name="test_exec_override", priority="low")
+        async def pb_low(alert):
+            pass
+
+        from opensoar.worker.tasks import execute_playbook_task
+
+        with patch.object(execute_playbook_task, "apply_async") as mock_apply:
+            # Override the playbook's low with high
+            execute_playbook_task.delay(
+                "test_exec_override", "alert-xyz", priority="high"
+            )
+
+        kwargs = mock_apply.call_args.kwargs
+        assert kwargs.get("queue") == QUEUE_HIGH
+        # priority should not appear as a task arg, only as routing hint
+        assert kwargs.get("args") == ("test_exec_override", "alert-xyz")
+
+    def test_unknown_playbook_falls_back_to_default_queue(self):
+        from opensoar.worker.tasks import execute_playbook_task
+
+        with patch.object(execute_playbook_task, "apply_async") as mock_apply:
+            execute_playbook_task.delay("not_registered_pb")
+
+        kwargs = mock_apply.call_args.kwargs
+        assert kwargs.get("queue") == QUEUE_DEFAULT
+
+
+class TestExecuteSequenceTaskRouting:
+    def test_sequence_uses_highest_priority_across_playbooks(self):
+        @playbook(trigger="webhook", name="test_seq_low", priority="low")
+        async def pb_low(alert):
+            pass
+
+        @playbook(trigger="webhook", name="test_seq_high", priority="high")
+        async def pb_high(alert):
+            pass
+
+        from opensoar.worker.tasks import execute_playbook_sequence_task
+
+        with patch.object(execute_playbook_sequence_task, "apply_async") as mock_apply:
+            execute_playbook_sequence_task.delay(
+                ["test_seq_low", "test_seq_high"], "alert-a"
+            )
+
+        kwargs = mock_apply.call_args.kwargs
+        # "high" beats "low": sequence must run on the hottest queue needed.
+        assert kwargs.get("queue") == QUEUE_HIGH
+
+
+class TestEnrichObservableRouting:
+    def test_enrich_task_routed_to_low_via_task_routes(self):
+        routes = celery_app.conf.task_routes or {}
+        assert "opensoar.enrich_observable" in routes
+        assert routes["opensoar.enrich_observable"]["queue"] == QUEUE_LOW
+
+
+class TestCeleryQueueDeclaration:
+    def test_all_three_queues_declared(self):
+        queue_names = {q.name for q in (celery_app.conf.task_queues or [])}
+        assert {QUEUE_HIGH, QUEUE_DEFAULT, QUEUE_LOW}.issubset(queue_names)
+
+    def test_default_queue_is_default(self):
+        assert celery_app.conf.task_default_queue == QUEUE_DEFAULT


### PR DESCRIPTION
## Summary

- Adds a ``priority`` kwarg to ``@playbook`` (``high`` / ``default`` / ``low``; default ``default``) and routes ``execute_playbook_task`` to the matching Celery queue. Callers can override with ``priority="high"`` on ``delay()``.
- ``execute_playbook_sequence_task`` picks the hottest queue across the batch so a ``high`` playbook is not starved behind ``low`` peers.
- ``enrich_observable_task`` is pinned to ``low`` via static ``task_routes`` — background work never competes with interactive playbook runs.
- ``docker-compose.yml`` now runs two worker services: ``worker-hot`` (``-Q high,default``) and ``worker-low`` (``-Q low``), each with independent ``WORKER_*_CONCURRENCY`` / ``WORKER_*_QUEUES`` env overrides.

## Queue to task mapping

| Queue     | Tasks                                           |
| --------- | ----------------------------------------------- |
| ``high``    | ``execute_playbook`` when playbook ``priority="high"`` (or overridden) |
| ``default`` | ``execute_playbook`` when ``priority="default"`` (fallback for unknown) |
| ``low``     | ``enrich_observable`` always; ``execute_playbook`` when ``priority="low"`` |

## Follow-ups

- [ ] Update ``helm/opensoar/templates/worker.yaml`` to deploy hot + low as separate Deployments — tracked against issue #84 (parallel Helm chart work).

## Test plan

- [x] ``ruff check src/ tests/`` clean
- [x] ``pytest tests/`` — 355 passed locally (Postgres + Redis)
- [x] New ``tests/test_worker_routing.py`` (17 tests) covers decorator priority, routing helpers, queue resolution, override behaviour, sequence batching, ``enrich_observable`` static route, and queue declarations
- [ ] CI (``gh run watch``)

Closes #85