### PR TITLE
Add Redis-based lock for distributed scheduler coordination

### DIFF
--- a/src/opensoar/core/scheduler.py
+++ b/src/opensoar/core/scheduler.py
@@ -1,11 +1,70 @@
-"""Simple interval-based scheduler for recurring playbook triggers."""
+"""Simple interval-based scheduler for recurring playbook triggers.
+
+Multi-instance safety (issue #111): when the scheduler runs in more than one
+process (e.g. two API replicas), each instance maintains its own in-memory
+schedule and would otherwise fire the same job independently. To avoid
+duplicate executions we wrap each scheduled tick in a Redis-backed
+``SET NX EX`` lock keyed by ``(job_name, tick_bucket)``. The first instance
+to land the key executes; the others skip. The lock TTL is short enough that
+a crashed instance cannot stall future runs but long enough to cover a
+typical playbook execution.
+"""
 from __future__ import annotations
 
 import logging
 import time
-from typing import Any, Callable
+from typing import Any, Callable, Protocol
 
 logger = logging.getLogger(__name__)
+
+
+# Default TTL for the per-tick Redis lock. Longer than any reasonable playbook
+# run, short enough that a crashed holder doesn't stall the next interval.
+DEFAULT_LOCK_TTL_SECONDS = 60
+
+
+class RedisLikeClient(Protocol):
+    """Subset of ``redis.asyncio.Redis`` that :class:`DistributedLock` uses."""
+
+    async def set(self, key: str, value: str, *, nx: bool = False, ex: int | None = None) -> Any: ...
+
+
+class DistributedLock:
+    """Thin wrapper around a Redis client that implements ``SET NX EX``.
+
+    The scheduler calls :meth:`acquire` before running a scheduled tick. If
+    another instance already holds the key, ``acquire`` returns ``False`` and
+    the local scheduler skips execution for that tick.
+    """
+
+    def __init__(self, client: RedisLikeClient, key_prefix: str = "opensoar:scheduler:") -> None:
+        self._client = client
+        self._key_prefix = key_prefix
+
+    def _full_key(self, key: str) -> str:
+        if key.startswith(self._key_prefix):
+            return key
+        return f"{self._key_prefix}{key}"
+
+    async def acquire(self, key: str, *, ttl_seconds: int = DEFAULT_LOCK_TTL_SECONDS) -> bool:
+        """Attempt to acquire the lock for ``key``.
+
+        Uses ``SET key value NX EX <ttl>`` which returns truthy only when the
+        key was created by this call. Any exception from the Redis client is
+        treated as "lock unavailable"; the caller then skips this tick rather
+        than risk a duplicate execution.
+        """
+        try:
+            result = await self._client.set(
+                self._full_key(key),
+                "1",
+                nx=True,
+                ex=max(1, int(ttl_seconds)),
+            )
+        except Exception:
+            logger.exception("scheduler.lock.error key=%s", key)
+            return False
+        return bool(result)
 
 
 class Scheduler:
@@ -19,10 +78,25 @@ class Scheduler:
         while True:
             await scheduler.tick()
             await asyncio.sleep(1)
+
+    Multi-instance deployments should pass a :class:`DistributedLock`:
+
+        from redis import asyncio as redis_asyncio
+        client = redis_asyncio.from_url(settings.redis_url, decode_responses=True)
+        scheduler = Scheduler(lock=DistributedLock(client))
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        lock: DistributedLock | None = None,
+        *,
+        instance_id: str | None = None,
+        lock_ttl_seconds: int = DEFAULT_LOCK_TTL_SECONDS,
+    ) -> None:
         self.jobs: dict[str, dict[str, Any]] = {}
+        self._lock = lock
+        self._instance_id = instance_id or ""
+        self._lock_ttl_seconds = lock_ttl_seconds
 
     def register(
         self,
@@ -36,6 +110,7 @@ class Scheduler:
             "interval": interval_seconds,
             "callback": callback,
             "last_run": 0.0,
+            "last_tick_id": None,
         }
         logger.info(f"Scheduler: registered job '{name}' (every {interval_seconds}s)")
 
@@ -56,15 +131,61 @@ class Scheduler:
             for name, job in self.jobs.items()
         ]
 
