### PR TITLE
Add POST /playbooks/reload endpoint for hot-reload

### DIFF
--- a/src/opensoar/api/playbooks.py
+++ b/src/opensoar/api/playbooks.py
@@ -8,7 +8,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from opensoar.api.deps import get_db
 from opensoar.auth.rbac import Permission, require_permission
+from opensoar.config import settings
 from opensoar.core.decorators import get_playbook_registry
+from opensoar.core.registry import PlaybookRegistry
 from opensoar.models.alert import Alert
 from opensoar.models.analyst import Analyst
 from opensoar.models.playbook import PlaybookDefinition
@@ -16,6 +18,27 @@ from opensoar.plugins import apply_tenant_access_query, enforce_tenant_access
 from opensoar.schemas.playbook import PlaybookResponse, PlaybookRunRequest, PlaybookUpdate
 
 router = APIRouter(prefix="/playbooks", tags=["playbooks"])
+
+
+@router.post("/reload")
+async def reload_playbooks(
+    session: AsyncSession = Depends(get_db),
+    analyst: Analyst = Depends(require_permission(Permission.PLAYBOOKS_MANAGE)),
+):
+    """Re-scan playbook directories and refresh the in-memory registry.
+
+    Clears the existing registry, re-imports modules from the configured
+    playbook directories, and syncs definitions to the database. This enables
+    hot-reload of playbooks without restarting the API (issue #112).
+
+    Note: in-flight playbook executions hold a reference to the old function
+    object and complete with the pre-reload code. New invocations use the
+    refreshed registry.
+    """
+    registry = PlaybookRegistry(settings.playbook_directories)
+    count = registry.clear_and_reload()
+    await registry.sync_to_db(session)
+    return {"count": count, "message": f"Reloaded {count} playbook(s)"}
 
 
 @router.get("", response_model=list[PlaybookResponse])

--- a/src/opensoar/core/registry.py
+++ b/src/opensoar/core/registry.py
@@ -37,6 +37,42 @@ class PlaybookRegistry:
             logger.info(f"  - {name} (trigger={pb.meta.trigger}, module={pb.module})")
         return registry
 
+    def clear_and_reload(self) -> int:
+        """Clear the in-memory playbook registry and re-discover playbooks.
+
+        Removes cached playbook modules from ``sys.modules`` so that edits on
+        disk are picked up, then wipes ``_PLAYBOOK_REGISTRY`` and re-scans the
+        configured playbook directories. Returns the number of playbooks
+        registered after the reload.
+
+        Note: in-flight executions hold a reference to the old function object
+        and will complete with the pre-reload code. New invocations use the
+        refreshed registry.
+        """
+        from opensoar.core.decorators import _PLAYBOOK_REGISTRY
+
+        module_prefixes = tuple(
+            Path(d).name
+            for d in self._playbook_dirs
+            if Path(d).name
+        )
+
+        if module_prefixes:
+            for mod_name in list(sys.modules):
+                if any(
+                    mod_name == prefix or mod_name.startswith(f"{prefix}.")
+                    for prefix in module_prefixes
+                ):
+                    del sys.modules[mod_name]
+
+        # Drop importlib's path/finder caches so edited files on disk are
+        # re-read (not served from a stale bytecode cache).
+        importlib.invalidate_caches()
+
+        _PLAYBOOK_REGISTRY.clear()
+        self.discover()
+        return len(get_playbook_registry())
+
     def _import_module(self, py_file: Path, base_dir: Path) -> None:
         relative = py_file.relative_to(base_dir.parent)
         module_name = str(relative.with_suffix("")).replace("/", ".").replace("\\", ".")

--- a/tests/test_playbooks_api.py
+++ b/tests/test_playbooks_api.py
@@ -159,3 +159,159 @@ class TestPlaybookAPI:
         )
         assert resp.status_code == 200
         assert resp.json()["enabled"] is True
