### PR TITLE
docs: fix remaining PwnKit Labs refs in ui/ and deploy/ READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,11 @@ Areas where help is most needed:
 
 ---
 
-## Part of PwnKit Labs
+## Part of 0sec Labs
 
-**Open-source adversarial security for the agentic AI era.** OpenSOAR is one piece of the open-source PwnKit Labs stack:
-- **[pwnkit](https://github.com/PwnKit-Labs/pwnkit)** — AI agent pentester (detect)
-- **[foxguard](https://github.com/PwnKit-Labs/foxguard)** — Rust security scanner (prevent)
+**Open-source adversarial security for the agentic AI era.** OpenSOAR is one piece of the [0sec Labs](https://0sec.ai) stack:
+- **pwnkit** — autonomous AI pentester (detect) · closed source, [0sec.ai](https://0sec.ai)
+- **[foxguard](https://github.com/0sec-labs/foxguard)** — Rust security scanner (prevent)
 - **[opensoar](https://github.com/opensoar-hq/opensoar-core)** — Python-native SOAR platform (respond)
 
 ---

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -2,7 +2,7 @@
 
 This directory now owns the public self-hosted packaging entry points for OpenSOAR.
 
-**OpenSOAR is a PwnKit Labs product.**
+**OpenSOAR is a 0sec Labs product.**
 
 ## Deployment Paths
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -2,7 +2,7 @@
 
 React frontend for the OpenSOAR SOAR platform — built for SOC analysts doing alert triage and incident response.
 
-**OpenSOAR is a PwnKit Labs product.**
+**OpenSOAR is a 0sec Labs product.**
 
 ## Stack
 


### PR DESCRIPTION
Follow-up: two sub-READMEs still carried the pre-rebrand 'PwnKit Labs product' line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product attribution across the main, deployment, and UI documentation to reference 0sec Labs.
  * Refreshed ecosystem links and descriptions, including the renamed `pwnkit` entry and the addition of `foxguard`.
  * Updated references to the 0sec.ai technology stack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->