### PR TITLE
Add POST /ai/recommend for analyst action suggestions

### DIFF
--- a/src/opensoar/ai/prompts.py
+++ b/src/opensoar/ai/prompts.py
@@ -117,6 +117,48 @@ Alerts:
 {alerts_json}"""
 
 
+def build_recommendation_prompt(
+    alert: dict[str, Any],
+    observables: list[dict[str, Any]],
+    similar_alerts: list[dict[str, Any]],
+) -> str:
+    """Build a prompt that asks an LLM what a seasoned analyst would do next."""
+    alert_json = json.dumps(
+        {k: v for k, v in alert.items() if k not in ("id", "created_at", "updated_at")},
+        indent=2,
+        default=str,
+    )
+    observables_json = (
+        json.dumps(observables, indent=2, default=str) if observables else "(none)"
+    )
+    similar_json = (
+        json.dumps(similar_alerts, indent=2, default=str) if similar_alerts else "(none)"
+    )
+
+    return f"""You are a senior SOC analyst deciding the next action for an alert.
+
+Choose exactly ONE action from this vocabulary:
+- "isolate": quarantine the affected host from the network
+- "block": block the offending indicator (IP/domain/hash) at the perimeter
+- "enrich": gather more context before deciding (IOC lookups, user history, etc.)
+- "escalate": hand off to a human analyst or IR team
+- "resolve": close the alert as benign or already remediated
+
+Respond with ONLY a JSON object (no markdown, no prose) with these fields:
+- "action": one of "isolate", "block", "enrich", "escalate", "resolve"
+- "confidence": float between 0.0 and 1.0
+- "reasoning": 1-3 sentence justification grounded in the evidence below
+
+Alert under review:
+{alert_json}
+
+Linked observables and enrichments:
+{observables_json}
+
+Similar past alerts (same source_ip, for historical context):
+{similar_json}"""
+
+
 def build_correlation_prompt(alerts: list[dict[str, Any]]) -> str:
     """Build a prompt that groups related alerts into potential incidents."""
     alerts_json = json.dumps(alerts, indent=2, default=str)

--- a/src/opensoar/api/ai.py
+++ b/src/opensoar/api/ai.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import logging
 import uuid
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
@@ -15,14 +16,21 @@ from opensoar.ai.prompts import (
     build_auto_resolve_prompt,
     build_correlation_prompt,
     build_playbook_prompt,
+    build_recommendation_prompt,
     build_summarize_prompt,
     build_triage_prompt,
 )
 from opensoar.api.deps import get_db
 from opensoar.auth.jwt import require_analyst
+from opensoar.auth.rbac import Permission, require_permission
 from opensoar.config import settings
 from opensoar.models.alert import Alert
 from opensoar.models.analyst import Analyst
+from opensoar.models.observable import Observable
+from opensoar.schemas.ai import AiRecommendation, RecommendRequest
+
+ALLOWED_ACTIONS = {"isolate", "block", "enrich", "escalate", "resolve"}
+SIMILAR_ALERT_LIMIT = 5
 
 logger = logging.getLogger(__name__)
 
@@ -335,3 +343,142 @@ async def correlate_alerts(
         "groups": result_data.get("groups", []),
         "model": response.model,
     }
+
+
+def _normalize_confidence(raw: Any) -> float:
+    """Parse + clamp an LLM-reported confidence into [0.0, 1.0].
+
+    Accepts floats, ints, and percentage-style numbers. Values in (2, 100]
+    are treated as percentages and scaled by /100. Values just above 1.0
+    (e.g. 1.4) are treated as overconfident floats and clamped to 1.0 —
+    that is much more likely than a 1.4% confidence.
+    """
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return 0.0
+    if value > 2.0 and value <= 100.0:
+        value = value / 100.0
+    if value < 0.0:
+        return 0.0
+    if value > 1.0:
+        return 1.0
+    return value
+
+
+@router.post("/recommend", response_model=AiRecommendation)
+async def recommend_action(
+    body: RecommendRequest,
+    session: AsyncSession = Depends(get_db),
+    _analyst: Analyst = Depends(require_permission(Permission.AI_USE)),
+) -> AiRecommendation:
+    """Ask the LLM what a seasoned analyst would do for this alert."""
+    client = get_llm_client()
+    if client is None:
+        raise HTTPException(
+            status_code=503,
+            detail="AI features not configured. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or OLLAMA_URL.",
+        )
+
+    try:
+        alert_uuid = uuid.UUID(body.alert_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid alert_id") from None
+
+    result = await session.execute(select(Alert).where(Alert.id == alert_uuid))
+    alert = result.scalar_one_or_none()
+    if not alert:
+        raise HTTPException(status_code=404, detail="Alert not found")
+
+    # Linked observables + their enrichments
+    obs_result = await session.execute(
+        select(Observable).where(Observable.alert_id == alert_uuid)
+    )
+    observables = [
+        {
+            "type": obs.type,
+            "value": obs.value,
+            "source": obs.source,
+            "enrichment_status": obs.enrichment_status,
+            "enrichments": obs.enrichments or [],
+            "tags": obs.tags or [],
+        }
+        for obs in obs_result.scalars().all()
+    ]
+
+    # Similar past alerts by shared source_ip (top-N, newest first, excluding self)
+    similar: list[dict[str, Any]] = []
+    if alert.source_ip:
+        similar_result = await session.execute(
+            select(Alert)
+            .where(Alert.source_ip == alert.source_ip, Alert.id != alert_uuid)
+            .order_by(Alert.created_at.desc())
+            .limit(SIMILAR_ALERT_LIMIT)
+        )
+        similar = [
+            {
+                "id": str(s.id),
+                "title": s.title,
+                "severity": s.severity,
+                "status": s.status,
+                "determination": s.determination,
+                "rule_name": s.rule_name,
+            }
+            for s in similar_result.scalars().all()
+        ]
+
+    alert_data = {
+        "title": alert.title,
+        "severity": alert.severity,
+        "status": alert.status,
+        "description": alert.description,
+        "source_ip": alert.source_ip,
+        "dest_ip": alert.dest_ip,
+        "hostname": alert.hostname,
+        "rule_name": alert.rule_name,
+        "iocs": alert.iocs,
+        "tags": alert.tags,
+        "source": alert.source,
+    }
+
+    prompt = build_recommendation_prompt(alert_data, observables, similar)
+    response = await client.complete(
+        prompt,
+        system=(
+            "You are a senior SOC analyst. Recommend the single best next action. "
+            "Respond with JSON only."
+        ),
+        temperature=0.1,
+    )
+
+    content = (response.content or "").strip()
+    if content.startswith("```"):
+        content = content.strip("`")
+        if content.startswith("json"):
+            content = content[4:].strip()
+
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError:
+        logger.warning("recommend: LLM returned non-JSON output, falling back to escalate")
+        return AiRecommendation(
+            action="escalate",
+            confidence=0.0,
+            reasoning=f"Could not parse LLM response: {response.content[:500]}",
+        )
+
+    raw_action = parsed.get("action") if isinstance(parsed, dict) else None
+    action = raw_action if raw_action in ALLOWED_ACTIONS else "escalate"
+    confidence = _normalize_confidence(parsed.get("confidence", 0.0) if isinstance(parsed, dict) else 0.0)
+    reasoning = ""
+    if isinstance(parsed, dict):
+        reasoning = str(parsed.get("reasoning", "")).strip()
+    if not reasoning:
+        reasoning = "No reasoning provided by the model."
+    if raw_action not in ALLOWED_ACTIONS:
+        reasoning = (
+            f"Model returned unsupported action '{raw_action}'; defaulting to escalate. "
+            + reasoning
+        )
+
+    return AiRecommendation(action=action, confidence=confidence, reasoning=reasoning)

--- a/src/opensoar/schemas/ai.py
+++ b/src/opensoar/schemas/ai.py
@@ -1,0 +1,20 @@
+"""Pydantic v2 schemas for AI endpoints."""
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+RecommendedAction = Literal["isolate", "block", "enrich", "escalate", "resolve"]
+
+
+class AiRecommendation(BaseModel):
+    """An analyst-style action recommendation produced by an LLM."""
+
+    action: RecommendedAction
+    confidence: float = Field(ge=0.0, le=1.0)
+    reasoning: str
+
+
+class RecommendRequest(BaseModel):
+    alert_id: str

--- a/tests/test_ai_recommend.py
+++ b/tests/test_ai_recommend.py
@@ -1,0 +1,349 @@
+"""Tests for AI analyst recommendations — POST /ai/recommend."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from opensoar.ai.client import LLMResponse
+from opensoar.ai.prompts import build_recommendation_prompt
+from opensoar.schemas.ai import AiRecommendation
+
+
+class TestRecommendationPrompt:
+    def test_recommendation_prompt_includes_alert(self):
+        """Prompt should contain the alert data."""
+        alert = {
+            "title": "Brute Force SSH",
+            "severity": "high",
+            "source_ip": "10.0.0.1",
+            "hostname": "web-01",
+        }
+        prompt = build_recommendation_prompt(alert, observables=[], similar_alerts=[])
+        assert "Brute Force SSH" in prompt
+        assert "10.0.0.1" in prompt
+
+    def test_recommendation_prompt_mentions_action_choices(self):
+        """Prompt must list the allowed action vocabulary."""
+        prompt = build_recommendation_prompt({"title": "x"}, observables=[], similar_alerts=[])
+        for action in ("isolate", "block", "enrich", "escalate", "resolve"):
+            assert action in prompt
+
+    def test_recommendation_prompt_includes_observables(self):
+        """Prompt should embed observable + enrichment context."""
+        observables = [
+            {
+                "type": "ip",
+                "value": "203.0.113.5",
+                "enrichments": [{"source": "virustotal", "data": {"malicious": 40}}],
+            }
+        ]
+        prompt = build_recommendation_prompt(
+            {"title": "x"}, observables=observables, similar_alerts=[]
+        )
+        assert "203.0.113.5" in prompt
+        assert "virustotal" in prompt
+
+    def test_recommendation_prompt_includes_similar_alerts(self):
+        """Prompt should embed similar past alerts context."""
+        similar = [{"id": "abc", "title": "Prior brute force", "determination": "malicious"}]
+        prompt = build_recommendation_prompt(
+            {"title": "x"}, observables=[], similar_alerts=similar
+        )
+        assert "Prior brute force" in prompt
+        assert "malicious" in prompt
+
+
+class TestAiRecommendationSchema:
+    def test_valid_action_accepted(self):
+        """Schema accepts allowed action values."""
+        rec = AiRecommendation(action="isolate", confidence=0.9, reasoning="bad ip")
+        assert rec.action == "isolate"
+        assert rec.confidence == 0.9
+
+    def test_invalid_action_rejected(self):
+        """Schema rejects non-whitelisted action values."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            AiRecommendation(action="nuke", confidence=0.5, reasoning="x")
+
+    def test_confidence_bounds_enforced(self):
+        """Confidence must be between 0 and 1."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            AiRecommendation(action="block", confidence=1.5, reasoning="x")
+        with pytest.raises(ValidationError):
+            AiRecommendation(action="block", confidence=-0.1, reasoning="x")
+
+
+class TestRecommendEndpoint:
+    async def test_recommend_returns_schema(self, client, sample_alert_via_api, registered_analyst):
+        """POST /ai/recommend returns an AiRecommendation-shaped response."""
+        alert_id = sample_alert_via_api["alert_id"]
+
+        with patch("opensoar.api.ai.get_llm_client") as mock_get:
+            mock_client = AsyncMock()
+            mock_client.complete.return_value = LLMResponse(
+                content='{"action": "isolate", "confidence": 0.92, "reasoning": "Source IP seen in prior malicious events."}',
+                model="gpt-4o",
+                usage={},
+            )
+            mock_get.return_value = mock_client
+
+            resp = await client.post(
+                "/api/v1/ai/recommend",
+                json={"alert_id": str(alert_id)},
+                headers=registered_analyst["headers"],
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["action"] == "isolate"
+            assert data["confidence"] == 0.92
+            assert data["reasoning"]
+
+    async def test_recommend_routes_each_action(
+        self, client, sample_alert_via_api, registered_analyst
+    ):
+        """Each allowed action value round-trips through the endpoint."""
+        alert_id = sample_alert_via_api["alert_id"]
+
+        for action in ("isolate", "block", "enrich", "escalate", "resolve"):
+            with patch("opensoar.api.ai.get_llm_client") as mock_get:
+                mock_client = AsyncMock()
+                mock_client.complete.return_value = LLMResponse(
+                    content=f'{{"action": "{action}", "confidence": 0.7, "reasoning": "test"}}',
+                    model="gpt-4o",
+                    usage={},
+                )
+                mock_get.return_value = mock_client
+
+                resp = await client.post(
+                    "/api/v1/ai/recommend",
+                    json={"alert_id": str(alert_id)},
+                    headers=registered_analyst["headers"],
+                )
+                assert resp.status_code == 200
+                assert resp.json()["action"] == action
+
+    async def test_recommend_clamps_confidence_when_out_of_range(
+        self, client, sample_alert_via_api, registered_analyst
+    ):
+        """If the LLM returns a confidence outside [0,1], the endpoint clamps it."""
+        alert_id = sample_alert_via_api["alert_id"]
+
+        with patch("opensoar.api.ai.get_llm_client") as mock_get:
+            mock_client = AsyncMock()
+            mock_client.complete.return_value = LLMResponse(
+                content='{"action": "enrich", "confidence": 1.4, "reasoning": "over"}',
+                model="gpt-4o",
+                usage={},
+            )
+            mock_get.return_value = mock_client
+
+            resp = await client.post(
+                "/api/v1/ai/recommend",
+                json={"alert_id": str(alert_id)},
+                headers=registered_analyst["headers"],
+            )
+            assert resp.status_code == 200
+            assert resp.json()["confidence"] == 1.0
+
+    async def test_recommend_parses_confidence_as_percentage(
+        self, client, sample_alert_via_api, registered_analyst
+    ):
+        """A confidence >1 but <=100 is treated as a percentage and scaled."""
+        alert_id = sample_alert_via_api["alert_id"]
+
+        with patch("opensoar.api.ai.get_llm_client") as mock_get:
+            mock_client = AsyncMock()
+            mock_client.complete.return_value = LLMResponse(
+                content='{"action": "block", "confidence": 85, "reasoning": "pct"}',
+                model="gpt-4o",
+                usage={},
+            )
+            mock_get.return_value = mock_client
+
+            resp = await client.post(
+                "/api/v1/ai/recommend",
+                json={"alert_id": str(alert_id)},
+                headers=registered_analyst["headers"],
+            )
+            assert resp.status_code == 200
+            assert resp.json()["confidence"] == 0.85
+
+    async def test_recommend_works_with_no_observables(
+        self, client, sample_alert_via_api, registered_analyst
+    ):
+        """Endpoint succeeds when the alert has no linked observables."""
+        alert_id = sample_alert_via_api["alert_id"]
+
+        with patch("opensoar.api.ai.get_llm_client") as mock_get:
+            mock_client = AsyncMock()
+            mock_client.complete.return_value = LLMResponse(
+                content='{"action": "escalate", "confidence": 0.5, "reasoning": "limited context"}',
+                model="gpt-4o",
+                usage={},
+            )
+            mock_get.return_value = mock_client
+
+            resp = await client.post(
+                "/api/v1/ai/recommend",
+                json={"alert_id": str(alert_id)},
+                headers=registered_analyst["headers"],
+            )
+            assert resp.status_code == 200
+            assert resp.json()["action"] == "escalate"
+
+    async def test_recommend_fallback_on_malformed_llm_output(
+        self, client, sample_alert_via_api, registered_analyst
+    ):
+        """Non-JSON output from the LLM falls back to a safe escalate recommendation."""
+        alert_id = sample_alert_via_api["alert_id"]
+
+        with patch("opensoar.api.ai.get_llm_client") as mock_get:
+            mock_client = AsyncMock()
+            mock_client.complete.return_value = LLMResponse(
+                content="this is not json at all",
+                model="gpt-4o",
+                usage={},
+            )
+            mock_get.return_value = mock_client
+
+            resp = await client.post(
+                "/api/v1/ai/recommend",
+                json={"alert_id": str(alert_id)},
+                headers=registered_analyst["headers"],
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["action"] == "escalate"
+            assert data["confidence"] == 0.0
+            assert "this is not json" in data["reasoning"]
+
+    async def test_recommend_fallback_on_invalid_action(
+        self, client, sample_alert_via_api, registered_analyst
+    ):
+        """If LLM returns an action outside the vocabulary, fall back to escalate."""
+        alert_id = sample_alert_via_api["alert_id"]
+
+        with patch("opensoar.api.ai.get_llm_client") as mock_get:
+            mock_client = AsyncMock()
+            mock_client.complete.return_value = LLMResponse(
+                content='{"action": "destroy", "confidence": 0.9, "reasoning": "bad action"}',
+                model="gpt-4o",
+                usage={},
+            )
+            mock_get.return_value = mock_client
+
+            resp = await client.post(
+                "/api/v1/ai/recommend",
+                json={"alert_id": str(alert_id)},
+                headers=registered_analyst["headers"],
+            )
+            assert resp.status_code == 200
+            assert resp.json()["action"] == "escalate"
+
+    async def test_recommend_503_when_no_llm(self, client, sample_alert_via_api, registered_analyst):
+        """Graceful 503 when no LLM is configured."""
+        alert_id = sample_alert_via_api["alert_id"]
+
+        with patch("opensoar.api.ai.get_llm_client", return_value=None):
+            resp = await client.post(
+                "/api/v1/ai/recommend",
+                json={"alert_id": str(alert_id)},
+                headers=registered_analyst["headers"],
+            )
+            assert resp.status_code == 503
+
+    async def test_recommend_404_when_alert_missing(self, client, registered_analyst):
+        """Returns 404 when the alert id does not exist."""
+        missing_id = str(uuid.uuid4())
+
+        with patch("opensoar.api.ai.get_llm_client") as mock_get:
+            mock_get.return_value = AsyncMock()
+            resp = await client.post(
+                "/api/v1/ai/recommend",
+                json={"alert_id": missing_id},
+                headers=registered_analyst["headers"],
+            )
+            assert resp.status_code == 404
+
+    async def test_recommend_requires_ai_use_permission(
+        self, client, sample_alert_via_api, db_session_factory
+    ):
+        """Viewers (without AI_USE) are forbidden."""
+        from opensoar.auth.jwt import create_access_token
+        from opensoar.models.analyst import Analyst
+
+        alert_id = sample_alert_via_api["alert_id"]
+        async with db_session_factory() as sess:
+            viewer = Analyst(
+                username=f"viewer_{uuid.uuid4().hex[:8]}",
+                display_name="Viewer",
+                email="viewer@opensoar.app",
+                password_hash="x",
+                role="viewer",
+                is_active=True,
+            )
+            sess.add(viewer)
+            await sess.commit()
+            await sess.refresh(viewer)
+            token = create_access_token(viewer.id, viewer.username)
+
+        with patch("opensoar.api.ai.get_llm_client") as mock_get:
+            mock_get.return_value = AsyncMock()
+            resp = await client.post(
+                "/api/v1/ai/recommend",
+                json={"alert_id": str(alert_id)},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            assert resp.status_code == 403
+
+    async def test_recommend_pulls_similar_alerts_by_source_ip(
+        self, client, registered_analyst, db_session_factory
+    ):
+        """Endpoint surfaces historical alerts that share source_ip into the prompt."""
+        # Seed two past alerts that share source_ip with the target alert.
+        shared_ip = "198.51.100.77"
+        resp1 = await client.post(
+            "/api/v1/webhooks/alerts",
+            json={"rule_name": "Past malicious", "severity": "high", "source_ip": shared_ip},
+        )
+        assert resp1.status_code in (200, 201)
+        resp2 = await client.post(
+            "/api/v1/webhooks/alerts",
+            json={"rule_name": "Past suspicious", "severity": "medium", "source_ip": shared_ip},
+        )
+        assert resp2.status_code in (200, 201)
+        target = await client.post(
+            "/api/v1/webhooks/alerts",
+            json={"rule_name": "Current incident", "severity": "high", "source_ip": shared_ip},
+        )
+        target_id = target.json()["alert_id"]
+
+        with patch("opensoar.api.ai.get_llm_client") as mock_get:
+            mock_client = AsyncMock()
+            mock_client.complete.return_value = LLMResponse(
+                content='{"action": "block", "confidence": 0.8, "reasoning": "repeat offender"}',
+                model="gpt-4o",
+                usage={},
+            )
+            mock_get.return_value = mock_client
+
+            resp = await client.post(
+                "/api/v1/ai/recommend",
+                json={"alert_id": str(target_id)},
+                headers=registered_analyst["headers"],
+            )
+            assert resp.status_code == 200
+
+            # The prompt passed to the LLM should include the past alerts' titles.
+            prompt_used = mock_client.complete.await_args.args[0]
+            assert "Past malicious" in prompt_used
+            assert "Past suspicious" in prompt_used
+            # The target alert's id must not appear in the similar-alerts list.
+            similar_section = prompt_used.split("Similar past alerts", 1)[1]
+            assert str(target_id) not in similar_section

--- a/tests/test_ai_recommend.py
+++ b/tests/test_ai_recommend.py
@@ -307,7 +307,7 @@ class TestRecommendEndpoint:
     ):
         """Endpoint surfaces historical alerts that share source_ip into the prompt."""
         # Seed two past alerts that share source_ip with the target alert.
-        shared_ip = "198.51.100.77"
+        shared_ip = "192.0.2.231"
         resp1 = await client.post(
             "/api/v1/webhooks/alerts",
             json={"rule_name": "Past malicious", "severity": "high", "source_ip": shared_ip},


### PR DESCRIPTION
## Summary
- New `POST /ai/recommend` endpoint that returns an `AiRecommendation` ({action, confidence, reasoning}) for an alert.
- Prompt blends the alert, its linked observables + enrichments, and similar past alerts by shared `source_ip` (top-5).
- Graceful 503 when no LLM is configured; gated on `AI_USE` permission; robust fallbacks on malformed or off-vocabulary LLM output.

## Test plan
- [x] 18 new tests in `tests/test_ai_recommend.py` (prompt shape, schema bounds, action routing, confidence parsing + clamping, missing observables, fallback, RBAC, 404, similar-alerts lookup).
- [x] `ruff check src/ tests/` clean.
- [x] Existing `test_ai.py` + `test_ai_tier2.py` still green.

Closes #83