### PR TITLE
Enforce tenant scoping across all API query paths

### DIFF
--- a/src/opensoar/api/actions.py
+++ b/src/opensoar/api/actions.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 import logging
 import uuid
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from opensoar.api.deps import get_db
 from opensoar.auth.jwt import require_analyst
 from opensoar.models.activity import Activity
+from opensoar.models.alert import Alert
 from opensoar.models.analyst import Analyst
+from opensoar.plugins import enforce_tenant_access
 from opensoar.schemas.action import (
     ActionExecuteRequest,
     ActionExecuteResponse,
@@ -59,6 +62,7 @@ async def list_available_actions(ioc_type: str | None = None):
 @router.post("/execute", response_model=ActionExecuteResponse)
 async def execute_action(
     body: ActionExecuteRequest,
+    request: Request,
     session: AsyncSession = Depends(get_db),
     analyst: Analyst = Depends(require_analyst),
 ):
@@ -69,6 +73,26 @@ async def execute_action(
             ioc_value=body.ioc_value,
             status="failed",
             error=f"Unknown action: {body.action_name}",
+        )
+
+    # If the action is scoped to a specific alert, confirm the caller can access
+    # it before running the action or writing the audit activity.
+    if body.alert_id:
+        alert = (
+            await session.execute(
+                select(Alert).where(Alert.id == uuid.UUID(body.alert_id))
+            )
+        ).scalar_one_or_none()
+        if alert is None:
+            raise HTTPException(status_code=404, detail="Alert not found")
+        await enforce_tenant_access(
+            request.app,
+            resource=alert,
+            resource_type="alert",
+            action="execute_action",
+            analyst=analyst,
+            request=request,
+            session=session,
         )
 
     # Execute the action

--- a/src/opensoar/api/ai.py
+++ b/src/opensoar/api/ai.py
@@ -28,7 +28,7 @@ from opensoar.models.alert import Alert
 from opensoar.models.analyst import Analyst
 from opensoar.models.anomaly import Anomaly
 from opensoar.models.observable import Observable
-from opensoar.plugins import apply_tenant_access_query
+from opensoar.plugins import apply_tenant_access_query, enforce_tenant_access
 from opensoar.schemas.ai import AiRecommendation, RecommendRequest
 from opensoar.schemas.anomaly import AnomalyList, AnomalyResponse
 
@@ -74,8 +74,9 @@ class TriageRequest(BaseModel):
 @router.post("/summarize")
 async def summarize_alert(
     body: SummarizeRequest,
+    request: Request,
     session: AsyncSession = Depends(get_db),
-    _analyst: Analyst = Depends(require_analyst),
+    analyst: Analyst = Depends(require_analyst),
 ):
     """Generate a natural language summary of an alert using an LLM."""
     client = get_llm_client()
@@ -91,6 +92,15 @@ async def summarize_alert(
     alert = result.scalar_one_or_none()
     if not alert:
         raise HTTPException(status_code=404, detail="Alert not found")
+    await enforce_tenant_access(
+        request.app,
+        resource=alert,
+        resource_type="alert",
+        action="ai_summarize",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
 
     alert_data = {
         "title": alert.title,
@@ -121,8 +131,9 @@ async def summarize_alert(
 @router.post("/triage")
 async def triage_alert(
     body: TriageRequest,
+    request: Request,
     session: AsyncSession = Depends(get_db),
-    _analyst: Analyst = Depends(require_analyst),
+    analyst: Analyst = Depends(require_analyst),
 ):
     """Suggest severity and determination for an alert using an LLM."""
     client = get_llm_client()
@@ -138,6 +149,15 @@ async def triage_alert(
     alert = result.scalar_one_or_none()
     if not alert:
         raise HTTPException(status_code=404, detail="Alert not found")
+    await enforce_tenant_access(
+        request.app,
+        resource=alert,
+        resource_type="alert",
+        action="ai_triage",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
 
     alert_data = {
         "title": alert.title,
@@ -227,8 +247,9 @@ class AutoResolveRequest(BaseModel):
 @router.post("/auto-resolve")
 async def auto_resolve(
     body: AutoResolveRequest,
+    request: Request,
     session: AsyncSession = Depends(get_db),
-    _analyst: Analyst = Depends(require_analyst),
+    analyst: Analyst = Depends(require_analyst),
 ):
     """Evaluate alerts for automatic resolution as benign."""
     client = get_llm_client()
@@ -243,6 +264,20 @@ async def auto_resolve(
         )
         alert = result.scalar_one_or_none()
         if alert:
+            # Skip alerts the caller can't access across tenants — they never
+            # reach the LLM so we don't leak metadata through the prompt.
+            try:
+                await enforce_tenant_access(
+                    request.app,
+                    resource=alert,
+                    resource_type="alert",
+                    action="ai_auto_resolve",
+                    analyst=analyst,
+                    request=request,
+                    session=session,
+                )
+            except HTTPException:
+                continue
             alerts_data.append({
                 "id": str(alert.id),
                 "title": alert.title,
@@ -301,8 +336,9 @@ class CorrelateRequest(BaseModel):
 @router.post("/correlate")
 async def correlate_alerts(
     body: CorrelateRequest,
+    request: Request,
     session: AsyncSession = Depends(get_db),
-    _analyst: Analyst = Depends(require_analyst),
+    analyst: Analyst = Depends(require_analyst),
 ):
     """Use LLM reasoning to group related alerts into potential incidents."""
     client = get_llm_client()
@@ -316,6 +352,20 @@ async def correlate_alerts(
         )
         alert = result.scalar_one_or_none()
         if alert:
+            # Silently skip cross-tenant alerts so the LLM prompt never mixes
+            # data across tenant boundaries.
+            try:
+                await enforce_tenant_access(
+                    request.app,
+                    resource=alert,
+                    resource_type="alert",
+                    action="ai_correlate",
+                    analyst=analyst,
+                    request=request,
+                    session=session,
+                )
+            except HTTPException:
+                continue
             alerts_data.append({
                 "id": str(alert.id),
                 "title": alert.title,
@@ -372,8 +422,9 @@ def _normalize_confidence(raw: Any) -> float:
 @router.post("/recommend", response_model=AiRecommendation)
 async def recommend_action(
     body: RecommendRequest,
+    request: Request,
     session: AsyncSession = Depends(get_db),
-    _analyst: Analyst = Depends(require_permission(Permission.AI_USE)),
+    analyst: Analyst = Depends(require_permission(Permission.AI_USE)),
 ) -> AiRecommendation:
     """Ask the LLM what a seasoned analyst would do for this alert."""
     client = get_llm_client()
@@ -392,11 +443,29 @@ async def recommend_action(
     alert = result.scalar_one_or_none()
     if not alert:
         raise HTTPException(status_code=404, detail="Alert not found")
-
-    # Linked observables + their enrichments
-    obs_result = await session.execute(
-        select(Observable).where(Observable.alert_id == alert_uuid)
+    await enforce_tenant_access(
+        request.app,
+        resource=alert,
+        resource_type="alert",
+        action="ai_recommend",
+        analyst=analyst,
+        request=request,
+        session=session,
     )
+
+    # Linked observables + their enrichments — scope to tenant so the LLM
+    # never gets cross-tenant IOCs as context.
+    obs_query = select(Observable).where(Observable.alert_id == alert_uuid)
+    obs_query = await apply_tenant_access_query(
+        request.app,
+        query=obs_query,
+        resource_type="observable",
+        action="list",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
+    obs_result = await session.execute(obs_query)
     observables = [
         {
             "type": obs.type,
@@ -412,12 +481,22 @@ async def recommend_action(
     # Similar past alerts by shared source_ip (top-N, newest first, excluding self)
     similar: list[dict[str, Any]] = []
     if alert.source_ip:
-        similar_result = await session.execute(
+        similar_query = (
             select(Alert)
             .where(Alert.source_ip == alert.source_ip, Alert.id != alert_uuid)
             .order_by(Alert.created_at.desc())
             .limit(SIMILAR_ALERT_LIMIT)
         )
+        similar_query = await apply_tenant_access_query(
+            request.app,
+            query=similar_query,
+            resource_type="alert",
+            action="ai_recommend_similar",
+            analyst=analyst,
+            request=request,
+            session=session,
+        )
+        similar_result = await session.execute(similar_query)
         similar = [
             {
                 "id": str(s.id),

--- a/src/opensoar/api/ai_dedup.py
+++ b/src/opensoar/api/ai_dedup.py
@@ -15,7 +15,7 @@ import logging
 import uuid
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -31,6 +31,7 @@ from opensoar.config import settings
 from opensoar.integrations.cache import EnrichmentCache, get_default_cache
 from opensoar.models.alert import Alert
 from opensoar.models.analyst import Analyst
+from opensoar.plugins import apply_tenant_access_query, enforce_tenant_access
 
 logger = logging.getLogger(__name__)
 
@@ -111,8 +112,9 @@ async def _get_or_compute_embedding(
 @router.post("/deduplicate")
 async def deduplicate_alert(
     body: DeduplicateRequest,
+    request: Request,
     session: AsyncSession = Depends(get_db),
-    _analyst: Analyst = Depends(require_permission(Permission.AI_USE)),
+    analyst: Analyst = Depends(require_permission(Permission.AI_USE)),
 ) -> dict[str, Any]:
     """Return near-duplicate candidate alerts for the requested alert id.
 
@@ -139,6 +141,17 @@ async def deduplicate_alert(
     ).scalar_one_or_none()
     if target is None:
         raise HTTPException(status_code=404, detail="Alert not found")
+    # Block cross-tenant lookups before spending an embedding round-trip — the
+    # LLM/embedding provider never sees the alert text unless the caller owns it.
+    await enforce_tenant_access(
+        request.app,
+        resource=target,
+        resource_type="alert",
+        action="ai_deduplicate",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
 
     cache = get_default_cache()
     threshold = (
@@ -149,12 +162,23 @@ async def deduplicate_alert(
 
     target_vector = await _get_or_compute_embedding(target, client, cache)
 
-    # Pull the most recent candidate corpus. Skip the target itself.
+    # Pull the most recent candidate corpus. Skip the target itself, and limit
+    # the corpus to alerts the caller is authorised to see — duplicate hits
+    # should never span tenant boundaries.
     corpus_query = (
         select(Alert)
         .where(Alert.id != target.id)
         .order_by(Alert.created_at.desc())
         .limit(DEDUP_CORPUS_LIMIT)
+    )
+    corpus_query = await apply_tenant_access_query(
+        request.app,
+        query=corpus_query,
+        resource_type="alert",
+        action="ai_deduplicate_corpus",
+        analyst=analyst,
+        request=request,
+        session=session,
     )
     corpus = (await session.execute(corpus_query)).scalars().all()
 

--- a/src/opensoar/api/alerts.py
+++ b/src/opensoar/api/alerts.py
@@ -154,9 +154,27 @@ async def get_alert_runs(
     query = select(PlaybookRun).where(PlaybookRun.alert_id == alert_id).order_by(
         PlaybookRun.created_at.desc()
     )
+    query = await apply_tenant_access_query(
+        request.app,
+        query=query,
+        resource_type="playbook_run",
+        action="list",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
+    count_query = select(func.count(PlaybookRun.id)).where(PlaybookRun.alert_id == alert_id)
+    count_query = await apply_tenant_access_query(
+        request.app,
+        query=count_query,
+        resource_type="playbook_run",
+        action="count",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
     result = await session.execute(query)
     runs = result.scalars().all()
-    count_query = select(func.count(PlaybookRun.id)).where(PlaybookRun.alert_id == alert_id)
     total = (await session.execute(count_query)).scalar() or 0
     return PlaybookRunList(
         runs=[PlaybookRunResponse.model_validate(r) for r in runs],
@@ -482,6 +500,7 @@ async def claim_alert(
 @router.post("/bulk", response_model=BulkOperationResult)
 async def bulk_update_alerts(
     body: BulkAlertUpdate,
+    request: Request,
     session: AsyncSession = Depends(get_db),
     analyst: Analyst = Depends(require_permission(Permission.ALERTS_UPDATE)),
 ):
@@ -490,9 +509,17 @@ async def bulk_update_alerts(
     failed = 0
     errors: list[str] = []
 
-    result = await session.execute(
-        select(Alert).where(Alert.id.in_(body.alert_ids))
+    query = select(Alert).where(Alert.id.in_(body.alert_ids))
+    query = await apply_tenant_access_query(
+        request.app,
+        query=query,
+        resource_type="alert",
+        action="bulk_update",
+        analyst=analyst,
+        request=request,
+        session=session,
     )
+    result = await session.execute(query)
     alerts = {a.id: a for a in result.scalars().all()}
 
     for aid in body.alert_ids:
@@ -503,6 +530,16 @@ async def bulk_update_alerts(
             continue
 
         try:
+            # Per-record tenant guard for resource-level validators.
+            await enforce_tenant_access(
+                request.app,
+                resource=alert,
+                resource_type="alert",
+                action="bulk_update",
+                analyst=analyst,
+                request=request,
+                session=session,
+            )
             if body.action == "resolve":
                 if alert.status == "resolved":
                     continue

--- a/src/opensoar/api/dashboard.py
+++ b/src/opensoar/api/dashboard.py
@@ -140,6 +140,15 @@ async def dashboard_stats(
     # Totals
     total_alerts = sum(alerts_by_severity.values())
     total_runs_q = select(func.count(PlaybookRun.id))
+    total_runs_q = await apply_tenant_access_query(
+        request.app,
+        query=total_runs_q,
+        resource_type="playbook_run",
+        action="dashboard_stats",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
     total_runs = (await session.execute(total_runs_q)).scalar() or 0
 
     # Open alerts count (new + in_progress)
@@ -183,6 +192,15 @@ async def dashboard_stats(
     # Active runs (running/pending)
     active_runs_q = select(func.count(PlaybookRun.id)).where(
         PlaybookRun.status.in_(["running", "pending"])
+    )
+    active_runs_q = await apply_tenant_access_query(
+        request.app,
+        query=active_runs_q,
+        resource_type="playbook_run",
+        action="dashboard_stats",
+        analyst=analyst,
+        request=request,
+        session=session,
     )
     active_runs = (await session.execute(active_runs_q)).scalar() or 0
 
@@ -237,6 +255,15 @@ async def dashboard_stats(
 
     # Recent runs
     recent_runs_q = select(PlaybookRun).order_by(PlaybookRun.created_at.desc()).limit(5)
+    recent_runs_q = await apply_tenant_access_query(
+        request.app,
+        query=recent_runs_q,
+        resource_type="playbook_run",
+        action="dashboard_stats",
+        analyst=analyst,
+        request=request,
+        session=session,
+    )
     recent_runs = (await session.execute(recent_runs_q)).scalars().all()
 
     # Unassigned open alerts count

--- a/src/opensoar/api/incidents.py
+++ b/src/opensoar/api/incidents.py
@@ -715,12 +715,52 @@ async def list_incident_activities(
         session=session,
     )
 
-    query = (
-        select(Activity)
-        .where(Activity.incident_id == incident_id)
-        .order_by(Activity.created_at.desc())
+    # Scope alert-linked activities to alerts the caller may see. We look at
+    # every alert_id referenced by an activity on this incident (including
+    # alerts that were later unlinked so history is preserved) and run them
+    # through the tenant validator so foreign-tenant leaks are blocked even if
+    # the row is still visible for historical reasons.
+    referenced_alert_ids = list(
+        (
+            await session.execute(
+                select(Activity.alert_id)
+                .where(
+                    Activity.incident_id == incident_id,
+                    Activity.alert_id.isnot(None),
+                )
+                .distinct()
+            )
+        ).scalars().all()
     )
-    count_query = select(func.count(Activity.id)).where(Activity.incident_id == incident_id)
+    if referenced_alert_ids:
+        visible_alert_query = select(Alert.id).where(
+            Alert.id.in_(referenced_alert_ids)
+        )
+        visible_alert_query = await apply_tenant_access_query(
+            request.app,
+            query=visible_alert_query,
+            resource_type="alert",
+            action="list",
+            analyst=analyst,
+            request=request,
+            session=session,
+        )
+        visible_alert_ids = list(
+            (await session.execute(visible_alert_query)).scalars().all()
+        )
+    else:
+        visible_alert_ids = []
+
+    conditions = [
+        (Activity.incident_id == incident_id) & Activity.alert_id.is_(None)
+    ]
+    if visible_alert_ids:
+        conditions.append(Activity.alert_id.in_(visible_alert_ids))
+
+    base_where = or_(*conditions)
+
+    query = select(Activity).where(base_where).order_by(Activity.created_at.desc())
+    count_query = select(func.count(Activity.id)).where(base_where)
 
     total = (await session.execute(count_query)).scalar() or 0
     result = await session.execute(query.offset(offset).limit(limit))

--- a/tests/test_tenant_isolation.py
+++ b/tests/test_tenant_isolation.py
@@ -1,0 +1,640 @@
+"""Cross-tenant isolation test suite (issue #113).
+
+Validates that every multi-tenant-scoped query path runs through the
+``apply_tenant_access_query``/``enforce_tenant_access`` plugin hook so optional
+packages can scope results and block cross-tenant reads or writes. The core
+package has no built-in tenant definition — these tests register a custom
+validator that keys off the ``partner`` field on alerts (and inferred tenant
+membership on ancestor-linked records like runs/observables/activities) to
+prove the hook fires everywhere it must.
+
+Two analysts in different "tenants" (partners acme-corp and globex) each own
+alerts + downstream records. Analyst A must never be able to read or mutate
+analyst B's records through any endpoint.
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import HTTPException
+
+from opensoar.plugins import register_tenant_access_validator
+
+
+# ── Shared test helpers ────────────────────────────────────────
+
+
+class _SwapValidators:
+    """Replace registered validators for the duration of a ``with`` block."""
+
+    def __init__(self, app, validators):
+        self.app = app
+        self.validators = validators
+        self.previous: list = []
+
+    def __enter__(self):
+        self.previous = list(self.app.state.tenant_access_validators)
+        self.app.state.tenant_access_validators = []
+        for validator in self.validators:
+            register_tenant_access_validator(self.app, validator)
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.app.state.tenant_access_validators = self.previous
+
+
+def _swap_validators(app, *validators):
+    return _SwapValidators(app, validators)
+
+
+def _make_partner_validator(allowed_partner: str):
+    """Return a validator that limits callers to ``allowed_partner``.
+
+    The validator:
+      * filters list queries by ``Alert.partner == allowed_partner`` when the
+        query is over ``Alert``
+      * filters ancestor-joined queries (runs, observables, activities) by
+        walking back to the parent alert's partner
+      * raises 403 on resource access for any non-matching record
+    """
+
+    async def validator(**kwargs):
+        from sqlalchemy import select
+
+        from opensoar.models.activity import Activity
+        from opensoar.models.alert import Alert
+        from opensoar.models.incident import Incident
+        from opensoar.models.incident_alert import IncidentAlert
+        from opensoar.models.observable import Observable
+        from opensoar.models.playbook_run import PlaybookRun
+
+        query = kwargs.get("query")
+        if query is not None:
+            rtype = kwargs.get("resource_type")
+            if rtype in {"alert", "anomaly"}:
+                # Both use a ``partner`` column directly.
+                target = Alert if rtype == "alert" else query.froms_expected  # noqa: F841
+                if rtype == "alert":
+                    return query.where(Alert.partner == allowed_partner)
+                # anomaly lives in its own model with a partner column
+                from opensoar.models.anomaly import Anomaly
+
+                return query.where(Anomaly.partner == allowed_partner)
+            if rtype == "playbook_run":
+                allowed_alert_ids = select(Alert.id).where(
+                    Alert.partner == allowed_partner
+                )
+                return query.where(
+                    PlaybookRun.alert_id.in_(allowed_alert_ids)
+                )
+            if rtype == "observable":
+                allowed_alert_ids = select(Alert.id).where(
+                    Alert.partner == allowed_partner
+                )
+                allowed_incident_ids = (
+                    select(IncidentAlert.incident_id)
+                    .join(Alert, Alert.id == IncidentAlert.alert_id)
+                    .where(Alert.partner == allowed_partner)
+                )
+                return query.where(
+                    (Observable.alert_id.in_(allowed_alert_ids))
+                    | (Observable.incident_id.in_(allowed_incident_ids))
+                )
+            if rtype == "incident":
+                allowed_incident_ids = (
+                    select(IncidentAlert.incident_id)
+                    .join(Alert, Alert.id == IncidentAlert.alert_id)
+                    .where(Alert.partner == allowed_partner)
+                )
+                return query.where(Incident.id.in_(allowed_incident_ids))
+            if rtype == "activity":
+                allowed_alert_ids = select(Alert.id).where(
+                    Alert.partner == allowed_partner
+                )
+                return query.where(
+                    Activity.alert_id.in_(allowed_alert_ids)
+                )
+            return None
+
+        # Resource enforcement path
+        resource = kwargs.get("resource")
+        if resource is None:
+            return None
+
+        partner = getattr(resource, "partner", None)
+        if partner is not None:
+            if partner != allowed_partner:
+                raise HTTPException(status_code=403, detail="Tenant access denied")
+            return
+
+        alert_id = getattr(resource, "alert_id", None)
+        if alert_id is not None:
+            session = kwargs.get("session")
+            parent_partner = (
+                await session.execute(
+                    select(Alert.partner).where(Alert.id == alert_id)
+                )
+            ).scalar_one_or_none()
+            if parent_partner and parent_partner != allowed_partner:
+                raise HTTPException(status_code=403, detail="Tenant access denied")
+            return
+
+        incident_id = getattr(resource, "incident_id", None)
+        if incident_id is not None and isinstance(resource, Observable):
+            session = kwargs.get("session")
+            owner = (
+                await session.execute(
+                    select(Alert.partner)
+                    .join(IncidentAlert, IncidentAlert.alert_id == Alert.id)
+                    .where(IncidentAlert.incident_id == incident_id)
+                    .limit(1)
+                )
+            ).scalar_one_or_none()
+            if owner and owner != allowed_partner:
+                raise HTTPException(status_code=403, detail="Tenant access denied")
+            return
+
+        # Incidents linking back through IncidentAlert
+        if isinstance(resource, Incident):
+            session = kwargs.get("session")
+            owner = (
+                await session.execute(
+                    select(Alert.partner)
+                    .join(IncidentAlert, IncidentAlert.alert_id == Alert.id)
+                    .where(IncidentAlert.incident_id == resource.id)
+                    .limit(1)
+                )
+            ).scalar_one_or_none()
+            if owner and owner != allowed_partner:
+                raise HTTPException(status_code=403, detail="Tenant access denied")
+
+    return validator
+
+
+async def _create_alert_with_partner(client, partner: str, title: str) -> str:
+    resp = await client.post(
+        "/api/v1/webhooks/alerts",
+        json={
+            "rule_name": title,
+            "severity": "high",
+            "source_ip": "10.0.0.1",
+            "partner": partner,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["alert_id"]
+
+
+# ── Tests ──────────────────────────────────────────────────────
+
+
+class TestAlertTenantIsolation:
+    async def test_list_alerts_filters_by_tenant(
+        self, client, registered_analyst
+    ):
+        from opensoar.main import app
+
+        await _create_alert_with_partner(client, "acme-corp", "A1")
+        await _create_alert_with_partner(client, "globex", "B1")
+
+        with _swap_validators(app, _make_partner_validator("acme-corp")):
+            resp = await client.get(
+                "/api/v1/alerts", headers=registered_analyst["headers"]
+            )
+
+        assert resp.status_code == 200
+        partners = {a["partner"] for a in resp.json()["alerts"]}
+        assert "globex" not in partners
+        assert partners <= {"acme-corp"}
+
+    async def test_get_alert_detail_blocked_cross_tenant(
+        self, client, registered_analyst
+    ):
+        from opensoar.main import app
+
+        foreign_id = await _create_alert_with_partner(client, "globex", "B1")
+
+        with _swap_validators(app, _make_partner_validator("acme-corp")):
+            resp = await client.get(
+                f"/api/v1/alerts/{foreign_id}",
+                headers=registered_analyst["headers"],
+            )
+
+        assert resp.status_code == 403
+
+    async def test_patch_alert_blocked_cross_tenant(
+        self, client, registered_analyst
+    ):
+        from opensoar.main import app
+
+        foreign_id = await _create_alert_with_partner(client, "globex", "B1")
+
+        with _swap_validators(app, _make_partner_validator("acme-corp")):
+            resp = await client.patch(
+                f"/api/v1/alerts/{foreign_id}",
+                headers=registered_analyst["headers"],
+                json={"status": "in_progress"},
+            )
+
+        assert resp.status_code == 403
+
+    async def test_claim_alert_blocked_cross_tenant(
+        self, client, registered_analyst
+    ):
+        from opensoar.main import app
+
+        foreign_id = await _create_alert_with_partner(client, "globex", "B1")
+
+        with _swap_validators(app, _make_partner_validator("acme-corp")):
+            resp = await client.post(
+                f"/api/v1/alerts/{foreign_id}/claim",
+                headers=registered_analyst["headers"],
+            )
+
+        assert resp.status_code == 403
+
+    async def test_delete_alert_blocked_cross_tenant(
+        self, client, registered_admin
+    ):
+        from opensoar.main import app
+
+        foreign_id = await _create_alert_with_partner(client, "globex", "B1")
+
+        with _swap_validators(app, _make_partner_validator("acme-corp")):
+            resp = await client.delete(
+                f"/api/v1/alerts/{foreign_id}",
+                headers=registered_admin["headers"],
+            )
+
+        assert resp.status_code == 403
+
+    async def test_bulk_update_isolates_foreign_alerts(
+        self, client, registered_analyst
+    ):
+        """Bulk resolve must skip/deny alerts belonging to another tenant."""
+        from opensoar.main import app
+
+        mine = await _create_alert_with_partner(client, "acme-corp", "A1")
+        foreign = await _create_alert_with_partner(client, "globex", "B1")
+
+        with _swap_validators(app, _make_partner_validator("acme-corp")):
+            resp = await client.post(
+                "/api/v1/alerts/bulk",
+                headers=registered_analyst["headers"],
+                json={
+                    "alert_ids": [mine, foreign],
+                    "action": "resolve",
+                    "determination": "benign",
+                },
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        # foreign must not be counted as updated — either failed or filtered out
+        assert body["updated"] <= 1
+        # foreign should be reported as unreachable / not found / denied
+        assert body["failed"] >= 1 or body["updated"] == 1
+
+
+class TestAlertRunsTenantIsolation:
+    async def test_list_alert_runs_blocked_cross_tenant(
+        self, client, registered_analyst
+    ):
+        from opensoar.main import app
+
+        foreign_id = await _create_alert_with_partner(client, "globex", "B1")
+
+        with _swap_validators(app, _make_partner_validator("acme-corp")):
+            resp = await client.get(
+                f"/api/v1/alerts/{foreign_id}/runs",
+                headers=registered_analyst["headers"],
+            )
+
+        # Either 403 from parent-alert check or filtered list — but never leaks
+        assert resp.status_code in (403, 200)
+        if resp.status_code == 200:
+            # If scoped, runs list must be empty for cross-tenant alert
+            assert resp.json()["total"] == 0
+
+    async def test_global_runs_list_filtered_by_tenant(
+        self, client, db_session_factory, registered_analyst
+    ):
+        from opensoar.main import app
+        from opensoar.models.playbook import PlaybookDefinition
+        from opensoar.models.playbook_run import PlaybookRun
+
+        mine = uuid.UUID(
+            await _create_alert_with_partner(client, "acme-corp", "A1")
+        )
+        foreign = uuid.UUID(
+            await _create_alert_with_partner(client, "globex", "B1")
+        )
+
+        async with db_session_factory() as sess:
+            pb = PlaybookDefinition(
+                name=f"runs_test_{uuid.uuid4().hex[:6]}",
+                module_path="test",
+                function_name="fn",
+                trigger_type="webhook",
+                trigger_config={},
+                enabled=True,
+            )
+            sess.add(pb)
+            await sess.flush()
+            sess.add_all(
+                [
+                    PlaybookRun(
+                        playbook_id=pb.id,
+                        alert_id=mine,
+                        status="completed",
+                    ),
+                    PlaybookRun(
+                        playbook_id=pb.id,
+                        alert_id=foreign,
+                        status="completed",
+                    ),
+                ]
+            )
+            await sess.commit()
+
+        with _swap_validators(app, _make_partner_validator("acme-corp")):
+            resp = await client.get(
+                "/api/v1/runs", headers=registered_analyst["headers"]
+            )
+
+        assert resp.status_code == 200
+        returned_ids = {
+            r["alert_id"] for r in resp.json()["runs"] if r.get("alert_id")
+        }
+        assert str(foreign) not in returned_ids
+
+
+class TestObservableTenantIsolation:
+    async def test_list_observables_scoped_to_tenant(
+        self, client, db_session_factory, registered_analyst
+    ):
+        from opensoar.main import app
+        from opensoar.models.observable import Observable
+
+        mine = uuid.UUID(
+            await _create_alert_with_partner(client, "acme-corp", "A1")
+        )
+        foreign = uuid.UUID(
+            await _create_alert_with_partner(client, "globex", "B1")
+        )
+
+        async with db_session_factory() as sess:
+            sess.add_all(
+                [
+                    Observable(
+                        type="ip",
+                        value=f"1.2.3.{uuid.uuid4().int % 254}",
+                        source="test",
+                        alert_id=mine,
+                    ),
+                    Observable(
+                        type="ip",
+                        value=f"4.5.6.{uuid.uuid4().int % 254}",
+                        source="test",
+                        alert_id=foreign,
+                    ),
+                ]
+            )
+            await sess.commit()
+
+        with _swap_validators(app, _make_partner_validator("acme-corp")):
+            resp = await client.get(
+                "/api/v1/observables", headers=registered_analyst["headers"]
+            )
+
+        assert resp.status_code == 200
+        returned_alert_ids = {
+            o["alert_id"]
+            for o in resp.json()["observables"]
+            if o.get("alert_id")
+        }
+        assert str(foreign) not in returned_alert_ids
+
+
+class TestAiEndpointTenantIsolation:
+    """AI endpoints must enforce tenant access before handing data to LLMs."""
+
+    async def test_summarize_blocks_cross_tenant_alert(
+        self, client, registered_analyst, monkeypatch
+    ):
+        from opensoar.main import app
+        from opensoar.api import ai as ai_module
+
+        # Stub the LLM client so we don't hit the network — the call should
+        # never happen anyway because tenant enforcement should kick in first.
+        class _FakeClient:
+            async def complete(self, *a, **kw):  # pragma: no cover
+                raise AssertionError(
+                    "LLM must not be called when tenant access is denied"
+                )
+
+        monkeypatch.setattr(ai_module, "get_llm_client", lambda: _FakeClient())
+
+        foreign_id = await _create_alert_with_partner(client, "globex", "B1")
+
+        with _swap_validators(app, _make_partner_validator("acme-corp")):
+            resp = await client.post(
+                "/api/v1/ai/summarize",
+                headers=registered_analyst["headers"],
+                json={"alert_id": foreign_id},
+            )
+
+        assert resp.status_code == 403
+
+    async def test_triage_blocks_cross_tenant_alert(
+        self, client, registered_analyst, monkeypatch
+    ):
+        from opensoar.main import app
+        from opensoar.api import ai as ai_module
+
+        class _FakeClient:
+            async def complete(self, *a, **kw):  # pragma: no cover
+                raise AssertionError(
+                    "LLM must not be called when tenant access is denied"
+                )
+
+        monkeypatch.setattr(ai_module, "get_llm_client", lambda: _FakeClient())
+
+        foreign_id = await _create_alert_with_partner(client, "globex", "B1")
+
+        with _swap_validators(app, _make_partner_validator("acme-corp")):
+            resp = await client.post(
+                "/api/v1/ai/triage",
+                headers=registered_analyst["headers"],
+                json={"alert_id": foreign_id},
+            )
+
+        assert resp.status_code == 403
+
+    async def test_recommend_blocks_cross_tenant_alert(
+        self, client, registered_analyst, monkeypatch
+    ):
+        from opensoar.main import app
+        from opensoar.api import ai as ai_module
+
+        class _FakeClient:
+            async def complete(self, *a, **kw):  # pragma: no cover
+                raise AssertionError(
+                    "LLM must not be called when tenant access is denied"
+                )
+
+        monkeypatch.setattr(ai_module, "get_llm_client", lambda: _FakeClient())
+
+        foreign_id = await _create_alert_with_partner(client, "globex", "B1")
+
+        with _swap_validators(app, _make_partner_validator("acme-corp")):
+            resp = await client.post(
+                "/api/v1/ai/recommend",
+                headers=registered_analyst["headers"],
+                json={"alert_id": foreign_id},
+            )
+
+        assert resp.status_code == 403
+
+    async def test_deduplicate_blocks_cross_tenant_alert(
+        self, client, registered_analyst, monkeypatch
+    ):
+        from opensoar.main import app
+        from opensoar.api import ai_dedup as dedup_module
+
+        class _FakeClient:
+            provider = "openai"
+            model = "fake"
+
+            async def embed(self, *a, **kw):  # pragma: no cover
+                raise AssertionError(
+                    "Embedding must not be called when tenant access is denied"
+                )
+
+        monkeypatch.setattr(
+            dedup_module, "get_embedding_client", lambda: _FakeClient()
+        )
+
+        foreign_id = await _create_alert_with_partner(client, "globex", "B1")
+
+        with _swap_validators(app, _make_partner_validator("acme-corp")):
+            resp = await client.post(
+                "/api/v1/ai/deduplicate",
+                headers=registered_analyst["headers"],
+                json={"alert_id": foreign_id},
+            )
+
+        assert resp.status_code == 403
+
+
+class TestActivitiesTenantIsolation:
+    async def test_list_alert_activities_blocked_cross_tenant(
+        self, client, registered_analyst
+    ):
+        from opensoar.main import app
+
+        foreign_id = await _create_alert_with_partner(client, "globex", "B1")
+
+        with _swap_validators(app, _make_partner_validator("acme-corp")):
+            resp = await client.get(
+                f"/api/v1/alerts/{foreign_id}/activities",
+                headers=registered_analyst["headers"],
+            )
+
+        assert resp.status_code == 403
+
+    async def test_add_comment_blocked_cross_tenant(
+        self, client, registered_analyst
+    ):
+        from opensoar.main import app
+
+        foreign_id = await _create_alert_with_partner(client, "globex", "B1")
+
+        with _swap_validators(app, _make_partner_validator("acme-corp")):
+            resp = await client.post(
+                f"/api/v1/alerts/{foreign_id}/comments",
+                headers=registered_analyst["headers"],
+                json={"text": "hello"},
+            )
+
+        assert resp.status_code == 403
+
+
+class TestDashboardTenantIsolation:
+    async def test_dashboard_stats_filters_by_tenant(
+        self, client, registered_analyst
+    ):
+        from opensoar.main import app
+
+        await _create_alert_with_partner(client, "acme-corp", "A1")
+        await _create_alert_with_partner(client, "globex", "B1")
+        await _create_alert_with_partner(client, "globex", "B2")
+
+        with _swap_validators(app, _make_partner_validator("acme-corp")):
+            resp = await client.get(
+                "/api/v1/dashboard/stats",
+                headers=registered_analyst["headers"],
+            )
+
+        assert resp.status_code == 200
+        by_partner = resp.json()["alerts_by_partner"]
+        assert "globex" not in by_partner
+        # acme-corp's scoped total matches what was filtered in
+        assert resp.json()["total_alerts"] == by_partner.get("acme-corp", 0)
+
+
+class TestIncidentTenantIsolation:
+    async def test_list_incident_activities_filtered_by_tenant(
+        self, client, db_session_factory, registered_analyst
+    ):
+        """Activities linked to foreign alerts must not leak via the
+        incident-activities endpoint."""
+        from opensoar.main import app
+        from opensoar.models.activity import Activity
+        from opensoar.models.incident import Incident
+        from opensoar.models.incident_alert import IncidentAlert
+
+        mine = uuid.UUID(
+            await _create_alert_with_partner(client, "acme-corp", "A1")
+        )
+        foreign = uuid.UUID(
+            await _create_alert_with_partner(client, "globex", "B1")
+        )
+
+        async with db_session_factory() as sess:
+            incident = Incident(title="shared", severity="medium")
+            sess.add(incident)
+            await sess.flush()
+            sess.add_all(
+                [
+                    IncidentAlert(incident_id=incident.id, alert_id=mine),
+                    IncidentAlert(incident_id=incident.id, alert_id=foreign),
+                    Activity(
+                        incident_id=incident.id,
+                        alert_id=mine,
+                        action="status_change",
+                        detail="mine-only",
+                    ),
+                    Activity(
+                        incident_id=incident.id,
+                        alert_id=foreign,
+                        action="status_change",
+                        detail="foreign-only",
+                    ),
+                ]
+            )
+            await sess.commit()
+            incident_id = incident.id
+
+        with _swap_validators(app, _make_partner_validator("acme-corp")):
+            resp = await client.get(
+                f"/api/v1/incidents/{incident_id}/activities",
+                headers=registered_analyst["headers"],
+            )
+
+        # If the incident is cross-tenant-visible (spanning both partners),
+        # response either blocks or filters activities to mine-only.
+        assert resp.status_code in (200, 403)
+        if resp.status_code == 200:
+            details = {a["detail"] for a in resp.json()["activities"]}
+            assert "foreign-only" not in details


### PR DESCRIPTION
## Summary

- Routes every multi-tenant-scoped read/mutation through the `apply_tenant_access_query` / `enforce_tenant_access` plugin hooks so optional packages can filter and block cross-tenant access.
- Closes gaps in bulk alert update, the AI endpoints (`summarize`, `triage`, `recommend`, `deduplicate`), alert-activity listings, and incident-activity listings where data was loaded or handed to an LLM before tenant validators ran.
- Adds `tests/test_tenant_isolation.py` (17 tests) that install a partner-field validator via `_swap_validators` and assert every list, detail, mutation and AI endpoint either filters or returns 403 on cross-tenant access. LLM and embedding clients are stubbed so any bypass is a hard failure.

Closes #113.

## Test plan

- [x] `pytest tests/test_tenant_isolation.py -v` — 17/17 pass
- [x] `pytest tests/ -v` — full suite green (590 passed)
- [x] `ruff check src/ tests/` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced access control validation for alert actions and AI-powered operations (summarize, triage, recommend, and deduplication).
  * Fixed potential cross-tenant data leakage in activities, incident tracking, and dashboard statistics.
  * Strengthened tenant boundary enforcement in bulk alert operations and observable queries.

* **Tests**
  * Added comprehensive test suite verifying tenant isolation across all API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->