### PR TITLE
Add semantic alert deduplication via LLM embeddings

### DIFF
--- a/src/opensoar/ai/embeddings.py
+++ b/src/opensoar/ai/embeddings.py
@@ -1,0 +1,177 @@
+"""Embedding client for semantic alert deduplication (issue #81).
+
+Mirrors :mod:`opensoar.ai.client` but emits dense vectors instead of text.
+Supports three providers:
+
+- ``openai`` — POST ``/v1/embeddings`` with ``text-embedding-3-small``.
+- ``ollama`` — POST ``/api/embeddings`` against a local server.
+- ``anthropic`` — reserved for Voyage / future first-party embedding API;
+  raises ``NotImplementedError`` for now so callers degrade gracefully.
+
+Graceful degradation: :func:`get_embedding_client` returns ``None`` when no
+provider is configured. The ``/ai/deduplicate`` endpoint then returns 503,
+matching the existing ``/ai/*`` endpoints.
+"""
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from typing import Any
+
+import aiohttp
+
+from opensoar.config import settings
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OPENAI_MODEL = "text-embedding-3-small"
+DEFAULT_OLLAMA_MODEL = "nomic-embed-text"
+DEFAULT_ANTHROPIC_MODEL = "voyage-3"
+
+
+@dataclass
+class EmbeddingResponse:
+    vector: list[float]
+    model: str
+
+
+class EmbeddingClient:
+    """Unified embedding client for multiple providers."""
+
+    def __init__(
+        self,
+        provider: str,
+        model: str,
+        api_key: str = "",
+        base_url: str = "",
+    ):
+        self.provider = provider
+        self.model = model
+        self.api_key = api_key
+        self.base_url = base_url
+
+    async def embed(self, text: str) -> EmbeddingResponse:
+        """Return an embedding vector for ``text``."""
+        return await self._call_provider(text=text)
+
+    async def _call_provider(self, *, text: str) -> EmbeddingResponse:
+        if self.provider == "openai":
+            return await self._call_openai(text)
+        if self.provider == "ollama":
+            return await self._call_ollama(text)
+        if self.provider == "anthropic":
+            return await self._call_anthropic(text)
+        raise ValueError(f"Unknown embedding provider: {self.provider}")
+
+    async def _call_openai(self, text: str) -> EmbeddingResponse:
+        url = self.base_url or "https://api.openai.com"
+        body: dict[str, Any] = {"model": self.model, "input": text}
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                f"{url}/v1/embeddings",
+                json=body,
+                headers={
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                },
+            ) as resp:
+                data = await resp.json()
+                if resp.status != 200:
+                    raise RuntimeError(f"OpenAI embedding error: {data}")
+                vector = data["data"][0]["embedding"]
+                return EmbeddingResponse(
+                    vector=list(vector),
+                    model=data.get("model", self.model),
+                )
+
+    async def _call_ollama(self, text: str) -> EmbeddingResponse:
+        url = self.base_url or "http://localhost:11434"
+        body: dict[str, Any] = {"model": self.model, "prompt": text}
+        async with aiohttp.ClientSession() as session:
+            async with session.post(f"{url}/api/embeddings", json=body) as resp:
+                data = await resp.json()
+                if resp.status != 200:
+                    raise RuntimeError(f"Ollama embedding error: {data}")
+                return EmbeddingResponse(
+                    vector=list(data.get("embedding", [])),
+                    model=self.model,
+                )
+
+    async def _call_anthropic(self, text: str) -> EmbeddingResponse:
+        # Anthropic does not yet ship a first-party embeddings endpoint.
+        # Voyage AI is their recommended provider but requires a separate key.
+        raise NotImplementedError(
+            "Anthropic embeddings are not available. Use 'openai' or 'ollama'."
+        )
+
+
+def get_embedding_client() -> EmbeddingClient | None:
+    """Build an embedding client from settings, or ``None`` if nothing is set.
+
+    Resolution order:
+      1. explicit ``AI_EMBEDDING_PROVIDER`` setting, paired with matching creds
+      2. first provider with configured credentials (openai → ollama)
+    """
+    provider = (getattr(settings, "ai_embedding_provider", None) or "").lower()
+    model_override = getattr(settings, "ai_embedding_model", None)
+
+    if provider == "openai":
+        if not settings.openai_api_key:
+            return None
+        return EmbeddingClient(
+            provider="openai",
+            api_key=settings.openai_api_key,
+            model=model_override or DEFAULT_OPENAI_MODEL,
+        )
+    if provider == "ollama":
+        if not settings.ollama_url:
+            return None
+        return EmbeddingClient(
+            provider="ollama",
+            base_url=settings.ollama_url,
+            model=model_override or DEFAULT_OLLAMA_MODEL,
+        )
+    if provider == "anthropic":
+        if not settings.anthropic_api_key:
+            return None
+        return EmbeddingClient(
+            provider="anthropic",
+            api_key=settings.anthropic_api_key,
+            model=model_override or DEFAULT_ANTHROPIC_MODEL,
+        )
+
+    # Auto-detect: prefer OpenAI, then Ollama.
+    if settings.openai_api_key:
+        return EmbeddingClient(
+            provider="openai",
+            api_key=settings.openai_api_key,
+            model=model_override or DEFAULT_OPENAI_MODEL,
+        )
+    if settings.ollama_url:
+        return EmbeddingClient(
+            provider="ollama",
+            base_url=settings.ollama_url,
+            model=model_override or DEFAULT_OLLAMA_MODEL,
+        )
+    return None
+
+
+def cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Cosine similarity between two equal-length dense vectors.
+
+    Returns 0.0 for empty, mismatched-length, or zero-norm inputs so callers
+    can safely threshold without guarding every edge case.
+    """
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = 0.0
+    norm_a = 0.0
+    norm_b = 0.0
+    for x, y in zip(a, b):
+        dot += x * y
+        norm_a += x * x
+        norm_b += y * y
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot / (math.sqrt(norm_a) * math.sqrt(norm_b))

--- a/src/opensoar/api/ai_dedup.py
+++ b/src/opensoar/api/ai_dedup.py
@@ -1,0 +1,190 @@
+"""Semantic alert deduplication endpoint (issue #81).
+
+POST /ai/deduplicate accepts an ``alert_id`` and returns near-duplicate
+candidate alerts ranked by cosine similarity of their embedding vectors.
+Uses the shared Redis-backed enrichment cache (``integrations/cache.py``)
+keyed by alert id so repeated requests avoid a round-trip to the provider.
+
+Kept in its own module so it doesn't collide with the parallel PRs that
+also touch ``opensoar.api.ai`` (anomaly detection, recommendations).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from opensoar.ai.embeddings import (
+    EmbeddingClient,
+    cosine_similarity,
+    get_embedding_client,
+)
+from opensoar.api.deps import get_db
+from opensoar.auth.rbac import Permission, require_permission
+from opensoar.config import settings
+from opensoar.integrations.cache import EnrichmentCache, get_default_cache
+from opensoar.models.alert import Alert
+from opensoar.models.analyst import Analyst
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/ai", tags=["ai"])
+
+EMBEDDING_CACHE_KEY_PREFIX = "opensoar:ai_embedding:"
+# Cap how many other alerts we compare against per request. Keeps latency
+# predictable without requiring pgvector / ANN index.
+DEDUP_CORPUS_LIMIT = 500
+
+
+class DeduplicateRequest(BaseModel):
+    alert_id: str
+    threshold: float | None = Field(
+        default=None,
+        ge=-1.0,
+        le=1.0,
+        description="Override AI_DEDUP_THRESHOLD for this request.",
+    )
+    limit: int = Field(default=10, ge=1, le=50)
+
+
+def _cache_key(alert_id: str) -> str:
+    return f"{EMBEDDING_CACHE_KEY_PREFIX}{alert_id}"
+
+
+def _alert_text(alert: Alert) -> str:
+    """Build a representative text payload for embedding a single alert."""
+    parts = [
+        f"Title: {alert.title or ''}",
+        f"Severity: {alert.severity or ''}",
+        f"Rule: {alert.rule_name or ''}",
+        f"Source: {alert.source or ''}",
+        f"Hostname: {alert.hostname or ''}",
+        f"Source IP: {alert.source_ip or ''}",
+        f"Destination IP: {alert.dest_ip or ''}",
+    ]
+    if alert.description:
+        parts.append(f"Description: {alert.description}")
+    if alert.tags:
+        parts.append(f"Tags: {', '.join(alert.tags)}")
+    if alert.iocs:
+        parts.append(f"IOCs: {json.dumps(alert.iocs, default=str)}")
+    return "\n".join(p for p in parts if p.split(": ", 1)[-1])
+
+
+async def _get_or_compute_embedding(
+    alert: Alert,
+    client: EmbeddingClient,
+    cache: EnrichmentCache,
+) -> list[float]:
+    """Fetch a cached embedding for ``alert`` or compute and persist one."""
+    key = _cache_key(str(alert.id))
+    cached_raw = await cache.backend.get(key)
+    if cached_raw is not None:
+        try:
+            payload = json.loads(cached_raw)
+            vector = payload.get("vector")
+            if isinstance(vector, list) and vector:
+                return [float(v) for v in vector]
+        except (json.JSONDecodeError, TypeError, ValueError):
+            logger.warning("ai_embedding.cache_decode_failed alert_id=%s", alert.id)
+
+    text = _alert_text(alert)
+    response = await client.embed(text)
+    payload = {"vector": response.vector, "model": response.model}
+    try:
+        encoded = json.dumps(payload)
+    except (TypeError, ValueError):
+        logger.warning("ai_embedding.cache_encode_failed alert_id=%s", alert.id)
+        return list(response.vector)
+
+    ttl = getattr(settings, "ai_embedding_cache_ttl", 7 * 24 * 3600)
+    await cache.backend.set(key, encoded, ttl_seconds=int(ttl))
+    return list(response.vector)
+
+
+@router.post("/deduplicate")
+async def deduplicate_alert(
+    body: DeduplicateRequest,
+    session: AsyncSession = Depends(get_db),
+    _analyst: Analyst = Depends(require_permission(Permission.AI_USE)),
+) -> dict[str, Any]:
+    """Return near-duplicate candidate alerts for the requested alert id.
+
+    Candidates are ranked by cosine similarity of their embeddings.
+    Returns 503 if no embedding provider is configured.
+    """
+    client = get_embedding_client()
+    if client is None:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Semantic deduplication is not configured. "
+                "Set AI_EMBEDDING_PROVIDER along with OPENAI_API_KEY or OLLAMA_URL."
+            ),
+        )
+
+    try:
+        alert_uuid = uuid.UUID(body.alert_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid alert_id")
+
+    target = (
+        await session.execute(select(Alert).where(Alert.id == alert_uuid))
+    ).scalar_one_or_none()
+    if target is None:
+        raise HTTPException(status_code=404, detail="Alert not found")
+
+    cache = get_default_cache()
+    threshold = (
+        body.threshold
+        if body.threshold is not None
+        else float(getattr(settings, "ai_dedup_threshold", 0.85))
+    )
+
+    target_vector = await _get_or_compute_embedding(target, client, cache)
+
+    # Pull the most recent candidate corpus. Skip the target itself.
+    corpus_query = (
+        select(Alert)
+        .where(Alert.id != target.id)
+        .order_by(Alert.created_at.desc())
+        .limit(DEDUP_CORPUS_LIMIT)
+    )
+    corpus = (await session.execute(corpus_query)).scalars().all()
+
+    scored: list[dict[str, Any]] = []
+    for candidate in corpus:
+        try:
+            cand_vector = await _get_or_compute_embedding(candidate, client, cache)
+        except Exception:  # pragma: no cover - defensive
+            logger.exception(
+                "ai_dedup.embedding_failed alert_id=%s", candidate.id
+            )
+            continue
+        score = cosine_similarity(target_vector, cand_vector)
+        if score >= threshold:
+            scored.append(
+                {
+                    "alert_id": str(candidate.id),
+                    "similarity": round(score, 4),
+                    "title": candidate.title,
+                    "severity": candidate.severity,
+                }
+            )
+
+    scored.sort(key=lambda r: r["similarity"], reverse=True)
+    scored = scored[: body.limit]
+
+    return {
+        "alert_id": str(target.id),
+        "threshold": threshold,
+        "provider": client.provider,
+        "model": client.model,
+        "candidates": scored,
+    }

--- a/src/opensoar/config.py
+++ b/src/opensoar/config.py
@@ -32,6 +32,11 @@ class Settings(BaseSettings):
     openai_api_key: str | None = None
     ollama_url: str | None = None
     llm_model: str | None = None
+    # Semantic alert deduplication (issue #81).
+    ai_embedding_provider: str | None = None
+    ai_embedding_model: str | None = None
+    ai_dedup_threshold: float = 0.85
+    ai_embedding_cache_ttl: int = 7 * 24 * 3600  # 7 days
     debug: bool = False
 
     # Enrichment cache TTLs (seconds). See opensoar.integrations.cache.

--- a/src/opensoar/main.py
+++ b/src/opensoar/main.py
@@ -11,6 +11,7 @@ from starlette.responses import FileResponse
 from opensoar.middleware.metrics import MetricsMiddleware
 from opensoar.middleware.rate_limit import RateLimitMiddleware
 from opensoar.api.ai import router as ai_router
+from opensoar.api.ai_dedup import router as ai_dedup_router
 from opensoar.api.actions import router as actions_router
 from opensoar.api.activities import router as activities_router
 from opensoar.api.alerts import router as alerts_router
@@ -103,6 +104,7 @@ app.include_router(incidents_router, prefix="/api/v1")
 app.include_router(integrations_router, prefix="/api/v1")
 app.include_router(observables_router, prefix="/api/v1")
 app.include_router(ai_router, prefix="/api/v1")
+app.include_router(ai_dedup_router, prefix="/api/v1")
 app.include_router(actions_router, prefix="/api/v1")
 app.include_router(api_keys_router, prefix="/api/v1")
 app.include_router(dashboard_router, prefix="/api/v1")

--- a/tests/test_ai_dedup.py
+++ b/tests/test_ai_dedup.py
@@ -1,0 +1,338 @@
+"""Tests for semantic alert deduplication via LLM embeddings (issue #81)."""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from opensoar.ai.embeddings import (
+    EmbeddingClient,
+    EmbeddingResponse,
+    cosine_similarity,
+    get_embedding_client,
+)
+from opensoar.integrations.cache import InMemoryCacheBackend
+
+
+# ── Unit: cosine similarity ─────────────────────────────────────────
+
+
+class TestCosineSimilarity:
+    def test_identical_vectors_return_one(self):
+        assert cosine_similarity([1.0, 0.0, 0.0], [1.0, 0.0, 0.0]) == pytest.approx(1.0)
+
+    def test_orthogonal_vectors_return_zero(self):
+        assert cosine_similarity([1.0, 0.0], [0.0, 1.0]) == pytest.approx(0.0)
+
+    def test_opposite_vectors_return_negative_one(self):
+        assert cosine_similarity([1.0, 0.0], [-1.0, 0.0]) == pytest.approx(-1.0)
+
+    def test_empty_vectors_return_zero(self):
+        assert cosine_similarity([], []) == 0.0
+
+    def test_zero_vector_returns_zero(self):
+        assert cosine_similarity([0.0, 0.0], [1.0, 1.0]) == 0.0
+
+    def test_mismatched_length_returns_zero(self):
+        assert cosine_similarity([1.0, 0.0], [1.0, 0.0, 0.0]) == 0.0
+
+
+# ── Unit: embedding client ──────────────────────────────────────────
+
+
+class TestEmbeddingClient:
+    def test_supports_multiple_providers(self):
+        c = EmbeddingClient(provider="openai", api_key="k", model="text-embedding-3-small")
+        assert c.provider == "openai"
+        c = EmbeddingClient(provider="ollama", base_url="http://x", model="nomic-embed-text")
+        assert c.provider == "ollama"
+        c = EmbeddingClient(provider="anthropic", api_key="k", model="voyage-3")
+        assert c.provider == "anthropic"
+
+    async def test_embed_calls_provider(self):
+        c = EmbeddingClient(provider="openai", api_key="k", model="text-embedding-3-small")
+        with patch.object(
+            c,
+            "_call_provider",
+            new_callable=AsyncMock,
+            return_value=EmbeddingResponse(vector=[0.1, 0.2, 0.3], model="text-embedding-3-small"),
+        ):
+            resp = await c.embed("some text")
+            assert resp.vector == [0.1, 0.2, 0.3]
+            assert resp.model == "text-embedding-3-small"
+
+    def test_unknown_provider_raises(self):
+        c = EmbeddingClient(provider="bogus", api_key="k", model="x")
+        with pytest.raises(ValueError):
+
+            async def _call():
+                await c._call_provider(text="hello")
+
+            import asyncio
+            asyncio.get_event_loop().run_until_complete(_call())
+
+
+# ── Unit: provider factory ──────────────────────────────────────────
+
+
+class TestGetEmbeddingClient:
+    def test_none_when_no_provider(self):
+        with patch("opensoar.ai.embeddings.settings") as mock_settings:
+            mock_settings.ai_embedding_provider = None
+            mock_settings.openai_api_key = None
+            mock_settings.anthropic_api_key = None
+            mock_settings.ollama_url = None
+            assert get_embedding_client() is None
+
+    def test_openai_when_configured(self):
+        with patch("opensoar.ai.embeddings.settings") as mock_settings:
+            mock_settings.ai_embedding_provider = "openai"
+            mock_settings.openai_api_key = "sk-test"
+            mock_settings.anthropic_api_key = None
+            mock_settings.ollama_url = None
+            mock_settings.ai_embedding_model = None
+            c = get_embedding_client()
+            assert c is not None
+            assert c.provider == "openai"
+            assert c.model == "text-embedding-3-small"
+
+    def test_ollama_when_configured(self):
+        with patch("opensoar.ai.embeddings.settings") as mock_settings:
+            mock_settings.ai_embedding_provider = "ollama"
+            mock_settings.openai_api_key = None
+            mock_settings.anthropic_api_key = None
+            mock_settings.ollama_url = "http://localhost:11434"
+            mock_settings.ai_embedding_model = None
+            c = get_embedding_client()
+            assert c is not None
+            assert c.provider == "ollama"
+
+    def test_auto_detect_openai_key(self):
+        """When no explicit provider is set, fall back to first available api key."""
+        with patch("opensoar.ai.embeddings.settings") as mock_settings:
+            mock_settings.ai_embedding_provider = None
+            mock_settings.openai_api_key = "sk-test"
+            mock_settings.anthropic_api_key = None
+            mock_settings.ollama_url = None
+            mock_settings.ai_embedding_model = None
+            c = get_embedding_client()
+            assert c is not None
+            assert c.provider == "openai"
+
+
+# ── Integration: /ai/deduplicate endpoint ───────────────────────────
+
+
+@pytest.fixture
+def memory_cache_backend():
+    """Provide an in-memory cache backend for dedup tests."""
+    from opensoar.integrations.cache import EnrichmentCache
+
+    backend = InMemoryCacheBackend()
+    cache = EnrichmentCache(backend=backend)
+    with patch("opensoar.api.ai_dedup.get_default_cache", return_value=cache):
+        yield cache
+
+
+class TestDeduplicateEndpoint:
+    async def test_returns_503_when_no_provider(self, client, registered_analyst, sample_alert_via_api):
+        alert_id = sample_alert_via_api["alert_id"]
+        with patch("opensoar.api.ai_dedup.get_embedding_client", return_value=None):
+            resp = await client.post(
+                "/api/v1/ai/deduplicate",
+                json={"alert_id": str(alert_id)},
+                headers=registered_analyst["headers"],
+            )
+            assert resp.status_code == 503
+            assert "not configured" in resp.json()["detail"].lower()
+
+    async def test_returns_404_for_missing_alert(self, client, registered_analyst):
+        with patch("opensoar.api.ai_dedup.get_embedding_client") as mock_get:
+            mock_client = AsyncMock()
+            mock_client.embed.return_value = EmbeddingResponse(
+                vector=[0.1] * 8, model="text-embedding-3-small"
+            )
+            mock_get.return_value = mock_client
+            resp = await client.post(
+                "/api/v1/ai/deduplicate",
+                json={"alert_id": "00000000-0000-0000-0000-000000000000"},
+                headers=registered_analyst["headers"],
+            )
+            assert resp.status_code == 404
+
+    async def test_requires_authentication(self, client, sample_alert_via_api):
+        alert_id = sample_alert_via_api["alert_id"]
+        resp = await client.post(
+            "/api/v1/ai/deduplicate",
+            json={"alert_id": str(alert_id)},
+        )
+        assert resp.status_code == 401
+
+    async def test_empty_corpus_returns_empty_candidates(
+        self, client, registered_analyst, sample_alert_via_api, memory_cache_backend
+    ):
+        """With a high threshold and unique vectors, no corpus alert should match."""
+        alert_id = sample_alert_via_api["alert_id"]
+
+        with patch("opensoar.api.ai_dedup.get_embedding_client") as mock_get:
+            mock_client = AsyncMock()
+            call_count = {"n": 0}
+
+            async def _embed(text):
+                # Each call returns a unique orthogonal basis vector in a large
+                # space. The first alert gets [1,0,0,...,0], the second
+                # [0,1,0,...,0], etc. — so cosine similarity between any two
+                # is exactly 0.0.
+                call_count["n"] += 1
+                v = [0.0] * 64
+                v[call_count["n"] % 64] = 1.0
+                return EmbeddingResponse(vector=v, model="mock")
+
+            mock_client.embed.side_effect = _embed
+            mock_get.return_value = mock_client
+
+            resp = await client.post(
+                "/api/v1/ai/deduplicate",
+                json={"alert_id": str(alert_id), "threshold": 0.99},
+                headers=registered_analyst["headers"],
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["alert_id"] == str(alert_id)
+            assert data["candidates"] == []
+            assert data["threshold"] == 0.99
+
+    async def test_similarity_threshold_filters_candidates(
+        self,
+        client,
+        registered_analyst,
+        db_session_factory,
+        memory_cache_backend,
+    ):
+        """Only alerts with similarity >= threshold should appear."""
+        import uuid as uuidlib
+
+        from opensoar.models.alert import Alert
+
+        # Build three alerts in the DB, assigning known embeddings.
+        a_id = uuidlib.uuid4()
+        b_id = uuidlib.uuid4()  # near-duplicate
+        c_id = uuidlib.uuid4()  # far
+
+        async with db_session_factory() as sess:
+            for aid, title in [
+                (a_id, "Brute force login attempts on web-01"),
+                (b_id, "Brute force login attempts against web-01"),
+                (c_id, "Disk usage at 95% on db-server"),
+            ]:
+                sess.add(
+                    Alert(
+                        id=aid,
+                        source="webhook",
+                        source_id=str(aid),
+                        title=title,
+                        severity="high",
+                        status="new",
+                        raw_payload={"title": title},
+                        normalized={"title": title},
+                    )
+                )
+            await sess.commit()
+
+        # Prime the cache with deterministic vectors.
+        vectors = {
+            str(a_id): [1.0, 0.0, 0.0],
+            str(b_id): [0.99, 0.14, 0.0],  # cos ≈ 0.99
+            str(c_id): [0.0, 1.0, 0.0],  # cos ≈ 0.0
+        }
+        for aid, vec in vectors.items():
+            await memory_cache_backend.backend.set(
+                f"opensoar:ai_embedding:{aid}",
+                json.dumps({"vector": vec, "model": "mock"}),
+                ttl_seconds=3600,
+            )
+
+        with patch("opensoar.api.ai_dedup.get_embedding_client") as mock_get:
+            mock_client = AsyncMock()
+
+            async def _embed(text):
+                # Fallback: return something orthogonal so untouched alerts stay
+                # below threshold. Cached entries should short-circuit this.
+                return EmbeddingResponse(vector=[0.0, 0.0, 1.0], model="mock")
+
+            mock_client.embed.side_effect = _embed
+            mock_get.return_value = mock_client
+
+            resp = await client.post(
+                "/api/v1/ai/deduplicate",
+                json={"alert_id": str(a_id), "threshold": 0.9},
+                headers=registered_analyst["headers"],
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["threshold"] == 0.9
+            cand_ids = [c["alert_id"] for c in data["candidates"]]
+            assert str(b_id) in cand_ids
+            assert str(c_id) not in cand_ids
+            assert str(a_id) not in cand_ids  # don't self-match
+
+            # Each candidate has a similarity score.
+            for c in data["candidates"]:
+                assert 0.0 <= c["similarity"] <= 1.0
+
+    async def test_uses_cached_embedding_when_available(
+        self,
+        client,
+        registered_analyst,
+        db_session_factory,
+        memory_cache_backend,
+    ):
+        """A cached embedding should be reused without re-embedding the target."""
+        import uuid as uuidlib
+
+        from opensoar.models.alert import Alert
+
+        unique_title = f"CacheTest-{uuidlib.uuid4().hex[:12]}"
+        alert_id = uuidlib.uuid4()
+
+        async with db_session_factory() as sess:
+            sess.add(
+                Alert(
+                    id=alert_id,
+                    source="webhook",
+                    source_id=str(alert_id),
+                    title=unique_title,
+                    severity="high",
+                    status="new",
+                    raw_payload={"title": unique_title},
+                    normalized={"title": unique_title},
+                )
+            )
+            await sess.commit()
+
+        await memory_cache_backend.backend.set(
+            f"opensoar:ai_embedding:{alert_id}",
+            json.dumps({"vector": [0.5, 0.5, 0.5], "model": "cached-model"}),
+            ttl_seconds=3600,
+        )
+
+        embedded_texts: list[str] = []
+
+        async def _embed(text):
+            embedded_texts.append(text)
+            return EmbeddingResponse(vector=[0.0, 1.0, 0.0], model="mock")
+
+        with patch("opensoar.api.ai_dedup.get_embedding_client") as mock_get:
+            mock_client = AsyncMock()
+            mock_client.embed.side_effect = _embed
+            mock_get.return_value = mock_client
+
+            resp = await client.post(
+                "/api/v1/ai/deduplicate",
+                json={"alert_id": str(alert_id)},
+                headers=registered_analyst["headers"],
+            )
+            assert resp.status_code == 200
+            # The target's unique title never gets embedded (cache hit on id).
+            assert not any(unique_title in t for t in embedded_texts)


### PR DESCRIPTION
## Summary
- New `POST /ai/deduplicate` endpoint returns near-duplicate candidate alert ids ranked by cosine similarity of embedding vectors.
- Pluggable `EmbeddingClient` mirroring the existing `LLMClient` pattern: OpenAI (`text-embedding-3-small`), Ollama (`nomic-embed-text`), and a reserved Anthropic/Voyage slot.
- Redis-backed embedding cache reuses `opensoar.integrations.cache` keyed by alert id with a configurable TTL (default 7 days).
- Settings: `AI_EMBEDDING_PROVIDER`, `AI_EMBEDDING_MODEL`, `AI_DEDUP_THRESHOLD` (default 0.85).
- RBAC via `Permission.AI_USE`; 503 graceful degradation when no provider is configured.

## Test plan
- [x] `ruff check src/ tests/` passes
- [x] `pytest tests/test_ai.py tests/test_ai_tier2.py tests/test_ai_dedup.py` — 34 passed
- [x] Unit: cosine similarity edge cases (identical, orthogonal, zero, mismatched length)
- [x] Unit: `get_embedding_client()` provider selection + graceful `None`
- [x] Integration: 503 without provider, 404 for missing alert, 401 without auth
- [x] Integration: threshold filters out non-matching alerts and orders by similarity
- [x] Integration: cached embedding reused without re-hitting the provider

Closes #81