### PR TITLE
Add data retention policies with admin purge endpoint

### DIFF
--- a/migrations/versions/b8d4e6f12a77_add_retention_archived_at.py
+++ b/migrations/versions/b8d4e6f12a77_add_retention_archived_at.py
@@ -1,0 +1,53 @@
+"""add retention archived_at columns
+
+Revision ID: b8d4e6f12a77
+Revises: a7c9d2e1b4f6
+Create Date: 2026-04-17 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b8d4e6f12a77"
+down_revision: Union[str, Sequence[str], None] = "a7c9d2e1b4f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add archived_at soft-delete columns for retention policies."""
+    op.add_column(
+        "alerts",
+        sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "incidents",
+        sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "activities",
+        sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_alerts_archived_at", "alerts", ["archived_at"], unique=False
+    )
+    op.create_index(
+        "ix_incidents_archived_at", "incidents", ["archived_at"], unique=False
+    )
+    op.create_index(
+        "ix_activities_archived_at", "activities", ["archived_at"], unique=False
+    )
+
+
+def downgrade() -> None:
+    """Drop retention archived_at columns."""
+    op.drop_index("ix_activities_archived_at", table_name="activities")
+    op.drop_index("ix_incidents_archived_at", table_name="incidents")
+    op.drop_index("ix_alerts_archived_at", table_name="alerts")
+    op.drop_column("activities", "archived_at")
+    op.drop_column("incidents", "archived_at")
+    op.drop_column("alerts", "archived_at")

