### PR TITLE
fix: use SQLAlchemy make_url for sync database URL conversion

### DIFF
--- a/src/opensoar/config.py
+++ b/src/opensoar/config.py
@@ -1,5 +1,6 @@
 from pydantic import model_validator
 from pydantic_settings import BaseSettings
+from sqlalchemy.engine import make_url
 
 
 class Settings(BaseSettings):
@@ -66,9 +67,8 @@ class Settings(BaseSettings):
 
     @property
     def sync_database_url(self) -> str:
-        return self.database_url.replace("+asyncpg", "+psycopg2").replace(
-            "postgresql+psycopg2", "postgresql"
-        )
+        url = make_url(self.database_url)
+        return str(url.set(drivername="postgresql"))
 
     @property
     def effective_celery_broker_url(self) -> str:


### PR DESCRIPTION
## Summary

- Replace fragile string replacement (`+asyncpg` → `+psycopg2` → strip) with SQLAlchemy's `make_url()` and `url.set(drivername=...)` 
- Handles any async driver variant correctly instead of assuming specific substrings

Closes #108