### PR TITLE
fix: warn when trigger condition references missing alert field

### DIFF
--- a/src/opensoar/core/registry.py
+++ b/src/opensoar/core/registry.py
@@ -73,6 +73,11 @@ class PlaybookRegistry:
             return True
 
         for key, expected in conditions.items():
+            if key not in alert_data:
+                logger.warning(
+                    "Trigger condition references field %r not present in alert data",
+                    key,
+                )
             actual = alert_data.get(key)
             if not self._condition_value_matches(expected, actual):
                 return False


### PR DESCRIPTION
## Summary

- Log a warning when a trigger condition references a field not present in the alert data
- A typo like `{"severiy": "critical"}` silently causes the playbook to never match — this makes it visible in logs

**Note:** Issue #110 originally described the behavior as matching everything; the actual behavior is the opposite (the playbook is silently skipped). Either way, the root problem is the same — no feedback on misconfigured conditions.

Closes #110