--- a/src/opensoar/api/admin_retention.py
+++ b/src/opensoar/api/admin_retention.py
@@ -1,0 +1,44 @@
+"""Admin endpoints for data retention management."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from opensoar.api.deps import get_db
+from opensoar.auth.rbac import Permission, require_permission
+from opensoar.models.analyst import Analyst
+from opensoar.plugins import dispatch_audit_event
+from opensoar.retention.service import run_retention_purge
+from opensoar.schemas.audit import AuditEvent
+
+router = APIRouter(prefix="/admin/retention", tags=["admin", "retention"])
+
+
+@router.post("/purge")
+async def purge_retention(
+    request: Request,
+    dry_run: bool = True,
+    session: AsyncSession = Depends(get_db),
+    admin: Analyst = Depends(require_permission(Permission.RETENTION_MANAGE)),
+) -> dict:
+    """Soft-delete resources past their retention threshold, hard-delete those
+    past the grace period. Use ``dry_run=true`` (default) to preview counts."""
+    result = await run_retention_purge(
+        session,
+        dry_run=dry_run,
+        actor_username=admin.username,
+        actor_id=admin.id,
+    )
+
+    await dispatch_audit_event(
+        request.app,
+        AuditEvent(
+            category="admin",
+            action="retention.purge" if not dry_run else "retention.purge.dry_run",
+            actor_id=admin.id,
+            actor_username=admin.username,
+            target_type="retention",
+            metadata_json=result,
+        ),
+    )
+    return result

--- a/src/opensoar/auth/rbac.py
+++ b/src/opensoar/auth/rbac.py
@@ -40,6 +40,7 @@ class Permission(StrEnum):
     ANALYSTS_MANAGE = "analysts:manage"
     API_KEYS_MANAGE = "api_keys:manage"
     SETTINGS_MANAGE = "settings:manage"
+    RETENTION_MANAGE = "retention:manage"
 
 
 CORE_ANALYST_ROLE_LABELS: dict[str, str] = {

--- a/src/opensoar/config.py
+++ b/src/opensoar/config.py
@@ -40,6 +40,14 @@ class Settings(BaseSettings):
     enrichment_cache_ttl_abuseipdb: int = 12 * 3600
     enrichment_cache_ttl_greynoise: int = 6 * 3600
 
+    # Data retention (days). Resolved alerts / closed incidents older than these
+    # thresholds are soft-deleted (archived_at set), then hard-deleted after the
+    # configurable grace period.
+    alerts_retention_days: int = 365
+    incidents_retention_days: int = 730
+    activities_retention_days: int = 365
+    retention_grace_days: int = 30
+
     @property
     def playbook_directories(self) -> list[str]:
         return [d.strip() for d in self.playbook_dirs.split(",") if d.strip()]

--- a/src/opensoar/main.py
+++ b/src/opensoar/main.py
@@ -13,6 +13,7 @@ from opensoar.middleware.rate_limit import RateLimitMiddleware
 from opensoar.api.ai import router as ai_router
 from opensoar.api.actions import router as actions_router
 from opensoar.api.activities import router as activities_router
+from opensoar.api.admin_retention import router as admin_retention_router
 from opensoar.api.alerts import router as alerts_router
 from opensoar.api.api_keys import router as api_keys_router
 from opensoar.api.auth import router as auth_router
@@ -106,6 +107,7 @@ app.include_router(ai_router, prefix="/api/v1")
 app.include_router(actions_router, prefix="/api/v1")
 app.include_router(api_keys_router, prefix="/api/v1")
 app.include_router(dashboard_router, prefix="/api/v1")
+app.include_router(admin_retention_router, prefix="/api/v1")
 
 # ── Prometheus scrape endpoint (no /api/v1 prefix) ──────────────────
 app.include_router(metrics_router)

--- a/src/opensoar/models/activity.py
+++ b/src/opensoar/models/activity.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
 
-from sqlalchemy import ForeignKey, String, Text
+from sqlalchemy import DateTime, ForeignKey, String, Text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -25,8 +26,11 @@ class Activity(Base):
     )
     action: Mapped[str] = mapped_column(String(50))
     # e.g. "status_change", "severity_change", "comment", "playbook_triggered",
-    #      "ioc_enriched", "assigned", "closed"
+    #      "ioc_enriched", "assigned", "closed", "retention_purge"
     detail: Mapped[str | None] = mapped_column(Text)
     metadata_json: Mapped[dict | None] = mapped_column(JSONB)
     analyst_username: Mapped[str | None] = mapped_column(String(100))
     mentions: Mapped[list[str] | None] = mapped_column(JSONB)
+    archived_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), index=True
+    )

--- a/src/opensoar/models/alert.py
+++ b/src/opensoar/models/alert.py
@@ -34,3 +34,6 @@ class Alert(Base):
     )
     assigned_username: Mapped[str | None] = mapped_column(String(100))
     duplicate_count: Mapped[int] = mapped_column(default=1, server_default="1")
+    archived_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), index=True
+    )

--- a/src/opensoar/models/incident.py
+++ b/src/opensoar/models/incident.py
@@ -23,3 +23,6 @@ class Incident(Base):
     assigned_username: Mapped[str | None] = mapped_column(String(100))
     tags: Mapped[list[str] | None] = mapped_column(ARRAY(String))
     closed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    archived_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), index=True
+    )

--- a/src/opensoar/retention/__init__.py
+++ b/src/opensoar/retention/__init__.py
@@ -1,0 +1,4 @@
+"""Data retention policy enforcement."""
+from opensoar.retention.service import run_retention_purge
+
+__all__ = ["run_retention_purge"]

--- a/src/opensoar/retention/service.py
+++ b/src/opensoar/retention/service.py
@@ -1,0 +1,277 @@
+"""Data retention purge service.
+
+Two-phase deletion:
+
+1. **Soft delete** — records that exceed their retention threshold get an
+   ``archived_at`` timestamp. They remain in the database during a configurable
+   grace period for easy recovery / audit.
+2. **Hard delete** — records already archived for longer than the grace period
+   are removed from the database.
+
+Every purge writes an Activity row with action ``retention_purge`` carrying the
+per-resource counts for audit purposes.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import and_, delete, func, or_, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from opensoar.config import settings
+from opensoar.models.activity import Activity
+from opensoar.models.alert import Alert
+from opensoar.models.incident import Incident
+
+logger = logging.getLogger(__name__)
+
+RESOLVED_ALERT_STATUSES = ("resolved", "closed")
+CLOSED_INCIDENT_STATUSES = ("closed", "resolved")
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _alert_retention_cutoff() -> datetime:
+    return _now() - timedelta(days=settings.alerts_retention_days)
+
+
+def _incident_retention_cutoff() -> datetime:
+    return _now() - timedelta(days=settings.incidents_retention_days)
+
+
+def _activity_retention_cutoff() -> datetime:
+    return _now() - timedelta(days=settings.activities_retention_days)
+
+
+def _grace_cutoff() -> datetime:
+    return _now() - timedelta(days=settings.retention_grace_days)
+
+
+async def _alert_counts(session: AsyncSession) -> dict[str, int]:
+    soft_q = select(func.count(Alert.id)).where(
+        Alert.archived_at.is_(None),
+        Alert.status.in_(RESOLVED_ALERT_STATUSES),
+        or_(
+            and_(
+                Alert.resolved_at.is_not(None),
+                Alert.resolved_at < _alert_retention_cutoff(),
+            ),
+            and_(
+                Alert.resolved_at.is_(None),
+                Alert.created_at < _alert_retention_cutoff(),
+            ),
+        ),
+    )
+    hard_q = select(func.count(Alert.id)).where(
+        Alert.archived_at.is_not(None),
+        Alert.archived_at < _grace_cutoff(),
+    )
+    soft = (await session.execute(soft_q)).scalar() or 0
+    hard = (await session.execute(hard_q)).scalar() or 0
+    return {"soft_delete_candidates": soft, "hard_delete_candidates": hard}
+
+
+async def _incident_counts(session: AsyncSession) -> dict[str, int]:
+    soft_q = select(func.count(Incident.id)).where(
+        Incident.archived_at.is_(None),
+        Incident.status.in_(CLOSED_INCIDENT_STATUSES),
+        or_(
+            and_(
+                Incident.closed_at.is_not(None),
+                Incident.closed_at < _incident_retention_cutoff(),
+            ),
+            and_(
+                Incident.closed_at.is_(None),
+                Incident.created_at < _incident_retention_cutoff(),
+            ),
+        ),
+    )
+    hard_q = select(func.count(Incident.id)).where(
+        Incident.archived_at.is_not(None),
+        Incident.archived_at < _grace_cutoff(),
+    )
+    soft = (await session.execute(soft_q)).scalar() or 0
+    hard = (await session.execute(hard_q)).scalar() or 0
+    return {"soft_delete_candidates": soft, "hard_delete_candidates": hard}
+
+
+async def _activity_counts(session: AsyncSession) -> dict[str, int]:
+    soft_q = select(func.count(Activity.id)).where(
+        Activity.archived_at.is_(None),
+        Activity.created_at < _activity_retention_cutoff(),
+    )
+    hard_q = select(func.count(Activity.id)).where(
+        Activity.archived_at.is_not(None),
+        Activity.archived_at < _grace_cutoff(),
+    )
+    soft = (await session.execute(soft_q)).scalar() or 0
+    hard = (await session.execute(hard_q)).scalar() or 0
+    return {"soft_delete_candidates": soft, "hard_delete_candidates": hard}
+
+
+async def _soft_delete_alerts(session: AsyncSession, now: datetime) -> int:
+    stmt = (
+        update(Alert)
+        .where(
+            Alert.archived_at.is_(None),
+            Alert.status.in_(RESOLVED_ALERT_STATUSES),
+            or_(
+                and_(
+                    Alert.resolved_at.is_not(None),
+                    Alert.resolved_at < _alert_retention_cutoff(),
+                ),
+                and_(
+                    Alert.resolved_at.is_(None),
+                    Alert.created_at < _alert_retention_cutoff(),
+                ),
+            ),
+        )
+        .values(archived_at=now)
+    )
+    result = await session.execute(stmt)
+    return result.rowcount or 0
+
+
+async def _soft_delete_incidents(session: AsyncSession, now: datetime) -> int:
+    stmt = (
+        update(Incident)
+        .where(
+            Incident.archived_at.is_(None),
+            Incident.status.in_(CLOSED_INCIDENT_STATUSES),
+            or_(
+                and_(
+                    Incident.closed_at.is_not(None),
+                    Incident.closed_at < _incident_retention_cutoff(),
+                ),
+                and_(
+                    Incident.closed_at.is_(None),
+                    Incident.created_at < _incident_retention_cutoff(),
+                ),
+            ),
+        )
+        .values(archived_at=now)
+    )
+    result = await session.execute(stmt)
+    return result.rowcount or 0
+
+
+async def _soft_delete_activities(session: AsyncSession, now: datetime) -> int:
+    stmt = (
+        update(Activity)
+        .where(
+            Activity.archived_at.is_(None),
+            Activity.created_at < _activity_retention_cutoff(),
+            # Never archive the retention-purge audit rows themselves.
+            Activity.action != "retention_purge",
+        )
+        .values(archived_at=now)
+    )
+    result = await session.execute(stmt)
+    return result.rowcount or 0
+
+
+async def _hard_delete_alerts(session: AsyncSession) -> int:
+    stmt = delete(Alert).where(
+        Alert.archived_at.is_not(None),
+        Alert.archived_at < _grace_cutoff(),
+    )
+    result = await session.execute(stmt)
+    return result.rowcount or 0
+
+
+async def _hard_delete_incidents(session: AsyncSession) -> int:
+    stmt = delete(Incident).where(
+        Incident.archived_at.is_not(None),
+        Incident.archived_at < _grace_cutoff(),
+    )
+    result = await session.execute(stmt)
+    return result.rowcount or 0
+
+
+async def _hard_delete_activities(session: AsyncSession) -> int:
+    stmt = delete(Activity).where(
+        Activity.archived_at.is_not(None),
+        Activity.archived_at < _grace_cutoff(),
+        Activity.action != "retention_purge",
+    )
+    result = await session.execute(stmt)
+    return result.rowcount or 0
+
+
+async def run_retention_purge(
+    session: AsyncSession,
+    *,
+    dry_run: bool = True,
+    actor_username: str | None = None,
+    actor_id: Any | None = None,
+) -> dict[str, Any]:
+    """Execute the retention purge.
+
+    When ``dry_run`` is true the session is not mutated and the return value
+    contains only candidate counts. Otherwise the function soft-deletes eligible
+    records, hard-deletes records beyond the grace period, writes an audit
+    Activity row, and commits the transaction.
+    """
+    logger.info(
+        "Retention purge starting (dry_run=%s, actor=%s)", dry_run, actor_username
+    )
+
+    alert_counts = await _alert_counts(session)
+    incident_counts = await _incident_counts(session)
+    activity_counts = await _activity_counts(session)
+
+    result: dict[str, Any] = {
+        "dry_run": dry_run,
+        "grace_days": settings.retention_grace_days,
+        "alerts": dict(alert_counts),
+        "incidents": dict(incident_counts),
+        "activities": dict(activity_counts),
+    }
+
+    if dry_run:
+        return result
+
+    now = _now()
+    alerts_soft = await _soft_delete_alerts(session, now)
+    incidents_soft = await _soft_delete_incidents(session, now)
+    activities_soft = await _soft_delete_activities(session, now)
+
+    alerts_hard = await _hard_delete_alerts(session)
+    incidents_hard = await _hard_delete_incidents(session)
+    activities_hard = await _hard_delete_activities(session)
+
+    result["alerts"].update(
+        {"soft_deleted": alerts_soft, "hard_deleted": alerts_hard}
+    )
+    result["incidents"].update(
+        {"soft_deleted": incidents_soft, "hard_deleted": incidents_hard}
+    )
+    result["activities"].update(
+        {"soft_deleted": activities_soft, "hard_deleted": activities_hard}
+    )
+
+    audit = Activity(
+        action="retention_purge",
+        detail=(
+            f"Retention purge: alerts soft={alerts_soft} hard={alerts_hard}, "
+            f"incidents soft={incidents_soft} hard={incidents_hard}, "
+            f"activities soft={activities_soft} hard={activities_hard}"
+        ),
+        analyst_id=actor_id,
+        analyst_username=actor_username,
+        metadata_json={
+            "alerts": result["alerts"],
+            "incidents": result["incidents"],
+            "activities": result["activities"],
+            "grace_days": settings.retention_grace_days,
+        },
+    )
+    session.add(audit)
+    await session.commit()
+
+    logger.info("Retention purge complete: %s", result)
+    return result

