### PR TITLE
Anomaly detection on alert patterns

### DIFF
--- a/migrations/versions/b9f28c61a4d3_add_anomalies_table.py
+++ b/migrations/versions/b9f28c61a4d3_add_anomalies_table.py
@@ -1,0 +1,60 @@
+"""add anomalies table
+
+Revision ID: b9f28c61a4d3
+Revises: a7c9d2e1b4f6
+Create Date: 2026-04-17
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "b9f28c61a4d3"
+down_revision: Union[str, Sequence[str], None] = "569afa72352c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "anomalies",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("kind", sa.String(50), nullable=False),
+        sa.Column("partner", sa.String(100), nullable=True),
+        sa.Column("rule_name", sa.String(500), nullable=True),
+        sa.Column("source_ip", sa.String(45), nullable=True),
+        sa.Column("score", sa.Float(), nullable=False, server_default="0"),
+        sa.Column("details", JSONB(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_anomalies"),
+    )
+    op.create_index("ix_anomalies_kind", "anomalies", ["kind"])
+    op.create_index("ix_anomalies_partner", "anomalies", ["partner"])
+    op.create_index("ix_anomalies_rule_name", "anomalies", ["rule_name"])
+    op.create_index("ix_anomalies_created_at", "anomalies", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_anomalies_created_at", table_name="anomalies")
+    op.drop_index("ix_anomalies_rule_name", table_name="anomalies")
+    op.drop_index("ix_anomalies_partner", table_name="anomalies")
+    op.drop_index("ix_anomalies_kind", table_name="anomalies")
+    op.drop_table("anomalies")

--- a/src/opensoar/ai/anomaly.py
+++ b/src/opensoar/ai/anomaly.py
@@ -1,0 +1,322 @@
+"""Alert pattern anomaly detection.
+
+The detector runs on a rolling 7-day window per
+``(partner, rule_name, source_ip)`` tuple and fires three heuristics:
+
+* ``count_spike`` — current-day count with a z-score > 3 against the trailing
+  baseline.
+* ``first_seen_ip`` — source IP never observed before for this
+  ``(partner, rule_name)`` pair.
+* ``new_severity`` — a severity level higher than anything observed before
+  for this ``(partner, rule_name)`` pair.
+
+The module exposes pure helpers (``zscore``, ``compute_anomaly_signals``) used
+in unit tests, plus ``run_anomaly_detection`` which persists anomalies to the
+DB and is safe to invoke from a Celery beat job or the ``Scheduler`` tick
+loop.
+"""
+from __future__ import annotations
+
+import logging
+import math
+from collections import defaultdict
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from opensoar.models.alert import Alert
+from opensoar.models.anomaly import Anomaly
+
+logger = logging.getLogger(__name__)
+
+# Severity ordering from lowest to highest. Unknown levels are treated as the
+# lowest so an alert labelled "info" cannot mask a later "critical".
+SEVERITY_ORDER: dict[str, int] = {
+    "info": 0,
+    "informational": 0,
+    "low": 1,
+    "medium": 2,
+    "moderate": 2,
+    "high": 3,
+    "critical": 4,
+}
+
+DEFAULT_BASELINE_DAYS = 7
+DEFAULT_ZSCORE_THRESHOLD = 3.0
+
+
+def zscore(sample: float, *, mean: float, stdev: float) -> float:
+    """Return the z-score of ``sample`` relative to ``mean`` / ``stdev``.
+
+    When ``stdev`` is zero we fall back to two special cases:
+      * If the sample matches the mean, the score is 0.
+      * Otherwise, we return ``+inf`` so threshold checks still fire.
+    """
+    if stdev == 0.0:
+        return 0.0 if sample == mean else math.inf
+    return (sample - mean) / stdev
+
+
+@dataclass
+class AnomalySignal:
+    """Pure-python anomaly record ready to be persisted or serialised."""
+
+    kind: str
+    partner: str | None
+    rule_name: str | None
+    source_ip: str | None
+    score: float
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_model_payload(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "partner": self.partner,
+            "rule_name": self.rule_name,
+            "source_ip": self.source_ip,
+            "score": float(self.score),
+            "details": dict(self.details),
+        }
+
+
+def _key(alert: Alert) -> tuple[str | None, str | None, str | None]:
+    return (alert.partner, alert.rule_name, alert.source_ip)
+
+
+def _day_bucket(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+
+
+def _severity_rank(severity: str | None) -> int:
+    if not severity:
+        return 0
+    return SEVERITY_ORDER.get(severity.lower(), 0)
+
+
+def _stdev(values: Sequence[float]) -> float:
+    if len(values) < 2:
+        return 0.0
+    mean = sum(values) / len(values)
+    variance = sum((v - mean) ** 2 for v in values) / (len(values) - 1)
+    return math.sqrt(variance)
+
+
+def compute_anomaly_signals(
+    *,
+    history: Iterable[Alert],
+    current: Iterable[Alert],
+    zscore_threshold: float = DEFAULT_ZSCORE_THRESHOLD,
+    baseline_days: int = DEFAULT_BASELINE_DAYS,
+) -> list[AnomalySignal]:
+    """Compute anomaly signals from a ``history`` window and ``current`` alerts.
+
+    Both iterables are plain ``Alert`` objects, in any order. The detector
+    deduplicates signals per ``(kind, partner, rule_name, source_ip)`` so a
+    burst of repeated alerts does not flood the anomaly table.
+    """
+    history_list = list(history)
+    current_list = list(current)
+
+    signals: list[AnomalySignal] = []
+    seen: set[tuple[str, str | None, str | None, str | None]] = set()
+
+    def _emit(signal: AnomalySignal) -> None:
+        dedup_key = (
+            signal.kind,
+            signal.partner,
+            signal.rule_name,
+            signal.source_ip,
+        )
+        if dedup_key in seen:
+            return
+        seen.add(dedup_key)
+        signals.append(signal)
+
+    # ── first_seen_ip ───────────────────────────────────────────────────
+    seen_ips: dict[tuple[str | None, str | None], set[str | None]] = defaultdict(set)
+    for alert in history_list:
+        seen_ips[(alert.partner, alert.rule_name)].add(alert.source_ip)
+
+    for alert in current_list:
+        if not alert.source_ip:
+            continue
+        bucket = (alert.partner, alert.rule_name)
+        if alert.source_ip not in seen_ips[bucket]:
+            _emit(
+                AnomalySignal(
+                    kind="first_seen_ip",
+                    partner=alert.partner,
+                    rule_name=alert.rule_name,
+                    source_ip=alert.source_ip,
+                    score=1.0,
+                    details={"severity": alert.severity},
+                )
+            )
+            # Record it so subsequent current alerts for the same key are
+            # deduplicated by ``_emit``.
+            seen_ips[bucket].add(alert.source_ip)
+
+    # ── new_severity ────────────────────────────────────────────────────
+    max_severity: dict[tuple[str | None, str | None], tuple[int, str | None]] = {}
+    for alert in history_list:
+        bucket = (alert.partner, alert.rule_name)
+        rank = _severity_rank(alert.severity)
+        current_best = max_severity.get(bucket, (-1, None))
+        if rank > current_best[0]:
+            max_severity[bucket] = (rank, alert.severity)
+
+    for alert in current_list:
+        bucket = (alert.partner, alert.rule_name)
+        rank = _severity_rank(alert.severity)
+        previous = max_severity.get(bucket)
+        if previous is None:
+            # A brand-new rule is covered by first_seen_ip; skip new_severity
+            # to avoid double-reporting.
+            max_severity[bucket] = (rank, alert.severity)
+            continue
+        prev_rank, prev_label = previous
+        if rank > prev_rank:
+            _emit(
+                AnomalySignal(
+                    kind="new_severity",
+                    partner=alert.partner,
+                    rule_name=alert.rule_name,
+                    source_ip=alert.source_ip,
+                    score=float(rank - prev_rank),
+                    details={
+                        "severity": alert.severity,
+                        "previous_max": prev_label,
+                    },
+                )
+            )
+            max_severity[bucket] = (rank, alert.severity)
+
+    # ── count_spike ─────────────────────────────────────────────────────
+    # Build daily counts per (partner, rule, ip) from history.
+    per_day: dict[
+        tuple[str | None, str | None, str | None], dict[datetime, int]
+    ] = defaultdict(lambda: defaultdict(int))
+    for alert in history_list:
+        per_day[_key(alert)][_day_bucket(alert.created_at)] += 1
+
+    current_counts: dict[tuple[str | None, str | None, str | None], int] = defaultdict(int)
+    for alert in current_list:
+        current_counts[_key(alert)] += 1
+
+    for key, count in current_counts.items():
+        history_daily = per_day.get(key, {})
+        # Only consider the baseline window days — we don't need more.
+        values = [float(v) for v in history_daily.values()][-baseline_days:]
+        if not values:
+            # No history for this key; first_seen_ip already covers this case.
+            continue
+        # Pad with zeros so an otherwise-quiet baseline is not considered
+        # equal to the current count.
+        while len(values) < baseline_days:
+            values.append(0.0)
+        mean = sum(values) / len(values)
+        stdev = _stdev(values)
+        score = zscore(float(count), mean=mean, stdev=stdev)
+        if score > zscore_threshold:
+            partner, rule_name, source_ip = key
+            _emit(
+                AnomalySignal(
+                    kind="count_spike",
+                    partner=partner,
+                    rule_name=rule_name,
+                    source_ip=source_ip,
+                    score=float(score if math.isfinite(score) else 1e6),
+                    details={
+                        "current_count": count,
+                        "baseline_mean": mean,
+                        "baseline_stdev": stdev,
+                        "baseline_days": baseline_days,
+                        "threshold": zscore_threshold,
+                    },
+                )
+            )
+
+    return signals
+
+
+async def run_anomaly_detection(
+    session: AsyncSession,
+    *,
+    now: datetime | None = None,
+    baseline_days: int = DEFAULT_BASELINE_DAYS,
+    zscore_threshold: float = DEFAULT_ZSCORE_THRESHOLD,
+) -> int:
+    """Run detection against the DB and persist any new anomalies.
+
+    Returns the number of anomaly rows inserted.
+
+    The method is idempotent within a detection day: if an anomaly with the
+    same ``(kind, partner, rule_name, source_ip)`` has already been persisted
+    in the last 24 hours it is not duplicated.
+    """
+    now = now or datetime.now(timezone.utc)
+    window_start = now - timedelta(days=baseline_days)
+    current_start = _day_bucket(now)
+
+    stmt = select(Alert).where(Alert.created_at >= window_start)
+    alerts: list[Alert] = list((await session.execute(stmt)).scalars().all())
+
+    current: list[Alert] = []
+    history: list[Alert] = []
+    for alert in alerts:
+        created = alert.created_at
+        if created and created.tzinfo is None:
+            created = created.replace(tzinfo=timezone.utc)
+        if created and created >= current_start:
+            current.append(alert)
+        else:
+            history.append(alert)
+
+    signals = compute_anomaly_signals(
+        history=history,
+        current=current,
+        zscore_threshold=zscore_threshold,
+        baseline_days=baseline_days,
+    )
+
+    if not signals:
+        return 0
+
+    # Dedupe against anomalies already stored in the current detection day so
+    # repeated runs are idempotent.
+    existing = (
+        await session.execute(
+            select(
+                Anomaly.kind,
+                Anomaly.partner,
+                Anomaly.rule_name,
+                Anomaly.source_ip,
+            ).where(Anomaly.created_at >= current_start)
+        )
+    ).all()
+    seen: set[tuple[str, str | None, str | None, str | None]] = {
+        (row.kind, row.partner, row.rule_name, row.source_ip) for row in existing
+    }
+
+    inserted = 0
+    for signal in signals:
+        key = (signal.kind, signal.partner, signal.rule_name, signal.source_ip)
+        if key in seen:
+            continue
+        session.add(Anomaly(**signal.to_model_payload()))
+        seen.add(key)
+        inserted += 1
+
+    if inserted:
+        await session.commit()
+        logger.info("anomaly detection: persisted %d new signal(s)", inserted)
+
+    return inserted

--- a/src/opensoar/api/ai.py
+++ b/src/opensoar/api/ai.py
@@ -6,9 +6,9 @@ import logging
 import uuid
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from opensoar.ai.client import LLMClient
@@ -26,8 +26,11 @@ from opensoar.auth.rbac import Permission, require_permission
 from opensoar.config import settings
 from opensoar.models.alert import Alert
 from opensoar.models.analyst import Analyst
+from opensoar.models.anomaly import Anomaly
 from opensoar.models.observable import Observable
+from opensoar.plugins import apply_tenant_access_query
 from opensoar.schemas.ai import AiRecommendation, RecommendRequest
+from opensoar.schemas.anomaly import AnomalyList, AnomalyResponse
 
 ALLOWED_ACTIONS = {"isolate", "block", "enrich", "escalate", "resolve"}
 SIMILAR_ALERT_LIMIT = 5
@@ -482,3 +485,61 @@ async def recommend_action(
         )
 
     return AiRecommendation(action=action, confidence=confidence, reasoning=reasoning)
+
+
+@router.get("/anomalies", response_model=AnomalyList)
+async def list_anomalies(
+    request: Request,
+    kind: str | None = None,
+    partner: str | None = None,
+    rule_name: str | None = None,
+    limit: int = Query(default=50, le=200),
+    offset: int = Query(default=0, ge=0),
+    session: AsyncSession = Depends(get_db),
+    analyst: Analyst = Depends(require_analyst),
+):
+    """List recent anomaly signals produced by the background detector.
+
+    Results are tenant-scoped via registered plugin validators (same hook used
+    by the alerts/incidents endpoints).
+    """
+    query = select(Anomaly).order_by(Anomaly.created_at.desc())
+    count_query = select(func.count(Anomaly.id))
+
+    if kind:
+        query = query.where(Anomaly.kind == kind)
+        count_query = count_query.where(Anomaly.kind == kind)
+    if partner:
+        query = query.where(Anomaly.partner == partner)
+        count_query = count_query.where(Anomaly.partner == partner)
+    if rule_name:
+        query = query.where(Anomaly.rule_name == rule_name)
+        count_query = count_query.where(Anomaly.rule_name == rule_name)
+
+    query = await apply_tenant_access_query(
+        request.app,
+        query=query,
+        resource_type="anomaly",
+        action="list",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
+    count_query = await apply_tenant_access_query(
+        request.app,
+        query=count_query,
+        resource_type="anomaly",
+        action="count",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
+
+    total = (await session.execute(count_query)).scalar() or 0
+    result = await session.execute(query.offset(offset).limit(limit))
+    anomalies = result.scalars().all()
+
+    return AnomalyList(
+        anomalies=[AnomalyResponse.model_validate(a) for a in anomalies],
+        total=total,
+    )

--- a/src/opensoar/models/__init__.py
+++ b/src/opensoar/models/__init__.py
@@ -3,6 +3,7 @@ from opensoar.models.activity import Activity
 from opensoar.models.alert import Alert
 from opensoar.models.analyst import Analyst
 from opensoar.models.analyst_identity import AnalystIdentity
+from opensoar.models.anomaly import Anomaly
 from opensoar.models.api_key import ApiKey
 from opensoar.models.incident import Incident
 from opensoar.models.incident_alert import IncidentAlert
@@ -18,6 +19,7 @@ __all__ = [
     "Alert",
     "Analyst",
     "AnalystIdentity",
+    "Anomaly",
     "ApiKey",
     "Incident",
     "IncidentAlert",

--- a/src/opensoar/models/anomaly.py
+++ b/src/opensoar/models/anomaly.py
@@ -1,0 +1,36 @@
+"""Model for anomalies produced by the AI anomaly detector."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, Float, String, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from opensoar.db import Base
+
+
+class Anomaly(Base):
+    """An anomaly signal produced by the rolling baseline analyser.
+
+    Each row represents a single heuristic firing for a
+    ``(partner, rule_name, source_ip)`` tuple on a given detection run.
+    """
+
+    __tablename__ = "anomalies"
+
+    kind: Mapped[str] = mapped_column(String(50), index=True)
+    # "count_spike" | "first_seen_ip" | "new_severity"
+    partner: Mapped[str | None] = mapped_column(String(100), index=True)
+    rule_name: Mapped[str | None] = mapped_column(String(500), index=True)
+    source_ip: Mapped[str | None] = mapped_column(String(45))
+    score: Mapped[float] = mapped_column(Float, default=0.0)
+    details: Mapped[dict | None] = mapped_column(JSONB, default=dict)
+    # Override created_at to add an index — anomaly listings are paginated by
+    # recency and this keeps /ai/anomalies fast as the table grows.
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+        index=True,
+    )

