### PR TITLE
Merge parallel Alembic heads into one

### DIFF
--- a/migrations/versions/569afa72352c_merge_retention_tenant_scoping_incident_.py
+++ b/migrations/versions/569afa72352c_merge_retention_tenant_scoping_incident_.py
@@ -1,0 +1,28 @@
+"""merge retention + tenant scoping + incident templates heads
+
+Revision ID: 569afa72352c
+Revises: b8d4e6f12a77, b8e4c1d2f5a9, b8f3d2c1a9e7
+Create Date: 2026-04-17 14:15:42.676802
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '569afa72352c'
+down_revision: Union[str, Sequence[str], None] = ('b8d4e6f12a77', 'b8e4c1d2f5a9', 'b8f3d2c1a9e7')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass


### PR DESCRIPTION
## Summary
Three feature PRs (#96 tenant scoping, #100 data retention, #101 incident templates) each added an Alembic migration pointing at the same parent. Main now reports three heads — the test fixture calls \`alembic upgrade head\` which fails with "Multiple head revisions are present".

Adds an empty merge migration unifying the three branches. \`alembic upgrade head\` now walks cleanly from pre-parallel state to \`569afa72352c\`.

## Test plan
- [x] \`alembic upgrade head\` clean from empty DB
- [x] \`alembic heads\` returns a single head after merge

Note: #102 anomaly detection (still open) adds a fourth migration — after this PR merges, rebase #102 so its \`down_revision\` points at this merge head.