### PR TITLE
Add incident templates

### DIFF
--- a/migrations/versions/b8f3d2c1a9e7_add_incident_templates.py
+++ b/migrations/versions/b8f3d2c1a9e7_add_incident_templates.py
@@ -1,0 +1,121 @@
+"""add incident_templates table
+
+Revision ID: b8f3d2c1a9e7
+Revises: a7c9d2e1b4f6
+Create Date: 2026-04-17
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "b8f3d2c1a9e7"
+down_revision: Union[str, Sequence[str], None] = "a7c9d2e1b4f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "incident_templates",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column(
+            "default_severity",
+            sa.String(length=20),
+            nullable=False,
+            server_default=sa.text("'medium'"),
+        ),
+        sa.Column(
+            "default_tags",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "playbook_ids",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "observable_types",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("tenant_id", sa.Uuid(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_incident_templates"),
+    )
+    op.create_index(
+        "ix_incident_templates_tenant_id",
+        "incident_templates",
+        ["tenant_id"],
+    )
+
+    # Seed the built-in templates so fresh installs have starter coverage
+    # for the three most common incident classes.
+    op.execute(
+        """
+        INSERT INTO incident_templates
+            (name, description, default_severity, default_tags,
+             playbook_ids, observable_types, tenant_id)
+        VALUES
+            (
+                'Phishing',
+                'Email-based credential harvest or malware delivery.',
+                'high',
+                '["phishing", "email"]'::jsonb,
+                '[]'::jsonb,
+                '["email", "url", "domain", "hash"]'::jsonb,
+                NULL
+            ),
+            (
+                'Ransomware',
+                'Encryption-based destructive attack on endpoints or file shares.',
+                'critical',
+                '["ransomware", "malware", "destructive"]'::jsonb,
+                '[]'::jsonb,
+                '["hash", "ip", "domain", "hostname"]'::jsonb,
+                NULL
+            ),
+            (
+                'Data Exfiltration',
+                'Unauthorized outbound transfer of sensitive data.',
+                'high',
+                '["data-exfil", "insider-threat", "dlp"]'::jsonb,
+                '[]'::jsonb,
+                '["ip", "domain", "url", "hostname"]'::jsonb,
+                NULL
+            )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_incident_templates_tenant_id",
+        table_name="incident_templates",
+    )
+    op.drop_table("incident_templates")

