### PR TITLE
README: fix stale PwnKit Labs branding + dead PwnKit-Labs/* links → 0sec Labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,11 @@ Areas where help is most needed:
 
 ---
 
-## Part of PwnKit Labs
+## Part of 0sec Labs
 
-**Open-source adversarial security for the agentic AI era.** OpenSOAR is one piece of the open-source PwnKit Labs stack:
-- **[pwnkit](https://github.com/PwnKit-Labs/pwnkit)** — AI agent pentester (detect)
-- **[foxguard](https://github.com/PwnKit-Labs/foxguard)** — Rust security scanner (prevent)
+**Open-source adversarial security for the agentic AI era.** OpenSOAR is one piece of the [0sec Labs](https://0sec.ai) stack:
+- **pwnkit** — autonomous AI pentester (detect) · closed source, [0sec.ai](https://0sec.ai)
+- **[foxguard](https://github.com/0sec-labs/foxguard)** — Rust security scanner (prevent)
 - **[opensoar](https://github.com/opensoar-hq/opensoar-core)** — Python-native SOAR platform (respond)
 
 ---


### PR DESCRIPTION
Part of the org-wide README refresh: fix pre-rebrand "PwnKit Labs" naming to "0sec Labs", repair dead `PwnKit-Labs/*` links, and apply the OpenSOAR house-style header where missing.