### PR TITLE
Reset API keys in client fixture so webhook tests stay in open mode

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,6 +125,18 @@ async def client(db_session_factory) -> AsyncGenerator[AsyncClient]:
 
     app.dependency_overrides[get_db] = override_get_db
 
+    # Wipe API keys so each test starts in webhook open mode unless it opts in.
+    # Without this, a key created by an earlier test leaks across the
+    # session-scoped DB and causes the #116 "keys exist → require key" check
+    # to reject unauthenticated webhook tests.
+    from sqlalchemy import delete
+
+    from opensoar.models.api_key import ApiKey
+
+    async with db_session_factory() as cleanup_sess:
+        await cleanup_sess.execute(delete(ApiKey))
+        await cleanup_sess.commit()
+
     with patch("opensoar.main.get_trigger_engine", return_value=mock_engine):
         with patch("opensoar.main._trigger_engine", mock_engine):
             from opensoar.middleware.metrics import reset_metrics


### PR DESCRIPTION
## Summary
PR #116 correctly tightened webhook auth (issue #107) so that once API keys exist in the DB, unauthenticated requests are rejected. But the test suite has a session-scoped DB engine, which means API keys created by earlier tests persist into later ones — the full suite went red on main even though each test passes in isolation.

Fix: delete all \`ApiKey\` rows at the start of the \`client\` fixture. Every test now starts in webhook open mode unless it explicitly mints a key (e.g. \`test_webhook_with_valid_key\`).

## Test plan
- [x] \`pytest tests/test_webhook_auth.py tests/test_webhooks.py tests/test_security_fixes.py\` — 27/27 pass
- [x] Full suite: \`pytest tests/\` — 546/546 pass
- [x] \`ruff check src/ tests/\` clean