--- a/src/opensoar/schemas/anomaly.py
+++ b/src/opensoar/schemas/anomaly.py
@@ -1,0 +1,27 @@
+"""Pydantic response schemas for anomaly records."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class AnomalyResponse(BaseModel):
+    id: uuid.UUID
+    kind: str
+    partner: str | None = None
+    rule_name: str | None = None
+    source_ip: str | None = None
+    score: float
+    details: dict[str, Any] | None = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class AnomalyList(BaseModel):
+    anomalies: list[AnomalyResponse]
+    total: int

--- a/src/opensoar/worker/anomaly.py
+++ b/src/opensoar/worker/anomaly.py
@@ -1,0 +1,63 @@
+"""Celery task + beat schedule entry for periodic anomaly detection.
+
+The task itself is a thin wrapper that invokes
+:func:`opensoar.ai.anomaly.run_anomaly_detection` against a fresh async
+session.  It is safe to schedule via ``celery beat`` or to drive directly from
+the in-process ``Scheduler`` utility during local development.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from celery.schedules import crontab
+
+from opensoar.worker.celery_app import celery_app
+
+logger = logging.getLogger(__name__)
+
+
+async def _run() -> int:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+    from opensoar.ai.anomaly import run_anomaly_detection
+    from opensoar.config import settings
+
+    engine = create_async_engine(settings.database_url)
+    session_factory = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    try:
+        async with session_factory() as session:
+            return await run_anomaly_detection(session)
+    finally:
+        await engine.dispose()
+
+
+@celery_app.task(name="opensoar.detect_anomalies")
+def detect_anomalies_task() -> dict:
+    """Celery entry point — persists anomaly signals for the trailing window."""
+    logger.info("running anomaly detection task")
+    try:
+        inserted = asyncio.run(_run())
+    except RuntimeError:
+        # We are already inside a running loop (e.g. in-process scheduler) —
+        # fall back to a fresh loop on a worker thread.
+        import concurrent.futures
+
+        with concurrent.futures.ThreadPoolExecutor() as pool:
+            inserted = pool.submit(asyncio.run, _run()).result()
+    return {"inserted": int(inserted)}
+
+
+# Run every 15 minutes by default. Beat only picks this up when the worker is
+# started with ``celery -A opensoar.worker.celery_app beat``; otherwise the
+# in-process Scheduler utility can call ``detect_anomalies_task.delay()`` on a
+# matching interval.
+celery_app.conf.beat_schedule = {
+    **celery_app.conf.get("beat_schedule", {}),
+    "opensoar-detect-anomalies": {
+        "task": "opensoar.detect_anomalies",
+        "schedule": crontab(minute="*/15"),
+    },
+}