--- a/src/opensoar/api/incident_templates.py
+++ b/src/opensoar/api/incident_templates.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from opensoar.api.deps import get_db
+from opensoar.auth.jwt import get_current_analyst
+from opensoar.auth.rbac import Permission, require_permission
+from opensoar.models.analyst import Analyst
+from opensoar.models.incident_template import IncidentTemplate
+from opensoar.plugins import apply_tenant_access_query, enforce_tenant_access
+from opensoar.schemas.incident_template import (
+    IncidentTemplateCreate,
+    IncidentTemplateList,
+    IncidentTemplateResponse,
+    IncidentTemplateUpdate,
+)
+
+router = APIRouter(prefix="/incident-templates", tags=["incident-templates"])
+
+
+@router.get("", response_model=IncidentTemplateList)
+async def list_incident_templates(
+    request: Request,
+    limit: int = Query(default=50, le=200),
+    offset: int = Query(default=0, ge=0),
+    session: AsyncSession = Depends(get_db),
+    analyst: Analyst | None = Depends(get_current_analyst),
+):
+    query = select(IncidentTemplate).order_by(IncidentTemplate.created_at.desc())
+    count_query = select(func.count(IncidentTemplate.id))
+
+    query = await apply_tenant_access_query(
+        request.app,
+        query=query,
+        resource_type="incident_template",
+        action="list",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
+    count_query = await apply_tenant_access_query(
+        request.app,
+        query=count_query,
+        resource_type="incident_template",
+        action="count",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
+
+    total = (await session.execute(count_query)).scalar() or 0
+    result = await session.execute(query.offset(offset).limit(limit))
+    templates = result.scalars().all()
+
+    return IncidentTemplateList(
+        templates=[IncidentTemplateResponse.model_validate(t) for t in templates],
+        total=total,
+    )
+
+
+@router.post("", response_model=IncidentTemplateResponse, status_code=201)
+async def create_incident_template(
+    data: IncidentTemplateCreate,
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+    analyst: Analyst = Depends(require_permission(Permission.SETTINGS_MANAGE)),
+):
+    template = IncidentTemplate(
+        name=data.name,
+        description=data.description,
+        default_severity=data.default_severity,
+        default_tags=list(data.default_tags),
+        playbook_ids=[str(pid) for pid in data.playbook_ids],
+        observable_types=list(data.observable_types),
+        tenant_id=data.tenant_id,
+    )
+    await enforce_tenant_access(
+        request.app,
+        resource=template,
+        resource_type="incident_template",
+        action="create",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
+    session.add(template)
+    await session.commit()
+    await session.refresh(template)
+    return IncidentTemplateResponse.model_validate(template)
+
+
+@router.get("/{template_id}", response_model=IncidentTemplateResponse)
+async def get_incident_template(
+    template_id: uuid.UUID,
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+    analyst: Analyst | None = Depends(get_current_analyst),
+):
+    template = (
+        await session.execute(
+            select(IncidentTemplate).where(IncidentTemplate.id == template_id)
+        )
+    ).scalar_one_or_none()
+    if not template:
+        raise HTTPException(status_code=404, detail="Incident template not found")
+    await enforce_tenant_access(
+        request.app,
+        resource=template,
+        resource_type="incident_template",
+        action="read",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
+    return IncidentTemplateResponse.model_validate(template)
+
+
+@router.patch("/{template_id}", response_model=IncidentTemplateResponse)
+async def update_incident_template(
+    template_id: uuid.UUID,
+    update: IncidentTemplateUpdate,
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+    analyst: Analyst = Depends(require_permission(Permission.SETTINGS_MANAGE)),
+):
+    template = (
+        await session.execute(
+            select(IncidentTemplate).where(IncidentTemplate.id == template_id)
+        )
+    ).scalar_one_or_none()
+    if not template:
+        raise HTTPException(status_code=404, detail="Incident template not found")
+    await enforce_tenant_access(
+        request.app,
+        resource=template,
+        resource_type="incident_template",
+        action="update",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
+
+    update_data = update.model_dump(exclude_unset=True)
+    if "playbook_ids" in update_data and update_data["playbook_ids"] is not None:
+        update_data["playbook_ids"] = [str(pid) for pid in update_data["playbook_ids"]]
+    for field, value in update_data.items():
+        setattr(template, field, value)
+
+    await session.commit()
+    await session.refresh(template)
+    return IncidentTemplateResponse.model_validate(template)
+
+
+@router.delete("/{template_id}")
+async def delete_incident_template(
+    template_id: uuid.UUID,
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+    analyst: Analyst = Depends(require_permission(Permission.SETTINGS_MANAGE)),
+):
+    template = (
+        await session.execute(
+            select(IncidentTemplate).where(IncidentTemplate.id == template_id)
+        )
+    ).scalar_one_or_none()
+    if not template:
+        raise HTTPException(status_code=404, detail="Incident template not found")
+    await enforce_tenant_access(
+        request.app,
+        resource=template,
+        resource_type="incident_template",
+        action="delete",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
+    await session.delete(template)
+    await session.commit()
+    return {"detail": "Incident template deleted"}

--- a/src/opensoar/api/incidents.py
+++ b/src/opensoar/api/incidents.py
@@ -19,7 +19,9 @@ from opensoar.models.alert import Alert
 from opensoar.models.analyst import Analyst
 from opensoar.models.incident import Incident
 from opensoar.models.incident_alert import IncidentAlert
+from opensoar.models.incident_template import IncidentTemplate
 from opensoar.models.observable import Observable
+from opensoar.models.playbook import PlaybookDefinition
 from opensoar.schemas.activity import (
     ActivityList,
     ActivityResponse,
@@ -202,28 +204,93 @@ async def list_incidents(
 @router.post("", response_model=IncidentResponse, status_code=201)
 async def create_incident(
     data: IncidentCreate,
+    request: Request,
     session: AsyncSession = Depends(get_db),
     analyst: Analyst = Depends(require_permission(Permission.INCIDENTS_CREATE)),
 ):
+    template: IncidentTemplate | None = None
+    if data.template_id is not None:
+        template = (
+            await session.execute(
+                select(IncidentTemplate).where(
+                    IncidentTemplate.id == data.template_id
+                )
+            )
+        ).scalar_one_or_none()
+        if template is None:
+            raise HTTPException(status_code=400, detail="Incident template not found")
+        await enforce_tenant_access(
+            request.app,
+            resource=template,
+            resource_type="incident_template",
+            action="read",
+            analyst=analyst,
+            request=request,
+            session=session,
+        )
+
+    severity = data.severity if data.severity is not None else (
+        template.default_severity if template else "medium"
+    )
+    if data.tags is not None:
+        tags = data.tags
+    elif template is not None:
+        tags = list(template.default_tags or [])
+    else:
+        tags = None
+
     incident = Incident(
         title=data.title,
         description=data.description,
-        severity=data.severity,
-        tags=data.tags,
+        severity=severity,
+        tags=tags,
     )
     session.add(incident)
     await session.flush()
+    metadata: dict = {"incident_title": incident.title}
+    if template is not None:
+        metadata["template_id"] = str(template.id)
+        metadata["template_name"] = template.name
     _append_incident_activity(
         session,
         incident_id=incident.id,
         analyst=analyst,
         action="incident_created",
         detail=_incident_activity_detail("incident_created", incident.title),
-        metadata_json={"incident_title": incident.title},
+        metadata_json=metadata,
     )
     await session.commit()
     await session.refresh(incident)
+
+    if template is not None and template.playbook_ids:
+        await _trigger_template_playbooks(session, template)
+
     return await _incident_response(session, incident)
+
+
+async def _trigger_template_playbooks(
+    session: AsyncSession, template: IncidentTemplate
+) -> None:
+    """Dispatch the playbooks listed on a template via the Celery worker."""
+    from opensoar.worker.tasks import execute_playbook_task
+
+    ids: list[uuid.UUID] = []
+    for raw in template.playbook_ids or []:
+        try:
+            ids.append(uuid.UUID(str(raw)))
+        except (ValueError, AttributeError, TypeError):
+            continue
+    if not ids:
+        return
+    result = await session.execute(
+        select(PlaybookDefinition).where(PlaybookDefinition.id.in_(ids))
+    )
+    playbooks = {pb.id: pb for pb in result.scalars().all()}
+    for pid in ids:
+        pb = playbooks.get(pid)
+        if pb is None:
+            continue
+        execute_playbook_task.delay(pb.name, None)
 
 
 @router.get("/{incident_id}", response_model=IncidentResponse)

--- a/src/opensoar/main.py
+++ b/src/opensoar/main.py
@@ -18,6 +18,7 @@ from opensoar.api.api_keys import router as api_keys_router
 from opensoar.api.auth import router as auth_router
 from opensoar.api.dashboard import router as dashboard_router
 from opensoar.api.health import router as health_router
+from opensoar.api.incident_templates import router as incident_templates_router
 from opensoar.api.incidents import router as incidents_router
 from opensoar.api.integrations import router as integrations_router
 from opensoar.api.metrics import router as metrics_router
@@ -100,6 +101,7 @@ app.include_router(activities_router, prefix="/api/v1")
 app.include_router(playbooks_router, prefix="/api/v1")
 app.include_router(runs_router, prefix="/api/v1")
 app.include_router(incidents_router, prefix="/api/v1")
+app.include_router(incident_templates_router, prefix="/api/v1")
 app.include_router(integrations_router, prefix="/api/v1")
 app.include_router(observables_router, prefix="/api/v1")
 app.include_router(ai_router, prefix="/api/v1")

--- a/src/opensoar/models/__init__.py
+++ b/src/opensoar/models/__init__.py
@@ -6,6 +6,7 @@ from opensoar.models.analyst_identity import AnalystIdentity
 from opensoar.models.api_key import ApiKey
 from opensoar.models.incident import Incident
 from opensoar.models.incident_alert import IncidentAlert
+from opensoar.models.incident_template import IncidentTemplate
 from opensoar.models.integration import IntegrationInstance
 from opensoar.models.observable import Observable
 from opensoar.models.playbook import PlaybookDefinition
@@ -20,6 +21,7 @@ __all__ = [
     "ApiKey",
     "Incident",
     "IncidentAlert",
+    "IncidentTemplate",
     "IntegrationInstance",
     "Observable",
     "PlaybookDefinition",

--- a/src/opensoar/models/incident_template.py
+++ b/src/opensoar/models/incident_template.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import String, Text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from opensoar.db import Base
+
+
+class IncidentTemplate(Base):
+    """Reusable incident template applied at incident creation.
+
+    The template captures the defaults a responder would otherwise have to
+    re-enter for each incident of a given type (severity, tags, IOC extraction
+    targets) and lists playbooks that should auto-run when an incident is
+    created from the template.  Templates can be global (``tenant_id`` NULL)
+    or tenant-scoped; enforcement goes through the standard tenant-access
+    validator chain in :mod:`opensoar.plugins`.
+    """
+
+    __tablename__ = "incident_templates"
+
+    name: Mapped[str] = mapped_column(String(255))
+    description: Mapped[str | None] = mapped_column(Text)
+    default_severity: Mapped[str] = mapped_column(String(20), default="medium")
+    default_tags: Mapped[list[str]] = mapped_column(JSONB, default=list)
+    playbook_ids: Mapped[list[str]] = mapped_column(JSONB, default=list)
+    observable_types: Mapped[list[str]] = mapped_column(JSONB, default=list)
+    tenant_id: Mapped[uuid.UUID | None] = mapped_column(nullable=True, index=True)

--- a/src/opensoar/schemas/incident.py
+++ b/src/opensoar/schemas/incident.py
@@ -9,8 +9,9 @@ from pydantic import BaseModel
 class IncidentCreate(BaseModel):
     title: str
     description: str | None = None
-    severity: str = "medium"
+    severity: str | None = None
     tags: list[str] | None = None
+    template_id: uuid.UUID | None = None
 
 
 class IncidentUpdate(BaseModel):

--- a/src/opensoar/schemas/incident_template.py
+++ b/src/opensoar/schemas/incident_template.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class IncidentTemplateBase(BaseModel):
+    name: str
+    description: str | None = None
+    default_severity: str = "medium"
+    default_tags: list[str] = Field(default_factory=list)
+    playbook_ids: list[str] = Field(default_factory=list)
+    observable_types: list[str] = Field(default_factory=list)
+
+
+class IncidentTemplateCreate(IncidentTemplateBase):
+    tenant_id: uuid.UUID | None = None
+
+
+class IncidentTemplateUpdate(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    default_severity: str | None = None
+    default_tags: list[str] | None = None
+    playbook_ids: list[str] | None = None
+    observable_types: list[str] | None = None
+    tenant_id: uuid.UUID | None = None
+
+
+class IncidentTemplateResponse(IncidentTemplateBase):
+    id: uuid.UUID
+    tenant_id: uuid.UUID | None = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class IncidentTemplateList(BaseModel):
+    templates: list[IncidentTemplateResponse]
+    total: int

--- a/src/opensoar/seed_templates.py
+++ b/src/opensoar/seed_templates.py
@@ -1,0 +1,37 @@
+"""Built-in incident templates shipped with OpenSOAR.
+
+These seed values are written into the database by the Alembic migration
+``b8f3d2c1a9e7_add_incident_templates`` so fresh installs have starter
+coverage for the three most common incident classes.  Exposed as plain
+Python so tests and the UI can introspect the same source of truth.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+SEED_INCIDENT_TEMPLATES: list[dict[str, Any]] = [
+    {
+        "name": "Phishing",
+        "description": "Email-based credential harvest or malware delivery.",
+        "default_severity": "high",
+        "default_tags": ["phishing", "email"],
+        "playbook_ids": [],
+        "observable_types": ["email", "url", "domain", "hash"],
+    },
+    {
+        "name": "Ransomware",
+        "description": "Encryption-based destructive attack on endpoints or file shares.",
+        "default_severity": "critical",
+        "default_tags": ["ransomware", "malware", "destructive"],
+        "playbook_ids": [],
+        "observable_types": ["hash", "ip", "domain", "hostname"],
+    },
+    {
+        "name": "Data Exfiltration",
+        "description": "Unauthorized outbound transfer of sensitive data.",
+        "default_severity": "high",
+        "default_tags": ["data-exfil", "insider-threat", "dlp"],
+        "playbook_ids": [],
+        "observable_types": ["ip", "domain", "url", "hostname"],
+    },
+]

--- a/tests/test_incident_templates_api.py
+++ b/tests/test_incident_templates_api.py
@@ -1,0 +1,326 @@
+"""Tests for incident templates and template-driven incident creation."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+from fastapi import HTTPException
+
+from opensoar.plugins import register_tenant_access_validator
+
+
+async def _create_template(client, headers, **overrides) -> dict:
+    body = {
+        "name": f"tmpl-{uuid.uuid4().hex[:8]}",
+        "description": "Template for phishing incidents",
+        "default_severity": "high",
+        "default_tags": ["phishing", "email"],
+        "playbook_ids": [],
+        "observable_types": ["email", "url", "domain"],
+    }
+    body.update(overrides)
+    resp = await client.post(
+        "/api/v1/incident-templates",
+        json=body,
+        headers=headers,
+    )
+    return resp
+
+
+class TestIncidentTemplateCRUD:
+    async def test_create_template(self, client, registered_admin):
+        resp = await _create_template(
+            client,
+            registered_admin["headers"],
+            name="Phishing Response",
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["name"] == "Phishing Response"
+        assert data["default_severity"] == "high"
+        assert data["default_tags"] == ["phishing", "email"]
+        assert data["observable_types"] == ["email", "url", "domain"]
+        assert data["playbook_ids"] == []
+        assert "id" in data and "created_at" in data
+
+    async def test_create_template_requires_admin(self, client, registered_analyst):
+        resp = await _create_template(client, registered_analyst["headers"])
+        # analyst role lacks SETTINGS_MANAGE permission
+        assert resp.status_code == 403
+
+    async def test_create_template_requires_auth(self, client):
+        resp = await client.post(
+            "/api/v1/incident-templates",
+            json={"name": "unauth", "default_severity": "low"},
+        )
+        assert resp.status_code == 401
+
+    async def test_list_templates(self, client, registered_admin):
+        await _create_template(client, registered_admin["headers"], name="A Template")
+        await _create_template(client, registered_admin["headers"], name="B Template")
+        resp = await client.get(
+            "/api/v1/incident-templates",
+            headers=registered_admin["headers"],
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] >= 2
+        names = {t["name"] for t in data["templates"]}
+        assert {"A Template", "B Template"}.issubset(names)
+
+    async def test_get_template(self, client, registered_admin):
+        create = await _create_template(
+            client, registered_admin["headers"], name="Get Target"
+        )
+        template_id = create.json()["id"]
+        resp = await client.get(
+            f"/api/v1/incident-templates/{template_id}",
+            headers=registered_admin["headers"],
+        )
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Get Target"
+
+    async def test_get_nonexistent_template(self, client, registered_admin):
+        resp = await client.get(
+            f"/api/v1/incident-templates/{uuid.uuid4()}",
+            headers=registered_admin["headers"],
+        )
+        assert resp.status_code == 404
+
+    async def test_update_template(self, client, registered_admin):
+        create = await _create_template(
+            client, registered_admin["headers"], name="Edit Me"
+        )
+        template_id = create.json()["id"]
+        resp = await client.patch(
+            f"/api/v1/incident-templates/{template_id}",
+            json={
+                "description": "Updated desc",
+                "default_severity": "critical",
+                "default_tags": ["phishing", "credential-harvest"],
+            },
+            headers=registered_admin["headers"],
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["description"] == "Updated desc"
+        assert data["default_severity"] == "critical"
+        assert data["default_tags"] == ["phishing", "credential-harvest"]
+
+    async def test_delete_template(self, client, registered_admin):
+        create = await _create_template(
+            client, registered_admin["headers"], name="To Delete"
+        )
+        template_id = create.json()["id"]
+        resp = await client.delete(
+            f"/api/v1/incident-templates/{template_id}",
+            headers=registered_admin["headers"],
+        )
+        assert resp.status_code == 200
+
+        resp = await client.get(
+            f"/api/v1/incident-templates/{template_id}",
+            headers=registered_admin["headers"],
+        )
+        assert resp.status_code == 404
+
+
+class TestIncidentTemplateTenantScoping:
+    async def test_tenant_validator_filters_list(self, client, registered_admin):
+        from opensoar.main import app
+        from opensoar.models.incident_template import IncidentTemplate
+
+        await _create_template(
+            client, registered_admin["headers"], name="Scoped Template"
+        )
+        await _create_template(
+            client, registered_admin["headers"], name="Blocked Template"
+        )
+
+        async def validator(**kwargs):
+            query = kwargs.get("query")
+            if query is not None and kwargs["resource_type"] == "incident_template":
+                return query.where(IncidentTemplate.name == "Scoped Template")
+            return None
+
+        original = list(app.state.tenant_access_validators)
+        app.state.tenant_access_validators = []
+        register_tenant_access_validator(app, validator)
+        try:
+            resp = await client.get(
+                "/api/v1/incident-templates",
+                headers=registered_admin["headers"],
+            )
+        finally:
+            app.state.tenant_access_validators = original
+
+        assert resp.status_code == 200
+        names = {t["name"] for t in resp.json()["templates"]}
+        assert names == {"Scoped Template"}
+
+    async def test_tenant_validator_blocks_detail_and_update(
+        self, client, registered_admin
+    ):
+        from opensoar.main import app
+
+        create = await _create_template(
+            client, registered_admin["headers"], name="Blocked Detail Tmpl"
+        )
+        template_id = create.json()["id"]
+
+        async def validator(**kwargs):
+            resource = kwargs.get("resource")
+            if resource is not None and getattr(resource, "name", "").startswith(
+                "Blocked"
+            ):
+                raise HTTPException(status_code=403, detail="Tenant access denied")
+
+        original = list(app.state.tenant_access_validators)
+        app.state.tenant_access_validators = []
+        register_tenant_access_validator(app, validator)
+        try:
+            detail = await client.get(
+                f"/api/v1/incident-templates/{template_id}",
+                headers=registered_admin["headers"],
+            )
+            update = await client.patch(
+                f"/api/v1/incident-templates/{template_id}",
+                json={"default_severity": "critical"},
+                headers=registered_admin["headers"],
+            )
+            delete = await client.delete(
+                f"/api/v1/incident-templates/{template_id}",
+                headers=registered_admin["headers"],
+            )
+        finally:
+            app.state.tenant_access_validators = original
+
+        assert detail.status_code == 403
+        assert update.status_code == 403
+        assert delete.status_code == 403
+
+
+class TestCreateIncidentFromTemplate:
+    async def test_create_incident_applies_template_defaults(
+        self, client, registered_admin, registered_analyst
+    ):
+        create = await _create_template(
+            client,
+            registered_admin["headers"],
+            name="Phishing Defaults",
+            default_severity="critical",
+            default_tags=["phishing", "email"],
+        )
+        template_id = create.json()["id"]
+
+        resp = await client.post(
+            "/api/v1/incidents",
+            json={
+                "title": "Phish on finance team",
+                "template_id": template_id,
+            },
+            headers=registered_analyst["headers"],
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["severity"] == "critical"
+        assert set(data["tags"] or []) == {"phishing", "email"}
+
+    async def test_explicit_fields_override_template_defaults(
+        self, client, registered_admin, registered_analyst
+    ):
+        create = await _create_template(
+            client,
+            registered_admin["headers"],
+            name="Override Defaults",
+            default_severity="low",
+            default_tags=["phishing"],
+        )
+        template_id = create.json()["id"]
+
+        resp = await client.post(
+            "/api/v1/incidents",
+            json={
+                "title": "Override me",
+                "template_id": template_id,
+                "severity": "high",
+                "tags": ["custom"],
+            },
+            headers=registered_analyst["headers"],
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["severity"] == "high"
+        assert data["tags"] == ["custom"]
+
+    async def test_template_not_found_returns_400(
+        self, client, registered_analyst
+    ):
+        resp = await client.post(
+            "/api/v1/incidents",
+            json={
+                "title": "Bad template",
+                "template_id": str(uuid.uuid4()),
+            },
+            headers=registered_analyst["headers"],
+        )
+        assert resp.status_code == 400
+
+    async def test_template_auto_runs_listed_playbooks(
+        self, client, registered_admin, registered_analyst, session
+    ):
+        """When creating from a template with playbook_ids, those playbooks run."""
+        from opensoar.models.playbook import PlaybookDefinition
+
+        pb = PlaybookDefinition(
+            name=f"pb_{uuid.uuid4().hex[:8]}",
+            module_path="playbooks.examples.noop",
+            function_name="noop",
+            enabled=True,
+        )
+        session.add(pb)
+        await session.commit()
+        await session.refresh(pb)
+
+        create = await _create_template(
+            client,
+            registered_admin["headers"],
+            name="Runs Playbooks",
+            playbook_ids=[str(pb.id)],
+        )
+        template_id = create.json()["id"]
+
+        delayed = []
+
+        def fake_delay(playbook_name, alert_id=None):
+            delayed.append((playbook_name, alert_id))
+            task = MagicMock()
+            task.id = "task-123"
+            return task
+
+        with patch(
+            "opensoar.worker.tasks.execute_playbook_task.delay",
+            side_effect=fake_delay,
+        ):
+            resp = await client.post(
+                "/api/v1/incidents",
+                json={
+                    "title": "Template run",
+                    "template_id": template_id,
+                },
+                headers=registered_analyst["headers"],
+            )
+        assert resp.status_code == 201
+        assert [name for name, _ in delayed] == [pb.name]
+
+
+class TestIncidentTemplateSeed:
+    async def test_seed_templates_loadable(self):
+        from opensoar.seed_templates import SEED_INCIDENT_TEMPLATES
+
+        names = {t["name"] for t in SEED_INCIDENT_TEMPLATES}
+        assert {"Phishing", "Ransomware", "Data Exfiltration"}.issubset(names)
+        for tmpl in SEED_INCIDENT_TEMPLATES:
+            assert tmpl["default_severity"] in {"low", "medium", "high", "critical"}
+            assert isinstance(tmpl["default_tags"], list)
+            assert isinstance(tmpl["observable_types"], list)

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -425,6 +425,24 @@ export interface Observable {
   created_at: string
 }
 
+export interface IncidentTemplate {
+  id: string
+  name: string
+  description: string | null
+  default_severity: string
+  default_tags: string[]
+  playbook_ids: string[]
+  observable_types: string[]
+  tenant_id: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface IncidentTemplateList {
+  templates: IncidentTemplate[]
+  total: number
+}
+
 export interface IncidentSuggestion {
   source_ip: string
   alert_count: number
@@ -581,8 +599,13 @@ export const api = {
       return fetchJSON<{ incidents: Incident2[]; total: number }>(`/incidents${q ? `?${q}` : ''}`)
     },
     get: (id: string) => fetchJSON<Incident2>(`/incidents/${id}`),
-    create: (data: { title: string; severity?: string; description?: string }) =>
-      postJSON<Incident2>('/incidents', data),
+    create: (data: {
+      title: string
+      severity?: string
+      description?: string
+      template_id?: string
+      tags?: string[]
+    }) => postJSON<Incident2>('/incidents', data as Record<string, unknown>),
     update: (id: string, data: Record<string, unknown>) =>
       patchJSON<Incident2>(`/incidents/${id}`, data),
     alerts: (id: string) => fetchJSON<Alert[]>(`/incidents/${id}/alerts`),
@@ -607,6 +630,22 @@ export const api = {
     unlinkAlert: (id: string, alertId: string) =>
       deleteJSON(`/incidents/${id}/alerts/${alertId}`),
     suggestions: () => fetchJSON<IncidentSuggestion[]>('/incidents/suggestions'),
+  },
+  incidentTemplates: {
+    list: () => fetchJSON<IncidentTemplateList>('/incident-templates'),
+    get: (id: string) => fetchJSON<IncidentTemplate>(`/incident-templates/${id}`),
+    create: (data: {
+      name: string
+      description?: string
+      default_severity?: string
+      default_tags?: string[]
+      playbook_ids?: string[]
+      observable_types?: string[]
+      tenant_id?: string | null
+    }) => postJSON<IncidentTemplate>('/incident-templates', data as Record<string, unknown>),
+    update: (id: string, data: Record<string, unknown>) =>
+      patchJSON<IncidentTemplate>(`/incident-templates/${id}`, data),
+    remove: (id: string) => deleteJSON(`/incident-templates/${id}`),
   },
   observables: {
     list: (params?: { type?: string; limit?: number; offset?: number }) => {

--- a/ui/src/pages/IncidentsListPage.tsx
+++ b/ui/src/pages/IncidentsListPage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from 'react-router'
 import { Briefcase, Clock, UserCheck, Plus, Link2, Globe } from 'lucide-react'
-import { api, type IncidentSuggestion } from '@/api'
+import { api, type IncidentSuggestion, type IncidentTemplate } from '@/api'
 import { PageHeader } from '@/components/ui/PageHeader'
 import { SeverityBadge, StatusBadge } from '@/components/ui/Badge'
 import { Button } from '@/components/ui/Button'
@@ -26,7 +26,29 @@ function CreateIncidentDialog({ open, onClose }: { open: boolean; onClose: () =>
     title: '',
     severity: 'medium',
     description: '',
+    templateId: '',
   })
+
+  const { data: templatesData } = useQuery({
+    queryKey: ['incident-templates'],
+    queryFn: () => api.incidentTemplates.list(),
+    enabled: open,
+  })
+  const templates: IncidentTemplate[] = templatesData?.templates ?? []
+
+  const applyTemplate = (templateId: string) => {
+    if (!templateId) {
+      setForm((f) => ({ ...f, templateId: '' }))
+      return
+    }
+    const tmpl = templates.find((t) => t.id === templateId)
+    if (!tmpl) return
+    setForm((f) => ({
+      ...f,
+      templateId,
+      severity: tmpl.default_severity || f.severity,
+    }))
+  }
 
   const createMutation = useMutation({
     mutationFn: () =>
@@ -34,12 +56,13 @@ function CreateIncidentDialog({ open, onClose }: { open: boolean; onClose: () =>
         title: form.title,
         severity: form.severity,
         description: form.description || undefined,
+        template_id: form.templateId || undefined,
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['incidents'] })
       toast.success('Incident created')
       onClose()
-      setForm({ title: '', severity: 'medium', description: '' })
+      setForm({ title: '', severity: 'medium', description: '', templateId: '' })
     },
     onError: (err) => {
       toast.error('Failed to create incident', err instanceof Error ? err.message : 'Unknown error')
@@ -53,6 +76,18 @@ function CreateIncidentDialog({ open, onClose }: { open: boolean; onClose: () =>
           <DialogTitle>Create Incident</DialogTitle>
         </DialogHeader>
         <DialogBody className="space-y-4">
+          <div>
+            <Label>Template</Label>
+            <Select
+              value={form.templateId}
+              onChange={(v) => applyTemplate(v)}
+              options={[
+                { value: '', label: 'No template' },
+                ...templates.map((t) => ({ value: t.id, label: t.name })),
+              ]}
+              className="w-full"
+            />
+          </div>
           <div>
             <Label>Title</Label>
             <Input


### PR DESCRIPTION
## Summary
- New `IncidentTemplate` model, Alembic migration, and tenant-scoped CRUD at `/api/v1/incident-templates` using the existing `enforce_tenant_access` / `apply_tenant_access_query` pattern.
- `POST /api/v1/incidents` accepts an optional `template_id` that applies severity and tag defaults (explicit fields win) and dispatches the template's playbooks via Celery.
- Migration seeds three starter templates: Phishing, Ransomware, Data Exfiltration (also exported from `opensoar.seed_templates`).
- UI incident create dialog gains a template picker that pre-fills severity.

## Test plan
- [x] `pytest tests/test_incident_templates_api.py` (15 tests covering CRUD, tenant isolation, template-apply, seed data)
- [x] `pytest tests/test_migrations.py` (model/migration in sync)
- [x] `ruff check src/ tests/`
- [x] `tsc -b` in `ui/` and `vitest run` (58/58 passing)

Closes #88