--- a/src/opensoar/worker/celery_app.py
+++ b/src/opensoar/worker/celery_app.py
@@ -20,3 +20,8 @@ celery_app.conf.update(
 )
 
 celery_app.autodiscover_tasks(["opensoar.worker"])
+
+# Import task modules that are not auto-discovered by the default Celery
+# conventions (which only discover `tasks.py` per package). These imports also
+# register their Celery beat schedules on module-load.
+import opensoar.worker.retention  # noqa: E402, F401

--- a/src/opensoar/worker/retention.py
+++ b/src/opensoar/worker/retention.py
@@ -1,0 +1,66 @@
+"""Celery task + beat schedule for periodic retention enforcement."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from celery.schedules import crontab
+
+from opensoar.worker.celery_app import celery_app
+
+logger = logging.getLogger(__name__)
+
+
+def _run_async(coro):
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            import concurrent.futures
+
+            with concurrent.futures.ThreadPoolExecutor() as pool:
+                return pool.submit(asyncio.run, coro).result()
+        return loop.run_until_complete(coro)
+    except RuntimeError:
+        return asyncio.run(coro)
+
+
+async def _execute_purge(dry_run: bool) -> dict[str, Any]:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+    from opensoar.config import settings
+    from opensoar.retention.service import run_retention_purge
+
+    engine = create_async_engine(settings.database_url)
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with session_factory() as session:
+            return await run_retention_purge(
+                session, dry_run=dry_run, actor_username="celery-beat"
+            )
+    finally:
+        await engine.dispose()
+
+
+@celery_app.task(name="opensoar.purge_retention", bind=True, max_retries=2)
+def purge_retention_task(self, dry_run: bool = False) -> dict[str, Any]:
+    """Periodic task that purges records past retention thresholds."""
+    logger.info("Running retention purge (dry_run=%s)", dry_run)
+    try:
+        result = _run_async(_execute_purge(dry_run))
+        logger.info("Retention purge result: %s", result)
+        return result
+    except Exception as exc:  # pragma: no cover - retry path
+        logger.exception("Retention purge failed")
+        raise self.retry(exc=exc, countdown=2 ** self.request.retries)
+
+
+# Run daily at 03:15 UTC.
+celery_app.conf.beat_schedule = {
+    **(celery_app.conf.beat_schedule or {}),
+    "opensoar-retention-purge": {
+        "task": "opensoar.purge_retention",
+        "schedule": crontab(hour=3, minute=15),
+        "args": (False,),
+    },
+}

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -1,0 +1,229 @@
+"""Tests for data retention policy enforcement (Issue #86)."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+from opensoar.auth.rbac import Permission, has_permission
+from opensoar.config import settings
+from opensoar.models.activity import Activity
+from opensoar.models.alert import Alert
+from opensoar.models.incident import Incident
+
+
+def _past(days: int) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(days=days)
+
+
+class TestRetentionSettings:
+    def test_default_retention_values(self):
+        assert settings.alerts_retention_days == 365
+        assert settings.incidents_retention_days == 730
+        assert settings.activities_retention_days == 365
+        assert settings.retention_grace_days == 30
+
+
+class TestRetentionPermission:
+    def test_admin_has_retention_manage(self):
+        assert has_permission("admin", Permission.RETENTION_MANAGE)
+
+    def test_analyst_cannot_manage_retention(self):
+        assert not has_permission("analyst", Permission.RETENTION_MANAGE)
+
+    def test_viewer_cannot_manage_retention(self):
+        assert not has_permission("viewer", Permission.RETENTION_MANAGE)
+
+
+class TestRetentionService:
+    async def test_dry_run_returns_counts_no_mutation(self, session):
+        from opensoar.retention.service import run_retention_purge
+
+        old_alert = Alert(
+            source="webhook",
+            source_id=f"old-{uuid.uuid4().hex[:8]}",
+            title="Old resolved alert",
+            severity="low",
+            status="resolved",
+            resolved_at=_past(400),
+        )
+        recent_alert = Alert(
+            source="webhook",
+            source_id=f"recent-{uuid.uuid4().hex[:8]}",
+            title="Recent resolved alert",
+            severity="low",
+            status="resolved",
+            resolved_at=_past(10),
+        )
+        session.add_all([old_alert, recent_alert])
+        await session.commit()
+
+        result = await run_retention_purge(session, dry_run=True)
+
+        assert result["dry_run"] is True
+        assert result["alerts"]["soft_delete_candidates"] >= 1
+        # Nothing changed
+        await session.refresh(old_alert)
+        assert old_alert.archived_at is None
+
+    async def test_purge_soft_deletes_old_resolved_alerts(self, session):
+        from opensoar.retention.service import run_retention_purge
+
+        alert = Alert(
+            source="webhook",
+            source_id=f"old-{uuid.uuid4().hex[:8]}",
+            title="Stale resolved alert",
+            severity="low",
+            status="resolved",
+            resolved_at=_past(400),
+        )
+        session.add(alert)
+        await session.commit()
+
+        result = await run_retention_purge(session, dry_run=False)
+
+        assert result["dry_run"] is False
+        assert result["alerts"]["soft_deleted"] >= 1
+        await session.refresh(alert)
+        assert alert.archived_at is not None
+
+    async def test_purge_hard_deletes_after_grace(self, session):
+        from opensoar.retention.service import run_retention_purge
+
+        archived_past_grace = _past(settings.retention_grace_days + 5)
+        alert = Alert(
+            source="webhook",
+            source_id=f"purge-{uuid.uuid4().hex[:8]}",
+            title="Long-archived alert",
+            severity="low",
+            status="resolved",
+            resolved_at=_past(500),
+            archived_at=archived_past_grace,
+        )
+        session.add(alert)
+        await session.commit()
+        alert_id = alert.id
+
+        result = await run_retention_purge(session, dry_run=False)
+
+        assert result["alerts"]["hard_deleted"] >= 1
+        remaining = (
+            await session.execute(select(Alert).where(Alert.id == alert_id))
+        ).scalar_one_or_none()
+        assert remaining is None
+
+    async def test_grace_period_respected(self, session):
+        """Alerts archived within the grace period must NOT be hard-deleted."""
+        from opensoar.retention.service import run_retention_purge
+
+        recently_archived = _past(5)  # well within 30-day grace
+        alert = Alert(
+            source="webhook",
+            source_id=f"grace-{uuid.uuid4().hex[:8]}",
+            title="Archived in grace window",
+            severity="low",
+            status="resolved",
+            resolved_at=_past(500),
+            archived_at=recently_archived,
+        )
+        session.add(alert)
+        await session.commit()
+        alert_id = alert.id
+
+        await run_retention_purge(session, dry_run=False)
+
+        survivor = (
+            await session.execute(select(Alert).where(Alert.id == alert_id))
+        ).scalar_one_or_none()
+        assert survivor is not None
+        assert survivor.archived_at is not None
+
+    async def test_purge_does_not_touch_open_incidents(self, session):
+        from opensoar.retention.service import run_retention_purge
+
+        open_incident = Incident(
+            title="Open incident",
+            severity="medium",
+            status="open",
+        )
+        session.add(open_incident)
+        await session.commit()
+        incident_id = open_incident.id
+
+        await run_retention_purge(session, dry_run=False)
+
+        surviving = (
+            await session.execute(select(Incident).where(Incident.id == incident_id))
+        ).scalar_one_or_none()
+        assert surviving is not None
+        assert surviving.archived_at is None
+
+    async def test_purge_writes_audit_activity(self, session):
+        from opensoar.retention.service import run_retention_purge
+
+        alert = Alert(
+            source="webhook",
+            source_id=f"audit-{uuid.uuid4().hex[:8]}",
+            title="Audit-test alert",
+            severity="low",
+            status="resolved",
+            resolved_at=_past(500),
+        )
+        session.add(alert)
+        await session.commit()
+
+        await run_retention_purge(session, dry_run=False)
+
+        rows = (
+            await session.execute(
+                select(Activity).where(Activity.action == "retention_purge")
+            )
+        ).scalars().all()
+        assert len(rows) >= 1
+        entry = rows[-1]
+        assert entry.metadata_json is not None
+        assert "alerts" in entry.metadata_json
+
+
+class TestRetentionEndpoint:
+    async def test_non_admin_cannot_call_endpoint(self, client, registered_analyst):
+        resp = await client.post(
+            "/api/v1/admin/retention/purge?dry_run=true",
+            headers=registered_analyst["headers"],
+        )
+        assert resp.status_code == 403
+
+    async def test_unauthenticated_rejected(self, client):
+        resp = await client.post("/api/v1/admin/retention/purge?dry_run=true")
+        assert resp.status_code in {401, 403}
+
+    async def test_admin_dry_run_returns_counts(self, client, registered_admin):
+        resp = await client.post(
+            "/api/v1/admin/retention/purge?dry_run=true",
+            headers=registered_admin["headers"],
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["dry_run"] is True
+        assert "alerts" in data
+        assert "incidents" in data
+        assert "activities" in data
+
+    async def test_admin_real_purge_succeeds(self, client, registered_admin):
+        resp = await client.post(
+            "/api/v1/admin/retention/purge?dry_run=false",
+            headers=registered_admin["headers"],
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["dry_run"] is False
+
+
+@pytest.mark.asyncio
+async def test_celery_beat_task_registered():
+    from opensoar.worker.retention import purge_retention_task
+
+    assert purge_retention_task is not None
+    assert purge_retention_task.name == "opensoar.purge_retention"


### PR DESCRIPTION
## Summary
- Adds configurable retention windows (alerts 365d, incidents 730d, activities 365d) with a two-phase purge: soft-delete via `archived_at`, hard-delete after a 30-day grace window.
- New admin endpoint `POST /api/v1/admin/retention/purge?dry_run=true` gated on a new `RETENTION_MANAGE` permission (admin role only).
- Celery beat task `opensoar.purge_retention` runs daily at 03:15 UTC.
- Every real purge writes an `Activity` audit row (action=`retention_purge`) and dispatches an `AuditEvent` through the existing plugin sinks.
- Async-compatible Alembic migration adds `archived_at` columns + indexes on `alerts`, `incidents`, `activities`.

## Retention defaults
| Setting | Default |
| --- | --- |
| `alerts_retention_days` | 365 |
| `incidents_retention_days` | 730 |
| `activities_retention_days` | 365 |
| `retention_grace_days` | 30 |

## Test plan
- [x] `ruff check src/ tests/` clean
- [x] `pytest tests/test_retention.py tests/test_migrations.py tests/test_rbac.py` - 36 passed
- [x] Dry-run returns counts without mutation
- [x] Real purge soft-deletes old resolved alerts / closed incidents / stale activities
- [x] Records within the grace window are preserved
- [x] Non-admin callers receive 403
- [x] Audit Activity row written with per-resource counts

Closes #86