### PR TITLE
Wire auto-enrichment through the TTL cache (#89)

### DIFF
--- a/src/opensoar/ingestion/webhook.py
+++ b/src/opensoar/ingestion/webhook.py
@@ -16,7 +16,7 @@ async def _auto_enrich(session: AsyncSession, alert: Alert) -> None:
 
     Every failure is swallowed: enrichment is a best-effort, fire-and-forget
     side effect of ingest and must never block alert creation (issue #66).
-    The TTL-cache hook for issue #67 lives inside
+    The TTL cache hook (issue #67 / #89) lives inside
     ``opensoar.worker.enrichment.should_enrich``.
     """
     try:
@@ -27,7 +27,9 @@ async def _auto_enrich(session: AsyncSession, alert: Alert) -> None:
         new_rows = await enrichment_mod.materialise_observables_for_alert(
             session, alert
         )
-        enrichment_mod.schedule_enrichment_for_alert(alert, new_rows)
+        await enrichment_mod.schedule_enrichment_for_alert(
+            session, alert, new_rows
+        )
     except Exception:
         logger.exception(
             "Auto-enrichment failed for alert %s; ingest continuing", alert.id

--- a/src/opensoar/middleware/metrics.py
+++ b/src/opensoar/middleware/metrics.py
@@ -48,6 +48,14 @@ playbook_run_duration_seconds: Histogram = Histogram(
     registry=registry,
 )
 
+enrichment_cache_skips_total: Counter = Counter(
+    "opensoar_enrichment_cache_skips_total",
+    "Observable enrichments skipped because every configured source had a "
+    "fresh TTL cache hit.",
+    ("type",),
+    registry=registry,
+)
+
 
 def reset_metrics() -> None:
     """Clear collected samples from every OpenSOAR metric.
@@ -59,6 +67,7 @@ def reset_metrics() -> None:
         alerts_ingested_total,
         playbook_runs_total,
         playbook_run_duration_seconds,
+        enrichment_cache_skips_total,
     ):
         # prometheus_client exposes ``_metrics`` as the labelled-child store.
         metric._metrics.clear()  # noqa: SLF001 — intentional reset for tests
@@ -78,6 +87,13 @@ def record_playbook_run(playbook_name: str, status: str, duration_seconds: float
     """Record a completed playbook run (counter + histogram)."""
     playbook_runs_total.labels(playbook=playbook_name, status=status).inc()
     playbook_run_duration_seconds.labels(playbook=playbook_name).observe(duration_seconds)
+
+
+def record_enrichment_cache_skip(observable_type: str) -> None:
+    """Increment the counter for enrichment enqueues skipped due to a fresh
+    TTL cache hit across every configured source for ``observable_type``.
+    """
+    enrichment_cache_skips_total.labels(type=observable_type).inc()
 
 
 def render_metrics() -> bytes:

--- a/src/opensoar/worker/enrichment.py
+++ b/src/opensoar/worker/enrichment.py
@@ -2,14 +2,15 @@
 
 When an alert is ingested, each newly extracted observable (IP / domain /
 hash / URL) gets a fire-and-forget Celery task that dispatches to the
-configured enrichment integrations (VirusTotal, AbuseIPDB). Results are
-appended to ``Observable.enrichments`` and the ``enrichment_status``
-transitions ``pending -> complete`` (or ``failed``).
+configured enrichment integrations (VirusTotal, AbuseIPDB, GreyNoise).
+Results are appended to ``Observable.enrichments`` and the
+``enrichment_status`` transitions ``pending -> complete`` (or ``failed``).
 
 This module is intentionally decoupled from the rest of the ingest path:
 
-- ``should_enrich(observable)`` is the integration hook where issue #67's
-  TTL cache will slot in (today it always returns True).
+- ``should_enrich(session, observable, partner)`` consults the TTL
+  enrichment cache (issue #67) and returns ``False`` only when every
+  configured source for the observable's type has a fresh cache hit.
 - ``enqueue_enrichment`` is the single call-site the ingest path uses; it
   swallows all errors so enrichment problems never block alert creation.
 - ``_dispatch_enrichments`` is the pure-async worker body; it is mocked in
@@ -40,7 +41,8 @@ logger = logging.getLogger(__name__)
 # observable from being enriched twice while a previous task is still running
 # (or has just completed). Redis is used in production; in tests and when
 # Redis is unavailable we fall back to an in-memory dict so enqueue never
-# errors. The TTL is deliberately short — longer caching is issue #67's job.
+# errors. The TTL is deliberately short — longer caching lives in the
+# integration-level TTL cache (issue #67, wired in via ``should_enrich``).
 
 INFLIGHT_TTL_SECONDS = 300  # 5 minutes
 
@@ -114,35 +116,138 @@ def reset_inflight_tracker() -> None:
         pass
 
 
-# ── Public hook for issue #67 ────────────────────────────────────────────────
+# ── Source → observable-type capability map ─────────────────────────────────
+#
+# When ``should_enrich`` consults the TTL cache it has to know which configured
+# integrations would actually run for this observable's type. VirusTotal covers
+# IPs, domains, hashes and URLs; AbuseIPDB and GreyNoise are IP-only. Sources
+# not listed here are ignored by the cache-freshness check (they never affect
+# the skip decision).
+_SOURCE_TYPE_CAPABILITIES: dict[str, frozenset[str]] = {
+    "virustotal": frozenset({"ip", "domain", "hash", "url"}),
+    "abuseipdb": frozenset({"ip"}),
+    "greynoise": frozenset({"ip"}),
+}
+
+_CACHE_AWARE_SOURCES: tuple[str, ...] = tuple(_SOURCE_TYPE_CAPABILITIES.keys())
 
 
-def should_enrich(observable: Observable) -> bool:
+async def _configured_sources_for(
+    session: AsyncSession, obs_type: str, partner: str | None
+) -> list[str]:
+    """Return the integration types that are enabled for ``partner`` and that
+    handle observable type ``obs_type``. Tenant-agnostic rows (partner IS NULL)
+    are always included.
+    """
+    query = select(IntegrationInstance.integration_type).where(
+        IntegrationInstance.enabled.is_(True),
+        IntegrationInstance.integration_type.in_(_CACHE_AWARE_SOURCES),
+    )
+    if partner is not None:
+        query = query.where(
+            (IntegrationInstance.partner == partner)
+            | (IntegrationInstance.partner.is_(None))
+        )
+    else:
+        query = query.where(IntegrationInstance.partner.is_(None))
+
+    rows = (await session.execute(query)).scalars().all()
+    # Deduplicate while filtering by type capability.
+    sources: list[str] = []
+    seen: set[str] = set()
+    for source in rows:
+        if source in seen:
+            continue
+        if obs_type not in _SOURCE_TYPE_CAPABILITIES.get(source, frozenset()):
+            continue
+        seen.add(source)
+        sources.append(source)
+    return sources
+
+
+# ── Public hook: consults the TTL cache (issue #89) ─────────────────────────
+
+
+async def should_enrich(
+    session: AsyncSession,
+    observable: Observable,
+    partner: str | None = None,
+) -> bool:
     """Decide whether ``observable`` should be enriched now.
 
-    Today this always returns ``True``. Issue #67 will plug a TTL cache in
-    here (returning ``False`` when a fresh enrichment already exists for the
-    same ``(type, value)``). Keep the signature stable.
+    Returns ``False`` only when every configured enrichment source that can
+    handle this observable's type already has a fresh entry in the TTL cache.
+    Partial freshness, stale entries or missing entries all return ``True``
+    (enqueue). When no source is configured for the observable's type there
+    is nothing to cache-skip, so this also returns ``True``.
     """
-    return True
+    try:
+        sources = await _configured_sources_for(
+            session, observable.type, partner
+        )
+    except Exception:  # pragma: no cover - defensive
+        logger.exception(
+            "should_enrich: failed to query configured sources; defaulting to enqueue"
+        )
+        return True
+
+    if not sources:
+        # No configured source can cover this observable — nothing to skip.
+        return True
+
+    from opensoar.integrations.cache import get_default_cache
+
+    try:
+        cache = get_default_cache()
+    except Exception:  # pragma: no cover - defensive
+        logger.exception("should_enrich: cache unavailable; defaulting to enqueue")
+        return True
+
+    for source in sources:
+        try:
+            cached = await cache.get(source, observable.type, observable.value)
+        except Exception:  # pragma: no cover - defensive
+            logger.exception(
+                "should_enrich: cache lookup failed for %s:%s:%s; enqueue",
+                source,
+                observable.type,
+                observable.value,
+            )
+            return True
+        if cached is None:
+            # Missing or expired entry => must enqueue.
+            return True
+
+    # Every configured source had a fresh hit — safe to skip.
+    return False
 
 
 # ── Enqueue ──────────────────────────────────────────────────────────────────
 
 
-def enqueue_enrichment(observable: Observable, partner: str | None = None) -> bool:
+async def enqueue_enrichment(
+    session: AsyncSession,
+    observable: Observable,
+    partner: str | None = None,
+) -> bool:
     """Fire-and-forget dispatch of an enrichment task for ``observable``.
 
-    Returns True if a task was enqueued, False if it was suppressed (dedup or
-    hook returned False) or if the broker call failed. *Never* raises —
-    enrichment failures must never block alert ingest.
+    Returns True if a task was enqueued, False if it was suppressed (dedup,
+    cache-fresh across every configured source, or a broker failure). *Never*
+    raises — enrichment failures must never block alert ingest.
     """
-    if not should_enrich(observable):
+    if not await should_enrich(session, observable, partner):
         logger.debug(
-            "should_enrich hook declined enrichment for %s:%s",
+            "TTL cache satisfied; skipping enrichment for %s:%s",
             observable.type,
             observable.value,
         )
+        try:
+            from opensoar.middleware.metrics import record_enrichment_cache_skip
+
+            record_enrichment_cache_skip(observable.type)
+        except Exception:  # pragma: no cover - metrics must never break ingest
+            logger.exception("Failed to record enrichment cache skip metric")
         return False
 
     if not _mark_inflight(observable.type, observable.value, partner):
@@ -460,14 +565,16 @@ async def materialise_observables_for_alert(
     return new_rows
 
 
-def schedule_enrichment_for_alert(alert, observables: list[Observable]) -> None:
+async def schedule_enrichment_for_alert(
+    session: AsyncSession, alert, observables: list[Observable]
+) -> None:
     """Enqueue an enrichment task for each newly created observable.
 
     Swallows every exception so enrichment problems never block ingest.
     """
     for obs in observables:
         try:
-            enqueue_enrichment(obs, partner=alert.partner)
+            await enqueue_enrichment(session, obs, partner=alert.partner)
         except Exception:  # pragma: no cover - defensive
             logger.exception(
                 "Unexpected error while scheduling enrichment for %s", obs.id

--- a/tests/test_auto_enrichment.py
+++ b/tests/test_auto_enrichment.py
@@ -151,12 +151,18 @@ class TestDuplicateDispatchSuppression:
             f"Expected one dispatch for (ip, 10.200.200.200); got {calls}"
         )
 
-    async def test_should_enrich_hook_defaults_true(self):
-        """The ``should_enrich`` hook is the integration point for issue #67's
-        TTL cache. Today it must default to True so every new observable is
-        enriched.
+    async def test_should_enrich_hook_defaults_true(
+        self, session: AsyncSession
+    ):
+        """Without any configured integrations or cache entries the hook must
+        return True so every new observable gets enriched. Issue #89 wires the
+        TTL cache in — with nothing configured, there is nothing to skip.
         """
+        from opensoar.integrations import cache as cache_mod
         from opensoar.worker import enrichment
+
+        # Isolate the cache singleton so other tests do not bleed fresh hits in.
+        cache_mod.reset_default_cache()
 
         class _Stub:
             type = "ip"
@@ -164,7 +170,7 @@ class TestDuplicateDispatchSuppression:
             enrichments = None
             enrichment_status = "pending"
 
-        assert enrichment.should_enrich(_Stub()) is True
+        assert await enrichment.should_enrich(session, _Stub()) is True
 
 
 # ── (b) task writes enrichment + flips status ────────────────────────────────

--- a/tests/test_wire_enrich_cache.py
+++ b/tests/test_wire_enrich_cache.py
@@ -1,0 +1,285 @@
+"""Tests for wiring auto-enrichment to the TTL cache (issue #89).
+
+``should_enrich`` must consult :class:`EnrichmentCache`: it returns ``False``
+only when every configured enrichment source for the observable's type has a
+fresh cache entry. Any stale or missing source means the observable still
+needs to be enqueued. Cache-driven skips increment the Prometheus counter
+``opensoar_enrichment_cache_skips_total{type}``.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from opensoar.integrations.cache import EnrichmentCache, InMemoryCacheBackend
+from opensoar.middleware import metrics as metrics_mod
+from opensoar.models.integration import IntegrationInstance
+from opensoar.models.observable import Observable
+
+
+@pytest.fixture(autouse=True)
+async def _reset_state(db_session_factory):
+    """Reset cache singleton, metrics, in-flight tracker, and any leftover
+    integration rows so cases are isolated from the shared test DB.
+    """
+    from sqlalchemy import delete
+
+    from opensoar.integrations import cache as cache_mod
+    from opensoar.worker import enrichment
+
+    async with db_session_factory() as s:
+        await s.execute(delete(IntegrationInstance))
+        await s.commit()
+
+    cache_mod.reset_default_cache()
+    metrics_mod.reset_metrics()
+    enrichment.reset_inflight_tracker()
+    yield
+    async with db_session_factory() as s:
+        await s.execute(delete(IntegrationInstance))
+        await s.commit()
+    cache_mod.reset_default_cache()
+    metrics_mod.reset_metrics()
+    enrichment.reset_inflight_tracker()
+
+
+async def _make_cache(monkeypatch) -> EnrichmentCache:
+    """Install an isolated in-memory cache as the module-level singleton."""
+    from opensoar.integrations import cache as cache_mod
+
+    backend = InMemoryCacheBackend()
+    cache = EnrichmentCache(backend=backend)
+    monkeypatch.setattr(cache_mod, "get_default_cache", lambda: cache)
+    return cache
+
+
+async def _add_integration(
+    session: AsyncSession, integration_type: str, partner: str | None = None
+) -> IntegrationInstance:
+    instance = IntegrationInstance(
+        integration_type=integration_type,
+        name=f"{integration_type}-test",
+        partner=partner,
+        config={"api_key": "test"},
+        enabled=True,
+    )
+    session.add(instance)
+    await session.commit()
+    await session.refresh(instance)
+    return instance
+
+
+class TestShouldEnrichConsultsCache:
+    async def test_no_configured_sources_means_enqueue(
+        self, session: AsyncSession, monkeypatch
+    ):
+        """With no enabled integrations, there is nothing to cache-skip — enqueue."""
+        from opensoar.worker import enrichment
+
+        await _make_cache(monkeypatch)
+        obs = Observable(type="ip", value="203.0.113.1", source="test")
+        assert await enrichment.should_enrich(session, obs, partner=None) is True
+
+    async def test_fresh_cache_for_all_sources_skips(
+        self, session: AsyncSession, monkeypatch
+    ):
+        """If every configured source has a fresh cache entry, skip the enqueue."""
+        from opensoar.worker import enrichment
+
+        cache = await _make_cache(monkeypatch)
+        await _add_integration(session, "virustotal")
+        await _add_integration(session, "abuseipdb")
+
+        value = "203.0.113.2"
+        await cache.set("virustotal", "ip", value, {"vt": 1}, ttl_seconds=3600)
+        await cache.set("abuseipdb", "ip", value, {"abuse": 1}, ttl_seconds=3600)
+
+        obs = Observable(type="ip", value=value, source="test")
+        assert await enrichment.should_enrich(session, obs, partner=None) is False
+
+    async def test_partial_freshness_still_enqueues(
+        self, session: AsyncSession, monkeypatch
+    ):
+        """If any configured source is missing from cache, enqueue."""
+        from opensoar.worker import enrichment
+
+        cache = await _make_cache(monkeypatch)
+        await _add_integration(session, "virustotal")
+        await _add_integration(session, "abuseipdb")
+
+        value = "203.0.113.3"
+        # Only VT cached — AbuseIPDB missing => partial freshness.
+        await cache.set("virustotal", "ip", value, {"vt": 1}, ttl_seconds=3600)
+
+        obs = Observable(type="ip", value=value, source="test")
+        assert await enrichment.should_enrich(session, obs, partner=None) is True
+
+    async def test_expired_entry_enqueues(
+        self, session: AsyncSession, monkeypatch
+    ):
+        """An expired cache entry must be treated as missing and enqueue."""
+        from opensoar.worker import enrichment
+
+        cache = await _make_cache(monkeypatch)
+        await _add_integration(session, "virustotal")
+
+        value = "203.0.113.4"
+        # Force an immediately-expired entry.
+        await cache.set("virustotal", "ip", value, {"vt": 1}, ttl_seconds=0)
+        cache.backend._fast_forward(1)
+
+        obs = Observable(type="ip", value=value, source="test")
+        assert await enrichment.should_enrich(session, obs, partner=None) is True
+
+    async def test_missing_entry_enqueues(
+        self, session: AsyncSession, monkeypatch
+    ):
+        """No cache entries at all must enqueue."""
+        from opensoar.worker import enrichment
+
+        await _make_cache(monkeypatch)
+        await _add_integration(session, "virustotal")
+
+        obs = Observable(type="ip", value="203.0.113.5", source="test")
+        assert await enrichment.should_enrich(session, obs, partner=None) is True
+
+    async def test_type_scoping_ignores_sources_that_dont_handle_type(
+        self, session: AsyncSession, monkeypatch
+    ):
+        """AbuseIPDB only handles IPs — for a hash observable it must not be
+        required to have a fresh entry before skipping.
+        """
+        from opensoar.worker import enrichment
+
+        cache = await _make_cache(monkeypatch)
+        await _add_integration(session, "virustotal")
+        await _add_integration(session, "abuseipdb")
+
+        value = "d41d8cd98f00b204e9800998ecf8427e"
+        # VT handles hashes; AbuseIPDB does not. Only VT fresh => skip.
+        await cache.set("virustotal", "hash", value, {"vt": 1}, ttl_seconds=3600)
+
+        obs = Observable(type="hash", value=value, source="test")
+        assert await enrichment.should_enrich(session, obs, partner=None) is False
+
+    async def test_partner_scoping_honours_tenant(
+        self, session: AsyncSession, monkeypatch
+    ):
+        """Only integrations matching the observable's partner (or tenant-agnostic)
+        contribute to the freshness decision.
+        """
+        from opensoar.worker import enrichment
+
+        await _make_cache(monkeypatch)
+        # Another tenant's VT — must be ignored.
+        await _add_integration(session, "virustotal", partner="other-tenant")
+
+        value = "203.0.113.6"
+        obs = Observable(type="ip", value=value, source="test")
+        # No integrations are configured for this tenant, so there is nothing
+        # to cache-skip: enqueue.
+        assert await enrichment.should_enrich(session, obs, partner="acme") is True
+
+
+class TestEnqueueRespectsCache:
+    async def test_enqueue_skipped_when_cache_fresh(
+        self, session: AsyncSession, monkeypatch
+    ):
+        """When should_enrich declines, enqueue_enrichment must not call .delay()."""
+        from opensoar.worker import enrichment
+
+        cache = await _make_cache(monkeypatch)
+        await _add_integration(session, "virustotal")
+        await _add_integration(session, "abuseipdb")
+
+        value = "203.0.113.10"
+        await cache.set("virustotal", "ip", value, {"vt": 1}, ttl_seconds=3600)
+        await cache.set("abuseipdb", "ip", value, {"abuse": 1}, ttl_seconds=3600)
+
+        obs = Observable(type="ip", value=value, source="test")
+
+        with patch(
+            "opensoar.worker.enrichment.enrich_observable_task.delay"
+        ) as delay:
+            enqueued = await enrichment.enqueue_enrichment(
+                session, obs, partner=None
+            )
+            assert enqueued is False
+            delay.assert_not_called()
+
+    async def test_enqueue_proceeds_when_cache_stale(
+        self, session: AsyncSession, monkeypatch
+    ):
+        from opensoar.worker import enrichment
+
+        await _make_cache(monkeypatch)
+        await _add_integration(session, "virustotal")
+
+        obs = Observable(type="ip", value="203.0.113.11", source="test")
+
+        with patch(
+            "opensoar.worker.enrichment.enrich_observable_task.delay"
+        ) as delay:
+            enqueued = await enrichment.enqueue_enrichment(
+                session, obs, partner=None
+            )
+            assert enqueued is True
+            delay.assert_called_once()
+
+
+class TestCacheSkipMetric:
+    async def test_skip_increments_counter_with_type_label(
+        self, session: AsyncSession, monkeypatch
+    ):
+        """A cache-driven skip must bump opensoar_enrichment_cache_skips_total{type}."""
+        from opensoar.worker import enrichment
+
+        cache = await _make_cache(monkeypatch)
+        await _add_integration(session, "virustotal")
+
+        value = "203.0.113.20"
+        await cache.set("virustotal", "ip", value, {"vt": 1}, ttl_seconds=3600)
+
+        obs = Observable(type="ip", value=value, source="test")
+        with patch(
+            "opensoar.worker.enrichment.enrich_observable_task.delay"
+        ):
+            await enrichment.enqueue_enrichment(session, obs, partner=None)
+
+        text = metrics_mod.render_metrics().decode("utf-8")
+        assert "opensoar_enrichment_cache_skips_total" in text
+        assert 'opensoar_enrichment_cache_skips_total{type="ip"} 1.0' in text
+
+    async def test_enqueue_does_not_increment_skip_counter(
+        self, session: AsyncSession, monkeypatch
+    ):
+        """When enqueue proceeds, the skip counter must not tick."""
+        from opensoar.worker import enrichment
+
+        await _make_cache(monkeypatch)
+        await _add_integration(session, "virustotal")
+
+        obs = Observable(type="ip", value="203.0.113.21", source="test")
+        with patch(
+            "opensoar.worker.enrichment.enrich_observable_task.delay"
+        ):
+            await enrichment.enqueue_enrichment(session, obs, partner=None)
+
+        text = metrics_mod.render_metrics().decode("utf-8")
+        # Counter may be rendered with 0.0 or not at all depending on whether
+        # it has been exercised; either way, no ip=1.0 tick should appear.
+        assert 'opensoar_enrichment_cache_skips_total{type="ip"} 1.0' not in text
+
+
+class TestMetricsHelperExposed:
+    def test_record_enrichment_cache_skip_increments_counter(self):
+        """The helper function must be wired up against the OpenSOAR registry."""
+        metrics_mod.record_enrichment_cache_skip("ip")
+        metrics_mod.record_enrichment_cache_skip("ip")
+        metrics_mod.record_enrichment_cache_skip("domain")
+
+        text = metrics_mod.render_metrics().decode("utf-8")
+        assert 'opensoar_enrichment_cache_skips_total{type="ip"} 2.0' in text
+        assert 'opensoar_enrichment_cache_skips_total{type="domain"} 1.0' in text


### PR DESCRIPTION
## Summary
- `should_enrich(session, observable, partner)` now consults `EnrichmentCache` (issue #67). It returns `False` only when every enabled source that can handle the observable's type already has a fresh cache entry; any stale/missing entry or partial freshness still enqueues.
- Adds Prometheus counter `opensoar_enrichment_cache_skips_total{type}` (issue #62 registry) and records a tick whenever the cache short-circuits an enqueue.
- `enqueue_enrichment` and `schedule_enrichment_for_alert` are now async and take the ingest session so the cache-aware hook can query `IntegrationInstance` rows without a separate DB handle. The ingest path (`_auto_enrich`) awaits both.

## Test plan
- [x] `ruff check src/ tests/` clean
- [x] `pytest tests/` — 350 passed locally against Postgres 16 + Redis 7
- [x] New suite `tests/test_wire_enrich_cache.py` covers fresh / stale / missing / partial / type-scoped / tenant-scoped cases and asserts the metric label
- [x] Existing `test_auto_enrichment.py` updated for the async signature

Closes #89