--- a/tests/test_anomaly_detection.py
+++ b/tests/test_anomaly_detection.py
@@ -1,0 +1,411 @@
+"""Tests for AI alert anomaly detection.
+
+Heuristics covered:
+  * Rolling 7-day count baseline per (partner, rule_name, source_ip) with z-score
+    greater than 3 flagged as a ``count_spike`` anomaly.
+  * First-time source_ip for a (partner, rule_name) flagged as ``first_seen_ip``.
+  * A newly elevated severity for a (partner, rule_name) flagged as
+    ``new_severity``.
+  * Clean traffic and empty history are no-ops.
+  * Listing anomalies via the API is tenant scoped.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from opensoar.ai.anomaly import (
+    AnomalySignal,
+    compute_anomaly_signals,
+    zscore,
+)
+from opensoar.models.alert import Alert
+from opensoar.models.anomaly import Anomaly
+
+
+def _make_alert(
+    *,
+    partner: str = "acme-corp",
+    rule_name: str = "Brute Force",
+    source_ip: str | None = "10.0.0.1",
+    severity: str = "medium",
+    created_at: datetime | None = None,
+) -> Alert:
+    """Build a detached ``Alert`` instance for baseline calculations."""
+    return Alert(
+        id=uuid.uuid4(),
+        source="webhook",
+        title=rule_name,
+        severity=severity,
+        status="new",
+        raw_payload={},
+        normalized={},
+        source_ip=source_ip,
+        rule_name=rule_name,
+        partner=partner,
+        created_at=created_at or datetime.now(timezone.utc),
+    )
+
+
+# ── Pure helpers ────────────────────────────────────────────────────────────
+
+
+class TestZScore:
+    def test_zscore_basic(self):
+        assert zscore(10, mean=5.0, stdev=2.0) == pytest.approx(2.5)
+
+    def test_zscore_zero_stdev_nonzero_deviation(self):
+        # When stdev is 0 but sample deviates, return +inf so downstream
+        # filters still fire.
+        assert zscore(10, mean=5.0, stdev=0.0) == float("inf")
+
+    def test_zscore_zero_stdev_no_deviation(self):
+        # Constant signal equal to its mean → no anomaly.
+        assert zscore(5, mean=5.0, stdev=0.0) == 0.0
+
+
+# ── compute_anomaly_signals ────────────────────────────────────────────────
+
+
+class TestComputeAnomalySignals:
+    def test_empty_history_no_anomalies(self):
+        """No history + no current alerts → no signals."""
+        signals = compute_anomaly_signals(history=[], current=[])
+        assert signals == []
+
+    def test_single_alert_no_history_is_first_seen(self):
+        """A brand-new rule/source_ip pair produces a first_seen_ip signal."""
+        now = datetime.now(timezone.utc)
+        alert = _make_alert(created_at=now)
+        signals = compute_anomaly_signals(history=[], current=[alert])
+        kinds = {s.kind for s in signals}
+        assert "first_seen_ip" in kinds
+
+    def test_repeated_source_ip_not_first_seen(self):
+        """If the history already contains this source_ip for the rule/partner,
+        no first_seen_ip signal fires."""
+        now = datetime.now(timezone.utc)
+        history = [
+            _make_alert(created_at=now - timedelta(days=i))
+            for i in range(1, 4)
+        ]
+        current = [_make_alert(created_at=now)]
+        signals = compute_anomaly_signals(history=history, current=current)
+        assert all(s.kind != "first_seen_ip" for s in signals)
+
+    def test_count_spike_flags_when_zscore_gt_3(self):
+        """A huge jump in daily count for a (partner, rule, source_ip) trips
+        count_spike."""
+        now = datetime.now(timezone.utc)
+        # Baseline: roughly one alert per day for 7 days.
+        history: list[Alert] = []
+        for day in range(1, 8):
+            history.append(
+                _make_alert(created_at=now - timedelta(days=day))
+            )
+        # Today: 40 alerts — massive spike.
+        current = [_make_alert(created_at=now) for _ in range(40)]
+        signals = compute_anomaly_signals(history=history, current=current)
+        spikes = [s for s in signals if s.kind == "count_spike"]
+        assert spikes, "expected a count_spike signal"
+        spike = spikes[0]
+        assert spike.partner == "acme-corp"
+        assert spike.rule_name == "Brute Force"
+        assert spike.source_ip == "10.0.0.1"
+        assert spike.score > 3.0
+        assert spike.details["current_count"] == 40
+
+    def test_count_spike_ignored_when_within_baseline(self):
+        """Matching baseline volumes produce no spike."""
+        now = datetime.now(timezone.utc)
+        history = [
+            _make_alert(created_at=now - timedelta(days=day))
+            for day in range(1, 8)
+        ]
+        current = [_make_alert(created_at=now)]
+        signals = compute_anomaly_signals(history=history, current=current)
+        assert all(s.kind != "count_spike" for s in signals)
+
+    def test_new_severity_level_detected(self):
+        """A higher severity than previously observed for a rule/partner fires
+        new_severity."""
+        now = datetime.now(timezone.utc)
+        history = [
+            _make_alert(severity="low", created_at=now - timedelta(days=2)),
+            _make_alert(severity="medium", created_at=now - timedelta(days=1)),
+        ]
+        current = [_make_alert(severity="critical", created_at=now)]
+        signals = compute_anomaly_signals(history=history, current=current)
+        new_sev = [s for s in signals if s.kind == "new_severity"]
+        assert new_sev, "expected a new_severity signal"
+        assert new_sev[0].details["severity"] == "critical"
+        assert new_sev[0].details["previous_max"] == "medium"
+
+    def test_known_severity_not_flagged(self):
+        """If the severity was already seen, no signal fires."""
+        now = datetime.now(timezone.utc)
+        history = [
+            _make_alert(severity="high", created_at=now - timedelta(days=2)),
+            _make_alert(severity="critical", created_at=now - timedelta(days=1)),
+        ]
+        current = [_make_alert(severity="high", created_at=now)]
+        signals = compute_anomaly_signals(history=history, current=current)
+        assert all(s.kind != "new_severity" for s in signals)
+
+    def test_partner_isolation_for_first_seen(self):
+        """A source_ip seen for tenant A is still ``first_seen_ip`` for tenant B."""
+        now = datetime.now(timezone.utc)
+        history = [
+            _make_alert(partner="acme-corp", created_at=now - timedelta(days=1)),
+        ]
+        current = [
+            _make_alert(partner="contoso", created_at=now),
+        ]
+        signals = compute_anomaly_signals(history=history, current=current)
+        first_seen = [s for s in signals if s.kind == "first_seen_ip"]
+        assert first_seen, "each partner keeps an independent baseline"
+        assert first_seen[0].partner == "contoso"
+
+    def test_signals_deduplicate_per_key(self):
+        """Repeated alerts for the same key only produce one first_seen_ip."""
+        now = datetime.now(timezone.utc)
+        current = [_make_alert(created_at=now) for _ in range(3)]
+        signals = compute_anomaly_signals(history=[], current=current)
+        first_seen = [s for s in signals if s.kind == "first_seen_ip"]
+        assert len(first_seen) == 1
+
+
+class TestAnomalySignalDataclass:
+    def test_to_model_payload_round_trips(self):
+        sig = AnomalySignal(
+            kind="count_spike",
+            partner="acme-corp",
+            rule_name="Brute Force",
+            source_ip="10.0.0.1",
+            score=7.5,
+            details={"current_count": 40, "baseline_mean": 1.0},
+        )
+        payload = sig.to_model_payload()
+        assert payload["kind"] == "count_spike"
+        assert payload["partner"] == "acme-corp"
+        assert payload["details"]["current_count"] == 40
+
+
+# ── Persistence + API endpoint ─────────────────────────────────────────────
+
+
+class TestAnomalyPersistence:
+    async def test_run_detection_persists_anomalies(self, session, db_session_factory):
+        """``run_anomaly_detection`` writes Anomaly rows for each signal."""
+        from opensoar.ai.anomaly import run_anomaly_detection
+        from sqlalchemy import select
+
+        now = datetime.now(timezone.utc)
+        unique_partner = f"persist-{uuid.uuid4().hex[:8]}"
+        # Seed an alert directly so the detector has something to analyse.
+        alert = Alert(
+            source="webhook",
+            title="Suspicious Login",
+            severity="high",
+            status="new",
+            raw_payload={},
+            normalized={},
+            source_ip="203.0.113.5",
+            rule_name=f"Suspicious Login {uuid.uuid4().hex[:8]}",
+            partner=unique_partner,
+            created_at=now,
+        )
+        session.add(alert)
+        await session.commit()
+
+        async with db_session_factory() as detect_session:
+            created = await run_anomaly_detection(detect_session, now=now)
+
+        assert created >= 1
+
+        rows = (
+            await session.execute(
+                select(Anomaly).where(Anomaly.partner == unique_partner)
+            )
+        ).scalars().all()
+        assert any(a.kind == "first_seen_ip" for a in rows)
+        assert any(a.partner == unique_partner for a in rows)
+
+    async def test_run_detection_is_idempotent(self, session, db_session_factory):
+        """Running detection twice on the same data should not duplicate rows."""
+        from opensoar.ai.anomaly import run_anomaly_detection
+        from sqlalchemy import func, select
+
+        now = datetime.now(timezone.utc)
+        unique_partner = f"idem-{uuid.uuid4().hex[:8]}"
+        alert = Alert(
+            source="webhook",
+            title="New Rule",
+            severity="medium",
+            status="new",
+            raw_payload={},
+            normalized={},
+            source_ip="198.51.100.7",
+            rule_name=f"New Rule {uuid.uuid4().hex[:8]}",
+            partner=unique_partner,
+            created_at=now,
+        )
+        session.add(alert)
+        await session.commit()
+
+        async with db_session_factory() as s1:
+            first = await run_anomaly_detection(s1, now=now)
+        async with db_session_factory() as s2:
+            second = await run_anomaly_detection(s2, now=now)
+
+        assert first >= 1
+        assert second == 0, "second pass should not insert duplicate anomalies"
+
+        total = (
+            await session.execute(
+                select(func.count(Anomaly.id)).where(Anomaly.partner == unique_partner)
+            )
+        ).scalar() or 0
+        assert total == first
+
+
+class TestAnomalyAPI:
+    async def test_list_anomalies_requires_auth(self, client):
+        resp = await client.get("/api/v1/ai/anomalies")
+        assert resp.status_code == 401
+
+    async def test_list_anomalies_empty_filter(self, client, registered_analyst):
+        """Filtering by a partner with no anomalies returns an empty page."""
+        unique_partner = f"no-such-partner-{uuid.uuid4().hex[:8]}"
+        resp = await client.get(
+            f"/api/v1/ai/anomalies?partner={unique_partner}",
+            headers=registered_analyst["headers"],
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data == {"anomalies": [], "total": 0}
+
+    async def test_list_anomalies_returns_recent(
+        self, client, registered_analyst, db_session_factory
+    ):
+        unique_partner = f"partner-{uuid.uuid4().hex[:8]}"
+        async with db_session_factory() as sess:
+            sess.add(
+                Anomaly(
+                    kind="count_spike",
+                    partner=unique_partner,
+                    rule_name="Brute Force",
+                    source_ip="10.0.0.1",
+                    score=7.1,
+                    details={"current_count": 42},
+                )
+            )
+            await sess.commit()
+
+        resp = await client.get(
+            f"/api/v1/ai/anomalies?partner={unique_partner}",
+            headers=registered_analyst["headers"],
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["anomalies"][0]["kind"] == "count_spike"
+        assert data["anomalies"][0]["partner"] == unique_partner
+        assert data["anomalies"][0]["rule_name"] == "Brute Force"
+
+    async def test_list_anomalies_filters(
+        self, client, registered_analyst, db_session_factory
+    ):
+        async with db_session_factory() as sess:
+            sess.add(
+                Anomaly(
+                    kind="count_spike",
+                    partner="acme-corp",
+                    rule_name="Brute Force",
+                    source_ip="10.0.0.1",
+                    score=7.1,
+                    details={},
+                )
+            )
+            sess.add(
+                Anomaly(
+                    kind="first_seen_ip",
+                    partner="contoso",
+                    rule_name="Phish Click",
+                    source_ip="198.51.100.7",
+                    score=1.0,
+                    details={},
+                )
+            )
+            await sess.commit()
+
+        resp = await client.get(
+            "/api/v1/ai/anomalies?kind=count_spike",
+            headers=registered_analyst["headers"],
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert all(a["kind"] == "count_spike" for a in data["anomalies"])
+
+        resp = await client.get(
+            "/api/v1/ai/anomalies?partner=contoso",
+            headers=registered_analyst["headers"],
+        )
+        data = resp.json()
+        assert all(a["partner"] == "contoso" for a in data["anomalies"])
+
+    async def test_list_anomalies_tenant_isolation(
+        self, client, registered_analyst, db_session_factory
+    ):
+        """Plugin tenant filters must be honoured — rows outside the analyst's
+        tenant are excluded when a tenant validator is registered."""
+        tenant_a = f"tenant-a-{uuid.uuid4().hex[:8]}"
+        tenant_b = f"tenant-b-{uuid.uuid4().hex[:8]}"
+        async with db_session_factory() as sess:
+            sess.add(
+                Anomaly(
+                    kind="count_spike",
+                    partner=tenant_a,
+                    rule_name="Brute Force",
+                    source_ip="10.0.0.1",
+                    score=7.1,
+                    details={},
+                )
+            )
+            sess.add(
+                Anomaly(
+                    kind="count_spike",
+                    partner=tenant_b,
+                    rule_name="Brute Force",
+                    source_ip="10.0.0.2",
+                    score=9.0,
+                    details={},
+                )
+            )
+            await sess.commit()
+
+        from opensoar.main import app
+
+        def _only_tenant_a(**kwargs):
+            query = kwargs["query"]
+            resource_type = kwargs["resource_type"]
+            if resource_type != "anomaly":
+                return query
+            return query.where(Anomaly.partner == tenant_a)
+
+        app.state.tenant_access_validators.append(_only_tenant_a)
+        try:
+            resp = await client.get(
+                "/api/v1/ai/anomalies",
+                headers=registered_analyst["headers"],
+            )
+        finally:
+            app.state.tenant_access_validators.remove(_only_tenant_a)
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert all(a["partner"] == tenant_a for a in data["anomalies"])
+        # Only one row for tenant_a was inserted by this test.
+        assert data["total"] == 1


### PR DESCRIPTION
## Summary
- Adds a rolling 7-day baseline analyser that flags three heuristics per `(partner, rule_name, source_ip)`: count z-score > 3 spikes, first-seen source IPs, and newly elevated severity levels.
- Persists signals to a dedicated `anomalies` table (new Alembic migration) and exposes them via `GET /ai/anomalies` with tenant isolation using the existing plugin hook.
- Adds a Celery task (`opensoar.detect_anomalies`) with a `celery beat` schedule of every 15 minutes; safe to drive from the in-process `Scheduler` utility during dev.

## Heuristics
- **count_spike** — daily count z-score above the trailing 7-day baseline > 3 (zero-variance baselines promote deviations to `+inf`).
- **first_seen_ip** — source IP never seen before for `(partner, rule_name)`.
- **new_severity** — severity strictly higher than anything previously observed for `(partner, rule_name)`.

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `pytest tests/` — 358 passed (20 new)
- [x] `alembic upgrade head` / `alembic downgrade` round-trip clean
- [x] `alembic check` reports no drift
- [x] Tenant isolation verified via plugin validator hook

Closes #82