+    def _tick_bucket(self, name: str) -> str:
+        """Stable identifier for the current scheduled tick window.
+
+        All instances observing roughly the same wall-clock time will compute
+        the same bucket for a given job, so their Redis keys collide and only
+        one acquires the lock.
+        """
+        job = self.jobs[name]
+        interval = max(1, int(job["interval"]))
+        # Use wall-clock seconds (not monotonic) so concurrent instances on
+        # different hosts agree on the bucket.
+        bucket = int(time.time()) // interval
+        return f"{name}:{bucket}"
+
+    def _lock_key(self, name: str) -> str:
+        return self._tick_bucket(name)
+
     async def tick(self) -> None:
-        """Check all jobs and run any that are due."""
+        """Check all jobs and run any that are due.
+
+        If a :class:`DistributedLock` is configured, each due job attempts to
+        acquire a per-tick Redis key before executing; instances that lose the
+        race skip the execution but still advance ``last_run`` so they don't
+        retry in a tight loop within the same interval window.
+        """
         now = time.monotonic()
         for name, job in self.jobs.items():
             elapsed = now - job["last_run"]
-            if elapsed >= job["interval"]:
-                try:
-                    await job["callback"]()
+            if elapsed < job["interval"]:
+                continue
+
+            tick_id = self._lock_key(name)
+
+            if self._lock is not None:
+                acquired = await self._lock.acquire(
+                    tick_id, ttl_seconds=self._lock_ttl_seconds
+                )
+                if not acquired:
+                    # Another instance is (or just was) executing this tick.
+                    # Advance our local clock so we don't retry every loop
+                    # iteration within the same interval window.
                     job["last_run"] = time.monotonic()
-                    logger.debug(f"Scheduler: ran job '{name}'")
-                except Exception:
-                    logger.exception(f"Scheduler: job '{name}' failed")
+                    job["last_tick_id"] = tick_id
+                    logger.debug(
+                        "scheduler.skip_locked job=%s tick=%s instance=%s",
+                        name,
+                        tick_id,
+                        self._instance_id,
+                    )
+                    continue
+
+            try:
+                await job["callback"]()
+                job["last_run"] = time.monotonic()
+                job["last_tick_id"] = tick_id
+                logger.debug(f"Scheduler: ran job '{name}'")
+            except Exception:
+                logger.exception(f"Scheduler: job '{name}' failed")

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,9 +1,10 @@
 """Tests for the scheduler — recurring playbook triggers."""
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock
 
-from opensoar.core.scheduler import Scheduler
+from opensoar.core.scheduler import DistributedLock, Scheduler
 
 
 class TestScheduler:
@@ -63,5 +64,118 @@ class TestScheduler:
         # Set last_run to now so it's not due
         import time
         scheduler.jobs["not_due"]["last_run"] = time.monotonic()