+
+
+class TestClearAndReload:
+    """Unit tests for the registry clear_and_reload helper (issue #112)."""
+
+    def test_clear_and_reload_refreshes_registry(self, tmp_path):
+        """Writing a playbook, reloading, mutating it, then reloading should
+        reflect the new metadata in the registry."""
+        import os
+
+        from opensoar.core.decorators import _PLAYBOOK_REGISTRY, get_playbook_registry
+
+        pb_dir = tmp_path / "reload_pbs"
+        pb_dir.mkdir()
+        (pb_dir / "__init__.py").write_text("")
+
+        pb_file = pb_dir / "sample_reload_pb.py"
+        pb_file.write_text(
+            "from opensoar import playbook\n"
+            "\n"
+            "@playbook(trigger='webhook', description='v1')\n"
+            "async def sample_reload_pb(alert):\n"
+            "    return {'version': 1}\n"
+        )
+        # Backdate the file so a second-resolution mtime change is visible
+        os.utime(pb_file, (1_000_000_000, 1_000_000_000))
+
+        # Ensure any prior entry is gone
+        _PLAYBOOK_REGISTRY.pop("sample_reload_pb", None)
+
+        registry = PlaybookRegistry([str(pb_dir)])
+        count = registry.clear_and_reload()
+        assert count >= 1
+        assert "sample_reload_pb" in get_playbook_registry()
+        assert get_playbook_registry()["sample_reload_pb"].meta.description == "v1"
+
+        # Mutate the playbook on disk (force a later mtime so source cache invalidates)
+        pb_file.write_text(
+            "from opensoar import playbook\n"
+            "\n"
+            "@playbook(trigger='webhook', description='v2')\n"
+            "async def sample_reload_pb(alert):\n"
+            "    return {'version': 2}\n"
+        )
+        os.utime(pb_file, (2_000_000_000, 2_000_000_000))
+
+        count = registry.clear_and_reload()
+        assert count >= 1
+        assert get_playbook_registry()["sample_reload_pb"].meta.description == "v2"
+
+        _PLAYBOOK_REGISTRY.pop("sample_reload_pb", None)
+
+    def test_clear_and_reload_drops_removed_playbooks(self, tmp_path):
+        """Playbooks that no longer exist on disk should be removed after reload."""
+        from opensoar.core.decorators import _PLAYBOOK_REGISTRY, get_playbook_registry
+
+        pb_dir = tmp_path / "reload_pbs_remove"
+        pb_dir.mkdir()
+        (pb_dir / "__init__.py").write_text("")
+
+        pb_file = pb_dir / "ephemeral_pb.py"
+        pb_file.write_text(
+            "from opensoar import playbook\n"
+            "\n"
+            "@playbook(trigger='webhook')\n"
+            "async def ephemeral_pb(alert):\n"
+            "    return {}\n"
+        )
+
+        _PLAYBOOK_REGISTRY.pop("ephemeral_pb", None)
+
+        registry = PlaybookRegistry([str(pb_dir)])
+        registry.clear_and_reload()
+        assert "ephemeral_pb" in get_playbook_registry()
+
+        # Delete the file and reload — registry should no longer contain it
+        pb_file.unlink()
+        registry.clear_and_reload()
+        assert "ephemeral_pb" not in get_playbook_registry()
+
+
+class TestReloadEndpoint:
+    """Integration tests for POST /api/v1/playbooks/reload (issue #112)."""
+
+    async def test_reload_requires_auth(self, client):
+        """Unauthenticated requests must be rejected."""
+        resp = await client.post("/api/v1/playbooks/reload")
+        assert resp.status_code == 401
+
+    async def test_reload_requires_admin(self, client, registered_analyst):
+        """Non-admin analysts lack PLAYBOOKS_MANAGE and must be rejected."""
+        resp = await client.post(
+            "/api/v1/playbooks/reload",
+            headers=registered_analyst["headers"],
+        )
+        assert resp.status_code == 403
+
+    async def test_reload_refreshes_registry(self, client, registered_admin, tmp_path, monkeypatch):
+        """Admin POST should re-scan the playbook dirs and return a count."""
+        import os
+
+        from opensoar.core.decorators import _PLAYBOOK_REGISTRY, get_playbook_registry
+
+        pb_dir = tmp_path / "endpoint_pbs"
+        pb_dir.mkdir()
+        (pb_dir / "__init__.py").write_text("")
+
+        pb_file = pb_dir / "endpoint_reload_pb.py"
+        pb_file.write_text(
+            "from opensoar import playbook\n"
+            "\n"
+            "@playbook(trigger='webhook', description='v1')\n"
+            "async def endpoint_reload_pb(alert):\n"
+            "    return {'version': 1}\n"
+        )
+        os.utime(pb_file, (1_000_000_000, 1_000_000_000))
+
+        _PLAYBOOK_REGISTRY.pop("endpoint_reload_pb", None)
+
+        # Point the endpoint at our temporary playbook dir
+        from opensoar.config import settings
+        monkeypatch.setattr(
+            type(settings),
+            "playbook_directories",
+            property(lambda self: [str(pb_dir)]),
+        )
+
+        resp = await client.post(
+            "/api/v1/playbooks/reload",
+            headers=registered_admin["headers"],
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "count" in body
+        assert body["count"] >= 1
+        assert "endpoint_reload_pb" in get_playbook_registry()
+        assert get_playbook_registry()["endpoint_reload_pb"].meta.description == "v1"
+
+        # Mutate on disk and reload again (force later mtime)
+        pb_file.write_text(
+            "from opensoar import playbook\n"
+            "\n"
+            "@playbook(trigger='webhook', description='v2')\n"
+            "async def endpoint_reload_pb(alert):\n"
+            "    return {'version': 2}\n"
+        )
+        os.utime(pb_file, (2_000_000_000, 2_000_000_000))
+
+        resp = await client.post(
+            "/api/v1/playbooks/reload",
+            headers=registered_admin["headers"],
+        )
+        assert resp.status_code == 200
+        assert get_playbook_registry()["endpoint_reload_pb"].meta.description == "v2"
+
+        _PLAYBOOK_REGISTRY.pop("endpoint_reload_pb", None)


### PR DESCRIPTION
## Summary

- Adds `PlaybookRegistry.clear_and_reload()` which wipes the playbook module cache + `_PLAYBOOK_REGISTRY` and re-runs discovery against the configured directories.
- Exposes a new `POST /api/v1/playbooks/reload` endpoint guarded by `Permission.PLAYBOOKS_MANAGE` that calls the helper, syncs the refreshed registry to the database, and returns the loaded playbook count.
- No more full API restart required to pick up playbook source changes.

In-flight playbook executions keep a reference to the pre-reload function object and complete with the old code; subsequent invocations use the refreshed registry.

Closes #112.

## Test plan

- [x] `ruff check src/ tests/` passes
- [x] Unit test: `clear_and_reload` refreshes registry metadata when a playbook file is mutated on disk
- [x] Unit test: `clear_and_reload` drops playbooks whose files were deleted
- [x] Integration test: endpoint returns 401 without auth, 403 for non-admin, 200 + count for admin
- [x] Integration test: mutating a playbook on disk and POSTing the endpoint reflects the new metadata in the registry
- [x] Full suite: `pytest tests/` — 551 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated API endpoint to reload playbooks dynamically without restarting the application; admin-only access required. Returns count of reloaded playbooks.

* **Tests**
  * Added test coverage for playbook reload functionality, including authentication and authorization checks, and metadata refresh verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->