### PR TITLE
Add tenant_id scoping to playbooks and integrations

### DIFF
--- a/migrations/versions/b8e4c1d2f5a9_add_tenant_id_to_playbooks_and_integrations.py
+++ b/migrations/versions/b8e4c1d2f5a9_add_tenant_id_to_playbooks_and_integrations.py
@@ -1,0 +1,50 @@
+"""add tenant_id to playbooks and integrations
+
+Revision ID: b8e4c1d2f5a9
+Revises: a7c9d2e1b4f6
+Create Date: 2026-04-17
+
+Adds a nullable tenant_id UUID column to playbook_definitions and
+integration_instances so optional plugins can scope these resources to a
+tenant.  A NULL value represents a globally visible resource shared across
+tenants (for example, seeded built-ins).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "b8e4c1d2f5a9"
+down_revision: Union[str, Sequence[str], None] = "a7c9d2e1b4f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "playbook_definitions",
+        sa.Column("tenant_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.add_column(
+        "integration_instances",
+        sa.Column("tenant_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_index(
+        "ix_playbook_definitions_tenant_id",
+        "playbook_definitions",
+        ["tenant_id"],
+    )
+    op.create_index(
+        "ix_integration_instances_tenant_id",
+        "integration_instances",
+        ["tenant_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_integration_instances_tenant_id", table_name="integration_instances")
+    op.drop_index("ix_playbook_definitions_tenant_id", table_name="playbook_definitions")
+    op.drop_column("integration_instances", "tenant_id")
+    op.drop_column("playbook_definitions", "tenant_id")

--- a/src/opensoar/api/integrations.py
+++ b/src/opensoar/api/integrations.py
@@ -73,6 +73,7 @@ async def create_integration(
         integration_type=data.integration_type,
         name=data.name,
         partner=data.partner,
+        tenant_id=data.tenant_id,
         config=data.config,
         enabled=data.enabled,
     )

--- a/src/opensoar/models/integration.py
+++ b/src/opensoar/models/integration.py
@@ -1,7 +1,8 @@
+import uuid
 from datetime import datetime
 
 from sqlalchemy import Boolean, DateTime, String
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from opensoar.db import Base
@@ -13,6 +14,9 @@ class IntegrationInstance(Base):
     integration_type: Mapped[str] = mapped_column(String(100))
     name: Mapped[str] = mapped_column(String(255))
     partner: Mapped[str | None] = mapped_column(String(100))
+    tenant_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), nullable=True, index=True
+    )
     config: Mapped[dict] = mapped_column(JSONB, default=dict)
     enabled: Mapped[bool] = mapped_column(Boolean, default=True)
     health_status: Mapped[str | None] = mapped_column(String(20))

--- a/src/opensoar/models/playbook.py
+++ b/src/opensoar/models/playbook.py
@@ -1,5 +1,7 @@
-from sqlalchemy import String, Text, Boolean, Integer
-from sqlalchemy.dialects.postgresql import JSONB
+import uuid
+
+from sqlalchemy import Boolean, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from opensoar.db import Base
@@ -11,6 +13,9 @@ class PlaybookDefinition(Base):
     name: Mapped[str] = mapped_column(String(255), unique=True)
     description: Mapped[str | None] = mapped_column(Text)
     partner: Mapped[str | None] = mapped_column(String(100))
+    tenant_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), nullable=True, index=True
+    )
     module_path: Mapped[str] = mapped_column(String(500))
     function_name: Mapped[str] = mapped_column(String(255))
     trigger_type: Mapped[str | None] = mapped_column(String(50))

--- a/src/opensoar/schemas/integration.py
+++ b/src/opensoar/schemas/integration.py
@@ -11,6 +11,7 @@ class IntegrationCreate(BaseModel):
     integration_type: str
     name: str
     partner: str | None = None
+    tenant_id: uuid.UUID | None = None
     config: dict[str, Any] = {}
     enabled: bool = True
 
@@ -18,6 +19,7 @@ class IntegrationCreate(BaseModel):
 class IntegrationUpdate(BaseModel):
     name: str | None = None
     partner: str | None = None
+    tenant_id: uuid.UUID | None = None
     config: dict[str, Any] | None = None
     enabled: bool | None = None
 
@@ -27,6 +29,7 @@ class IntegrationResponse(BaseModel):
     integration_type: str
     name: str
     partner: str | None = None
+    tenant_id: uuid.UUID | None = None
     enabled: bool
     health_status: str | None = None
     last_health_check: datetime | None = None

--- a/src/opensoar/schemas/playbook.py
+++ b/src/opensoar/schemas/playbook.py
@@ -12,6 +12,7 @@ class PlaybookResponse(BaseModel):
     name: str
     description: str | None = None
     partner: str | None = None
+    tenant_id: uuid.UUID | None = None
     execution_order: int
     module_path: str
     function_name: str
@@ -27,6 +28,7 @@ class PlaybookResponse(BaseModel):
 class PlaybookUpdate(BaseModel):
     enabled: bool | None = None
     partner: str | None = None
+    tenant_id: uuid.UUID | None = None
 
 
 class PlaybookRunRequest(BaseModel):

--- a/tests/test_tenant_scope_playbooks_integrations.py
+++ b/tests/test_tenant_scope_playbooks_integrations.py
@@ -1,0 +1,440 @@
+"""Tenant scoping tests for playbooks and integrations.
+
+Covers the tenant_id model field, list filtering through registered
+tenant_access_validators, enforce_tenant_access on write paths, and the
+global (tenant_id=None) escape hatch that keeps built-ins visible to every
+tenant.  Mirrors the patterns proven out for alerts/incidents/observables.
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import HTTPException
+
+from opensoar.plugins import register_tenant_access_validator
+
+
+def _swap_validators(app, *validators):
+    """Context helper that replaces the registered validators and restores them."""
+
+    class _Swap:
+        def __init__(self, app, validators):
+            self.app = app
+            self.validators = validators
+            self.previous: list = []
+
+        def __enter__(self):
+            self.previous = list(self.app.state.tenant_access_validators)
+            self.app.state.tenant_access_validators = []
+            for validator in self.validators:
+                register_tenant_access_validator(self.app, validator)
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.app.state.tenant_access_validators = self.previous
+
+    return _Swap(app, validators)
+
+
+class TestPlaybookTenantScope:
+    async def test_playbook_model_accepts_tenant_id(self, session):
+        from opensoar.models.playbook import PlaybookDefinition
+
+        tenant_id = uuid.uuid4()
+        pb = PlaybookDefinition(
+            name=f"tenant_pb_{uuid.uuid4().hex[:6]}",
+            module_path="test",
+            function_name="fn",
+            trigger_type="webhook",
+            trigger_config={},
+            enabled=True,
+            tenant_id=tenant_id,
+        )
+        session.add(pb)
+        await session.commit()
+        await session.refresh(pb)
+
+        assert pb.tenant_id == tenant_id
+
+    async def test_playbook_tenant_id_nullable_means_global(self, session):
+        from opensoar.models.playbook import PlaybookDefinition
+
+        pb = PlaybookDefinition(
+            name=f"global_pb_{uuid.uuid4().hex[:6]}",
+            module_path="test",
+            function_name="fn",
+            trigger_type="webhook",
+            trigger_config={},
+            enabled=True,
+        )
+        session.add(pb)
+        await session.commit()
+        await session.refresh(pb)
+
+        assert pb.tenant_id is None
+
+    async def test_list_filters_by_tenant_validator_but_keeps_globals(
+        self, client, db_session_factory, registered_analyst
+    ):
+        from opensoar.main import app
+        from opensoar.models.playbook import PlaybookDefinition
+
+        tenant_a = uuid.uuid4()
+        tenant_b = uuid.uuid4()
+
+        async with db_session_factory() as sess:
+            sess.add_all(
+                [
+                    PlaybookDefinition(
+                        name=f"scope_global_{uuid.uuid4().hex[:6]}",
+                        module_path="test",
+                        function_name="fn",
+                        trigger_type="webhook",
+                        trigger_config={},
+                        enabled=True,
+                    ),
+                    PlaybookDefinition(
+                        name=f"scope_a_{uuid.uuid4().hex[:6]}",
+                        module_path="test",
+                        function_name="fn",
+                        trigger_type="webhook",
+                        trigger_config={},
+                        enabled=True,
+                        tenant_id=tenant_a,
+                    ),
+                    PlaybookDefinition(
+                        name=f"scope_b_{uuid.uuid4().hex[:6]}",
+                        module_path="test",
+                        function_name="fn",
+                        trigger_type="webhook",
+                        trigger_config={},
+                        enabled=True,
+                        tenant_id=tenant_b,
+                    ),
+                ]
+            )
+            await sess.commit()
+
+        async def validator(**kwargs):
+            query = kwargs.get("query")
+            if query is not None and kwargs["resource_type"] == "playbook":
+                from sqlalchemy import or_
+
+                return query.where(
+                    or_(
+                        PlaybookDefinition.tenant_id.is_(None),
+                        PlaybookDefinition.tenant_id == tenant_a,
+                    )
+                )
+            return None
+
+        with _swap_validators(app, validator):
+            resp = await client.get(
+                "/api/v1/playbooks", headers=registered_analyst["headers"]
+            )
+
+        assert resp.status_code == 200
+        returned = {pb["name"]: pb for pb in resp.json()}
+        # Global and tenant_a rows are visible, tenant_b is filtered out.
+        assert any(n.startswith("scope_global_") for n in returned)
+        assert any(n.startswith("scope_a_") for n in returned)
+        assert not any(n.startswith("scope_b_") for n in returned)
+
+    async def test_update_rejects_cross_tenant_writes(
+        self, client, db_session_factory, registered_admin
+    ):
+        from opensoar.main import app
+        from opensoar.models.playbook import PlaybookDefinition
+
+        other_tenant = uuid.uuid4()
+
+        async with db_session_factory() as sess:
+            pb = PlaybookDefinition(
+                name=f"cross_tenant_{uuid.uuid4().hex[:6]}",
+                module_path="test",
+                function_name="fn",
+                trigger_type="webhook",
+                trigger_config={},
+                enabled=True,
+                tenant_id=other_tenant,
+            )
+            sess.add(pb)
+            await sess.commit()
+            pb_id = pb.id
+
+        async def validator(**kwargs):
+            resource = kwargs.get("resource")
+            if resource is None:
+                return None
+            tenant = getattr(resource, "tenant_id", None)
+            if tenant is not None and tenant != uuid.UUID(int=0):
+                raise HTTPException(status_code=403, detail="Tenant access denied")
+
+        with _swap_validators(app, validator):
+            resp = await client.patch(
+                f"/api/v1/playbooks/{pb_id}",
+                headers=registered_admin["headers"],
+                json={"enabled": False},
+            )
+
+        assert resp.status_code == 403
+
+    async def test_global_playbook_visible_to_other_tenants(
+        self, client, db_session_factory, registered_analyst
+    ):
+        from opensoar.main import app
+        from opensoar.models.playbook import PlaybookDefinition
+
+        async with db_session_factory() as sess:
+            pb = PlaybookDefinition(
+                name=f"builtin_{uuid.uuid4().hex[:6]}",
+                module_path="test",
+                function_name="fn",
+                trigger_type="webhook",
+                trigger_config={},
+                enabled=True,
+            )
+            sess.add(pb)
+            await sess.commit()
+            pb_id = pb.id
+            pb_name = pb.name
+
+        foreign_tenant = uuid.uuid4()
+
+        async def validator(**kwargs):
+            query = kwargs.get("query")
+            if query is not None and kwargs["resource_type"] == "playbook":
+                from sqlalchemy import or_
+
+                return query.where(
+                    or_(
+                        PlaybookDefinition.tenant_id.is_(None),
+                        PlaybookDefinition.tenant_id == foreign_tenant,
+                    )
+                )
+            resource = kwargs.get("resource")
+            if resource is not None:
+                tenant = getattr(resource, "tenant_id", None)
+                if tenant is not None and tenant != foreign_tenant:
+                    raise HTTPException(status_code=403, detail="Tenant access denied")
+
+        with _swap_validators(app, validator):
+            list_resp = await client.get(
+                "/api/v1/playbooks", headers=registered_analyst["headers"]
+            )
+            detail_resp = await client.get(
+                f"/api/v1/playbooks/{pb_id}",
+                headers=registered_analyst["headers"],
+            )
+
+        assert list_resp.status_code == 200
+        assert any(pb["name"] == pb_name for pb in list_resp.json())
+        assert detail_resp.status_code == 200
+        assert detail_resp.json()["tenant_id"] is None
+
+
+class TestIntegrationTenantScope:
+    async def test_integration_model_accepts_tenant_id(self, session):
+        from opensoar.models.integration import IntegrationInstance
+
+        tenant_id = uuid.uuid4()
+        integration = IntegrationInstance(
+            integration_type="virustotal",
+            name=f"VT {uuid.uuid4().hex[:6]}",
+            config={"api_key": "x"},
+            enabled=True,
+            tenant_id=tenant_id,
+        )
+        session.add(integration)
+        await session.commit()
+        await session.refresh(integration)
+
+        assert integration.tenant_id == tenant_id
+
+    async def test_integration_tenant_id_nullable_means_global(self, session):
+        from opensoar.models.integration import IntegrationInstance
+
+        integration = IntegrationInstance(
+            integration_type="slack",
+            name=f"Slack {uuid.uuid4().hex[:6]}",
+            config={},
+            enabled=True,
+        )
+        session.add(integration)
+        await session.commit()
+        await session.refresh(integration)
+
+        assert integration.tenant_id is None
+
+    async def test_list_filters_by_tenant_but_keeps_globals(
+        self, client, db_session_factory, registered_admin
+    ):
+        from opensoar.main import app
+        from opensoar.models.integration import IntegrationInstance
+
+        tenant_a = uuid.uuid4()
+        tenant_b = uuid.uuid4()
+
+        async with db_session_factory() as sess:
+            sess.add_all(
+                [
+                    IntegrationInstance(
+                        integration_type="slack",
+                        name=f"global_int_{uuid.uuid4().hex[:6]}",
+                        config={},
+                        enabled=True,
+                    ),
+                    IntegrationInstance(
+                        integration_type="slack",
+                        name=f"tenant_a_int_{uuid.uuid4().hex[:6]}",
+                        config={},
+                        enabled=True,
+                        tenant_id=tenant_a,
+                    ),
+                    IntegrationInstance(
+                        integration_type="slack",
+                        name=f"tenant_b_int_{uuid.uuid4().hex[:6]}",
+                        config={},
+                        enabled=True,
+                        tenant_id=tenant_b,
+                    ),
+                ]
+            )
+            await sess.commit()
+
+        async def validator(**kwargs):
+            query = kwargs.get("query")
+            if query is not None and kwargs["resource_type"] == "integration":
+                from sqlalchemy import or_
+
+                return query.where(
+                    or_(
+                        IntegrationInstance.tenant_id.is_(None),
+                        IntegrationInstance.tenant_id == tenant_a,
+                    )
+                )
+            return None
+
+        with _swap_validators(app, validator):
+            resp = await client.get(
+                "/api/v1/integrations", headers=registered_admin["headers"]
+            )
+
+        assert resp.status_code == 200
+        names = {i["name"] for i in resp.json()}
+        assert any(n.startswith("global_int_") for n in names)
+        assert any(n.startswith("tenant_a_int_") for n in names)
+        assert not any(n.startswith("tenant_b_int_") for n in names)
+
+    async def test_update_rejects_cross_tenant_writes(
+        self, client, db_session_factory, registered_admin
+    ):
+        from opensoar.main import app
+        from opensoar.models.integration import IntegrationInstance
+
+        other_tenant = uuid.uuid4()
+
+        async with db_session_factory() as sess:
+            integration = IntegrationInstance(
+                integration_type="slack",
+                name=f"other_tenant_int_{uuid.uuid4().hex[:6]}",
+                config={},
+                enabled=True,
+                tenant_id=other_tenant,
+            )
+            sess.add(integration)
+            await sess.commit()
+            integration_id = integration.id
+
+        async def validator(**kwargs):
+            resource = kwargs.get("resource")
+            if resource is None:
+                return None
+            tenant = getattr(resource, "tenant_id", None)
+            if tenant is not None:
+                raise HTTPException(status_code=403, detail="Tenant access denied")
+
+        with _swap_validators(app, validator):
+            resp = await client.patch(
+                f"/api/v1/integrations/{integration_id}",
+                headers=registered_admin["headers"],
+                json={"enabled": False},
+            )
+
+        assert resp.status_code == 403
+
+    async def test_create_respects_tenant_validator_chain(
+        self, client, registered_admin
+    ):
+        from opensoar.main import app
+
+        called: list[str] = []
+
+        async def validator(**kwargs):
+            if kwargs.get("resource") is not None:
+                called.append(kwargs["action"])
+
+        with _swap_validators(app, validator):
+            resp = await client.post(
+                "/api/v1/integrations",
+                headers=registered_admin["headers"],
+                json={
+                    "integration_type": "slack",
+                    "name": f"tenant_create_{uuid.uuid4().hex[:6]}",
+                    "config": {},
+                },
+            )
+
+        assert resp.status_code == 201
+        assert "create" in called
+
+    async def test_global_integration_visible_to_tenants(
+        self, client, db_session_factory, registered_admin
+    ):
+        from opensoar.main import app
+        from opensoar.models.integration import IntegrationInstance
+
+        async with db_session_factory() as sess:
+            integration = IntegrationInstance(
+                integration_type="slack",
+                name=f"seeded_global_{uuid.uuid4().hex[:6]}",
+                config={},
+                enabled=True,
+            )
+            sess.add(integration)
+            await sess.commit()
+            integration_id = integration.id
+            integration_name = integration.name
+
+        foreign_tenant = uuid.uuid4()
+
+        async def validator(**kwargs):
+            query = kwargs.get("query")
+            if query is not None and kwargs["resource_type"] == "integration":
+                from sqlalchemy import or_
+
+                return query.where(
+                    or_(
+                        IntegrationInstance.tenant_id.is_(None),
+                        IntegrationInstance.tenant_id == foreign_tenant,
+                    )
+                )
+            resource = kwargs.get("resource")
+            if resource is not None:
+                tenant = getattr(resource, "tenant_id", None)
+                if tenant is not None and tenant != foreign_tenant:
+                    raise HTTPException(status_code=403, detail="Tenant access denied")
+
+        with _swap_validators(app, validator):
+            list_resp = await client.get(
+                "/api/v1/integrations", headers=registered_admin["headers"]
+            )
+            detail_resp = await client.get(
+                f"/api/v1/integrations/{integration_id}",
+                headers=registered_admin["headers"],
+            )
+
+        assert list_resp.status_code == 200
+        assert any(i["name"] == integration_name for i in list_resp.json())
+        assert detail_resp.status_code == 200
+        assert detail_resp.json()["tenant_id"] is None


### PR DESCRIPTION
## Summary
- Adds a nullable `tenant_id` (UUID) column to `playbook_definitions` and `integration_instances` via a new Alembic migration, mirroring the pattern used for alerts, incidents, and observables.
- `NULL` means globally visible (shared across tenants), keeping seeded built-ins reachable from every tenant.
- List endpoints already route through `apply_tenant_access_query` and writes through `enforce_tenant_access`, so registered tenant validators can now scope playbooks/integrations the same way they do other core resources.
- Surfaces `tenant_id` on the `PlaybookResponse`, `PlaybookUpdate`, `IntegrationCreate`, `IntegrationUpdate`, and `IntegrationResponse` schemas, and persists it on integration create.

## Test plan
- [x] `pytest tests/test_tenant_scope_playbooks_integrations.py` (11 new tests: tenant CRUD on playbooks and integrations, list filtered by validator, cross-tenant write rejected, globals visible to non-owner tenants, validator chain respected on create)
- [x] `pytest tests/` — full suite passes (349 tests)
- [x] `ruff check src/ tests/`
- [x] Alembic migration round-trips (`upgrade head` -> `downgrade a7c9d2e1b4f6` -> `upgrade head`) and `alembic check` reports no drift

Closes #87