+        await scheduler.tick()
+        cb.assert_not_awaited()
+
+
+class FakeRedisBackend:
+    """Minimal fake of redis.asyncio client for SET NX EX semantics.
+
+    Shared across instances to simulate a single Redis server seen by
+    multiple scheduler processes.
+    """
+
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    async def set(self, key, value, *, nx=False, ex=None):  # noqa: ARG002
+        if nx and key in self.store:
+            return None
+        self.store[key] = value
+        return True
+
+    async def get(self, key):
+        return self.store.get(key)
+
+    async def delete(self, key):
+        self.store.pop(key, None)
+        return 1
+
+
+class TestDistributedLock:
+    """DistributedLock wraps a Redis-style client with SET NX EX semantics."""
+
+    async def test_acquire_returns_true_when_unheld(self):
+        client = FakeRedisBackend()
+        lock = DistributedLock(client)
+        assert await lock.acquire("job:tick-1", ttl_seconds=60) is True
+
+    async def test_acquire_returns_false_when_held(self):
+        client = FakeRedisBackend()
+        lock = DistributedLock(client)
+        assert await lock.acquire("job:tick-1", ttl_seconds=60) is True
+        # Second attempt from same process or another process: denied.
+        assert await lock.acquire("job:tick-1", ttl_seconds=60) is False
+
+    async def test_acquire_different_keys_independent(self):
+        client = FakeRedisBackend()
+        lock = DistributedLock(client)
+        assert await lock.acquire("job:tick-1", ttl_seconds=60) is True
+        assert await lock.acquire("job:tick-2", ttl_seconds=60) is True
+
+
+class TestDistributedScheduler:
+    """When a lock is configured, only one instance runs each scheduled tick."""
+
+    async def test_single_instance_runs_with_lock(self):
+        """A lone scheduler should still fire jobs normally when a lock is set."""
+        client = FakeRedisBackend()
+        cb = AsyncMock()
+        scheduler = Scheduler(lock=DistributedLock(client))
+        scheduler.register("lonely", interval_seconds=0, callback=cb)
+        await scheduler.tick()
+        cb.assert_awaited_once()
+
+    async def test_two_instances_race_only_one_executes(self):
+        """Two schedulers sharing a Redis lock must not double-execute."""
+        client = FakeRedisBackend()  # shared "Redis"
+        cb_a = AsyncMock()
+        cb_b = AsyncMock()
+
+        sched_a = Scheduler(lock=DistributedLock(client), instance_id="a")
+        sched_b = Scheduler(lock=DistributedLock(client), instance_id="b")
+        # Both instances registered the same logical job.
+        sched_a.register("sync_job", interval_seconds=0, callback=cb_a)
+        sched_b.register("sync_job", interval_seconds=0, callback=cb_b)
+
+        # Run both ticks concurrently — simulates two API instances racing.
+        await asyncio.gather(sched_a.tick(), sched_b.tick())
+
+        total_calls = cb_a.await_count + cb_b.await_count
+        assert total_calls == 1, (
+            f"Expected exactly one execution across instances, got {total_calls}"
+        )
+
+    async def test_next_tick_after_interval_runs_again(self):
+        """The lock key is per scheduled tick, not permanent — next tick runs."""
+        client = FakeRedisBackend()
+        cb = AsyncMock()
+        scheduler = Scheduler(lock=DistributedLock(client))
+        scheduler.register("periodic", interval_seconds=0, callback=cb)
+
+        await scheduler.tick()
+        # Simulate the prior bucket's key expiring (as Redis TTL would) so the
+        # next scheduled tick starts fresh.
+        client.store.clear()
+        scheduler.jobs["periodic"]["last_run"] = 0.0
+        await scheduler.tick()
+
+        assert cb.await_count == 2
+
+    async def test_skipped_execution_advances_last_run(self):
+        """When lock is denied, the job should not rerun on the next tick
+        within the same interval window (avoids tight-loop retries)."""
+        client = FakeRedisBackend()
+        cb = AsyncMock()
+        lock = DistributedLock(client)
+        scheduler = Scheduler(lock=lock, instance_id="b")
+        scheduler.register("held", interval_seconds=60, callback=cb)
+
+        # Pre-acquire the lock via the same DistributedLock so prefixes match.
+        assert await lock.acquire(scheduler._lock_key("held"), ttl_seconds=60)
+
+        await scheduler.tick()
+        cb.assert_not_awaited()
+        # A second immediate tick must not run either — last_run was advanced.
         await scheduler.tick()
         cb.assert_not_awaited()


### PR DESCRIPTION
## Summary
- In-memory `Scheduler` had no cross-process coordination, so running multiple API or worker replicas caused every scheduled tick to fire once per instance.
- Added `DistributedLock` (Redis `SET NX EX`) and wired it into `Scheduler.tick()` keyed by `(job_name, tick_bucket)` so only the first instance to acquire the key runs the callback; the rest skip that tick.
- Losing instances advance their local `last_run` so they don't retry in a tight loop within the same window. TTL defaults to 60s — longer than typical playbook runs, short enough that a crashed holder doesn't stall the next interval.
- No Celery Beat migration: keeps the existing loop, adds coordination on top.

Closes #111

## Test plan
- [x] `pytest tests/test_scheduler.py` — 14 passing, including a race test that runs two schedulers concurrently against a shared fake Redis and asserts exactly one executes.
- [x] `ruff check src/ tests/` clean.
- [ ] CI green across all jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduler now supports distributed multi-instance deployments with automatic lock-based execution coordination, preventing duplicate scheduled job runs across processes.

* **Tests**
  * Added comprehensive test coverage for distributed scheduler locking, concurrent instance behavior, and lock expiration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->